### PR TITLE
feat(identity): add SCIM identity provider plugin

### DIFF
--- a/bom/operaton-only-bom/pom.xml
+++ b/bom/operaton-only-bom/pom.xml
@@ -57,6 +57,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.operaton.bpm.identity</groupId>
+        <artifactId>operaton-identity-scim</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-engine-plugin-spin</artifactId>
         <version>${project.version}</version>

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>operaton-identity-ldap</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.operaton.bpm.identity</groupId>
+      <artifactId>operaton-identity-scim</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.operaton.bpm.springboot</groupId>
       <artifactId>operaton-bpm-spring-boot-starter-rest</artifactId>
     </dependency>

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunConfiguration.java
@@ -29,9 +29,11 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cfg.ProcessEnginePlugin;
 import org.operaton.bpm.engine.impl.plugin.AdministratorAuthorizationPlugin;
 import org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin;
+import org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin;
 import org.operaton.bpm.run.property.OperatonBpmRunAdministratorAuthorizationProperties;
 import org.operaton.bpm.run.property.OperatonBpmRunLdapProperties;
 import org.operaton.bpm.run.property.OperatonBpmRunProperties;
+import org.operaton.bpm.run.property.OperatonBpmRunScimProperties;
 import org.operaton.bpm.spring.boot.starter.OperatonBpmAutoConfiguration;
 import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
 
@@ -44,6 +46,12 @@ public class OperatonBpmRunConfiguration {
   @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = OperatonBpmRunLdapProperties.PREFIX)
   public LdapIdentityProviderPlugin ldapIdentityProviderPlugin(OperatonBpmRunProperties properties) {
     return properties.getLdap();
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = OperatonBpmRunScimProperties.PREFIX)
+  public ScimIdentityProviderPlugin scimIdentityProviderPlugin(OperatonBpmRunProperties properties) {
+    return properties.getScim();
   }
 
   @Bean

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunProperties.java
@@ -39,6 +39,9 @@ public class OperatonBpmRunProperties {
   protected OperatonBpmRunLdapProperties ldap = new OperatonBpmRunLdapProperties();
 
   @NestedConfigurationProperty
+  protected OperatonBpmRunScimProperties scim = new OperatonBpmRunScimProperties();
+
+  @NestedConfigurationProperty
   protected List<OperatonBpmRunProcessEnginePluginProperty> processEnginePlugins = new ArrayList<>();
 
   @NestedConfigurationProperty
@@ -72,6 +75,14 @@ public class OperatonBpmRunProperties {
 
   public void setLdap(OperatonBpmRunLdapProperties ldap) {
     this.ldap = ldap;
+  }
+
+  public OperatonBpmRunScimProperties getScim() {
+    return scim;
+  }
+
+  public void setScim(OperatonBpmRunScimProperties scim) {
+    this.scim = scim;
   }
 
   public OperatonBpmRunAdministratorAuthorizationProperties getAdminAuth() {
@@ -113,6 +124,7 @@ public class OperatonBpmRunProperties {
         "auth=" + auth +
         ", cors=" + cors +
         ", ldap=" + ldap +
+        ", scim=" + scim +
         ", adminAuth=" + adminAuth +
         ", plugins=" + processEnginePlugins +
         ", rest=" + rest +

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunScimProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunScimProperties.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.property;
+
+import org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin;
+
+public class OperatonBpmRunScimProperties extends ScimIdentityProviderPlugin {
+
+  public static final String PREFIX = OperatonBpmRunProperties.PREFIX + ".scim";
+
+  boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  @Override
+  public String toString() {
+    return "OperatonBpmRunScimProperty [enabled=" + enabled +
+        ", scimVersion=" + scimVersion +
+        ", serverUrl=******" +
+        ", authenticationType=******" +
+        ", username=******" +
+        ", password=******" +
+        ", bearerToken=******" +
+        ", oauth2TokenUrl=******" +
+        ", oauth2ClientId=******" +
+        ", oauth2ClientSecret=******" +
+        ", oauth2Scope=******" +
+        ", usersEndpoint=" + usersEndpoint +
+        ", groupsEndpoint=" + groupsEndpoint +
+        ", userBaseFilter=" + userBaseFilter +
+        ", groupBaseFilter=" + groupBaseFilter +
+        ", userIdAttribute=" + userIdAttribute +
+        ", userFirstnameAttribute=" + userFirstnameAttribute +
+        ", userLastnameAttribute=" + userLastnameAttribute +
+        ", userPasswordAttribute=" + userPasswordAttribute +
+        ", userEmailsAttribute=" + userEmailsAttribute +
+        ", groupIdAttribute=" + groupIdAttribute +
+        ", groupNameAttribute=" + groupNameAttribute +
+        ", groupMembersAttribute=" + groupMembersAttribute +
+        ", allowModifications=" + allowModifications +
+        ", connectionTimeout=" + connectionTimeout +
+        ", acceptUntrustedCertificates=" + acceptUntrustedCertificates +
+        ", pageSize=" + pageSize +
+        ", authorizationCheckEnabled=" + authorizationCheckEnabled +
+        ", userAuthenticationEnabled=" + userAuthenticationEnabled +
+        ", userAuthenticationProtocol=" + userAuthenticationProtocol +
+        ", userAuthenticationUrl=" + userAuthenticationUrl + "]";
+  }
+}

--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -33,6 +33,7 @@
 
         <include>org.operaton.bpm:operaton-engine:jar</include>
         <include>org.operaton.bpm.identity:operaton-identity-ldap:jar</include>
+        <include>org.operaton.bpm.identity:operaton-identity-scim:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -94,6 +94,10 @@
       <artifactId>operaton-identity-ldap</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.operaton.bpm.identity</groupId>
+      <artifactId>operaton-identity-scim</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-core</artifactId>
     </dependency>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.operaton.bpm.identity</groupId>
+      <artifactId>operaton-identity-scim</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine-cdi</artifactId>
     </dependency>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>operaton-identity-ldap</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.operaton.bpm.identity</groupId>
+      <artifactId>operaton-identity-scim</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine-cdi</artifactId>
     </dependency>

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/identity/operaton-identity-scim/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/identity/operaton-identity-scim/main/module.xml
@@ -1,0 +1,15 @@
+<module xmlns="urn:jboss:module:1.0" name="org.operaton.bpm.identity.operaton-identity-scim">
+  <resources>
+    <resource-root path="operaton-identity-scim-@project.version@.jar" />
+  </resources>
+
+  <dependencies>
+
+    <module name="java.base" />
+    <module name="org.slf4j" />
+
+    <module name="org.operaton.bpm.operaton-engine" />
+    <module name="org.operaton.commons.operaton-commons-logging" />
+
+  </dependencies>
+</module>

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/wildfly/operaton-wildfly-subsystem/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/wildfly/operaton-wildfly-subsystem/main/module.xml
@@ -39,6 +39,7 @@
     <module name="org.operaton.commons.operaton-commons-utils" />
     <module name="org.operaton.bpm.operaton-engine" />
     <module name="org.operaton.bpm.identity.operaton-identity-ldap" />
+    <module name="org.operaton.bpm.identity.operaton-identity-scim" />
     <module name="org.operaton.bpm.operaton-engine-plugin-spin" services="import" />
     <module name="org.operaton.bpm.operaton-engine-plugin-connect" />
 

--- a/engine-plugins/identity-scim/README.md
+++ b/engine-plugins/identity-scim/README.md
@@ -1,0 +1,186 @@
+# Operaton SCIM Identity Provider Plugin
+
+This plugin provides integration with SCIM 2.0 (System for Cross-domain Identity Management) compliant identity providers such as Azure AD, Okta, OneLogin, and others.
+
+## Features
+
+- Query users and groups from SCIM 2.0 servers
+- Basic functionality for creating, updating and deleting users and groups (useful in a test environment)
+- Support for multiple authentication methods:
+  - Bearer Token
+  - Basic Authentication
+  - OAuth2 Client Credentials
+- Configurable attribute mappings for users and groups
+- Pagination support
+- Authorization checks
+- SSL/TLS configuration with support for self-signed certificates
+
+## Configuration
+
+### Basic Configuration with Bearer Token
+
+```xml
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://scim.example.com</property>
+    <property name="authenticationType">bearer</property>
+    <property name="bearerToken">your-access-token</property>
+  </properties>
+</plugin>
+```
+
+### Configuration with Basic Authentication
+
+```xml
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://scim.example.com</property>
+    <property name="authenticationType">basic</property>
+    <property name="username">admin</property>
+    <property name="password">password</property>
+  </properties>
+</plugin>
+```
+
+### Configuration with OAuth2
+
+```xml
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://scim.example.com</property>
+    <property name="authenticationType">oauth2</property>
+    <property name="oauth2TokenUrl">https://auth.example.com/oauth/token</property>
+    <property name="oauth2ClientId">your-client-id</property>
+    <property name="oauth2ClientSecret">your-client-secret</property>
+    <property name="oauth2Scope">scim.read</property>
+  </properties>
+</plugin>
+```
+
+## Configuration Options
+
+### Server Settings
+- `serverUrl` (required): Base URL of the SCIM server
+- `scimVersion`: SCIM version (default: "2.0")
+- `usersEndpoint`: Users endpoint path (default: "/Users")
+- `groupsEndpoint`: Groups endpoint path (default: "/Groups")
+
+### SCIM Authentication Settings
+- `authenticationType`: Authentication type - "bearer", "basic", or "oauth2" (default: "bearer")
+- `bearerToken`: Bearer token for authentication
+- `username`: Username for basic authentication
+- `password`: Password for basic authentication
+- `oauth2TokenUrl`: OAuth2 token endpoint URL
+- `oauth2ClientId`: OAuth2 client ID
+- `oauth2ClientSecret`: OAuth2 client secret
+- `oauth2Scope`: OAuth2 scope
+
+### User Authentication Settings
+- `userAuthenticationEnabled`: Enable user authentication via OIDC or via SCIM2 /Users/.search extension (default: false)
+- `userAuthenticationProtocol`: User authentication protocol "oidc" or "scim"
+- `userAuthenticationUrl`: End point for OIDC authentication
+
+### User Attribute Mapping
+- `userIdAttribute`: SCIM attribute for user ID (default: "userName")
+- `userFirstnameAttribute`: SCIM attribute for first name (default: "name.givenName")
+- `userLastnameAttribute`: SCIM attribute for last name (default: "name.familyName")
+- Email values are read from the SCIM `emails` array
+
+### Group Attribute Mapping
+- `groupIdAttribute`: SCIM attribute for group ID (default: "externalId")
+- `groupNameAttribute`: SCIM attribute for group name (default: "displayName")
+- `groupMembersAttribute`: SCIM attribute for group members (default: "members")
+
+### Connection Settings
+- `connectionTimeout`: Connection timeout in milliseconds (default: 30000)
+- `socketTimeout`: Socket timeout in milliseconds (default: 30000)
+- `maxConnections`: Maximum number of connections (default: 100)
+
+### SSL/TLS Settings
+- SSL/TLS is determined by the `serverUrl` scheme (`https://`)
+- `acceptUntrustedCertificates`: Accept self-signed certificates (default: false, use with caution)
+
+### Other Settings
+- `authorizationCheckEnabled`: Enable authorization checks (default: true)
+- `pageSize`: Number of results per page (default: 100)
+
+## Custom Attribute Mappings
+
+If your SCIM server uses custom attribute names, you can map them accordingly:
+
+```xml
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://scim.example.com</property>
+    <property name="bearerToken">your-token</property>
+    
+    <!-- Custom attribute mappings -->
+    <property name="userIdAttribute">id</property>
+    <property name="userFirstnameAttribute">givenName</property>
+    <property name="userLastnameAttribute">surname</property>
+    
+    <property name="groupIdAttribute">id</property>
+    <property name="groupNameAttribute">displayName</property>
+  </properties>
+</plugin>
+```
+
+## Limitations
+
+- In production, user and group management should be done through your SCIM server, allow modifications in test environment only
+- Multi-tenancy is not supported.
+
+## Supported SCIM Providers
+
+This plugin should work with any SCIM 2.0 compliant identity provider, including:
+- Azure Active Directory
+- Okta
+- OneLogin
+- Google Workspace
+- Ping Identity
+- And other SCIM 2.0 compliant providers
+
+## Security Considerations
+
+- Always use SSL/TLS in production
+- Only use `acceptUntrustedCertificates=true` for development/testing
+- Store credentials securely and consider using environment variables or secure vaults
+- Regularly rotate OAuth2 client secrets and access tokens
+- Monitor and audit access to the SCIM endpoints
+
+## Troubleshooting
+
+### Enable Debug Logging
+
+To see detailed SCIM queries and responses, enable debug logging for the SCIM plugin:
+
+```xml
+<logger name="org.operaton.bpm.identity.impl.scim" level="DEBUG" />
+```
+
+Also, detailed SCIM logging could be enabled with enabling "verbose" property:
+
+```xml
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    ...
+    <property name="verbose">true</property>
+  </properties>
+</plugin>
+```
+
+### Common Issues
+
+1. **401 Unauthorized**: Check your authentication credentials and ensure they are valid
+2. **SSL Certificate Errors**: If using self-signed certificates, set `acceptUntrustedCertificates=true` (not recommended for production)
+3. **Empty Result Sets**: Verify your attribute mappings match your SCIM server's schema
+4. **Timeout Errors**: Increase `connectionTimeout` and `socketTimeout` values
+
+## License
+
+Apache License 2.0

--- a/engine-plugins/identity-scim/pom.xml
+++ b/engine-plugins/identity-scim/pom.xml
@@ -1,0 +1,176 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.operaton.bpm</groupId>
+    <artifactId>operaton-engine-plugins</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.operaton.bpm.identity</groupId>
+  <artifactId>operaton-identity-scim</artifactId>
+  <packaging>jar</packaging>
+  <name>Operaton - Engine Plugins - Identity - SCIM</name>
+  <description>${project.name}</description>
+
+  <properties>
+    <version.scimple>1.0.0-M1</version.scimple>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.operaton.commons</groupId>
+      <artifactId>operaton-commons-logging</artifactId>
+    </dependency>
+
+    <!-- Apache HttpClient 5 for HTTP requests -->
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+   
+    <!-- Jackson for JSON processing -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+  <!-- Apache SCIMple: real lightweight SCIM server: 
+       can be used as an alternative to the wiremock for testing -->
+  <!--<dependency>
+      <groupId>org.apache.directory.scimple</groupId>
+      <artifactId>scim-server</artifactId>
+      <version>${version.scimple}</version>
+      <scope>test</scope>
+    </dependency> -->
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Test dependencies for mockito -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- WireMock for mocking SCIM server -->
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency> 
+  </dependencies> 
+  
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+          <trimStackTrace>false</trimStackTrace>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <argLine>-Xshare:off</argLine>    
+        </configuration>
+      </plugin>
+  
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+            <!-- Use artifactSet to control dependencies -->
+              <artifactSet>
+                <includes>
+                  <include>org.apache.httpcomponents.client5:httpclient5</include>
+                  <include>org.apache.httpcomponents.core5:httpcore5-h2</include>
+                  <include>org.apache.httpcomponents.core5:httpcore5</include>
+                  <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <!-- shade http client and jackson -->
+                <relocation>
+                  <pattern>org.apache.hc</pattern>
+                  <shadedPattern>scimplugin.org.apache.httpcomponents</shadedPattern>
+                  <excludes>
+                    <exclude>org.apache.logging:*</exclude>
+                    <exclude>org.slf4j:*</exclude>
+                  </excludes>
+                </relocation>
+
+                <relocation>
+                  <pattern>com.fasterxml.jackson.core</pattern>
+                  <shadedPattern>scimplugin.com.fasterxml.jackson.core</shadedPattern>
+                </relocation>
+
+                <relocation>
+                  <pattern>com.fasterxml.jackson.databind</pattern>
+                  <shadedPattern>scimplugin.com.fasterxml.jackson.databind</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson.annotation</pattern>
+                  <shadedPattern>scimplugin.com.fasterxml.jackson.annotation</shadedPattern>
+                </relocation>
+              </relocations>
+
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>META-INF/*.SF</resource>
+                  <resource>META-INF/*.DSA</resource>
+                  <resource>META-INF/*.RSA</resource>
+                </transformer>
+              </transformers>
+
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <!-- Exclude not needed to suppress warnings -->
+                  <excludes>
+                    <exclude>META-INF/INDEX.LIST</exclude>
+                    <exclude>META-INF/DEPENDENCIES</exclude>
+                    <exclude>META-INF/NOTICE*</exclude>
+                    <exclude>META-INF/LICENSE*</exclude>
+                    <exclude>META-INF/*.MF</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/**/module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>  
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimClient.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimClient.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.ParseException;
+import org.operaton.bpm.engine.impl.identity.IdentityProviderException;
+import org.operaton.bpm.identity.impl.scim.ScimClient.HttpMethod;
+import org.operaton.bpm.identity.impl.scim.util.ScimPluginLogger;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * HTTP client for SCIM API operations.
+ */
+public class ScimClient {
+
+  protected final ScimConfiguration configuration;
+  protected final ObjectMapper objectMapper;
+  protected CloseableHttpClient httpClient;
+  protected ScimOAuth2TokenStore oauth2TokenStore;
+  protected enum HttpMethod {GET, POST, PUT, PATCH, DEL};
+  protected ScimSimpleCache<JsonNode> responseCache;
+
+  public ScimClient(ScimConfiguration configuration) {
+    this(configuration, null, null);
+  }
+
+  public ScimClient(ScimConfiguration configuration, ScimSimpleCache<JsonNode> responseCache) {
+    this(configuration, responseCache, null);
+  }
+
+  public ScimClient(ScimConfiguration configuration, ScimSimpleCache<JsonNode> responseCache, ScimOAuth2TokenStore oauth2TokenStore) {
+    this.configuration = configuration;
+    this.objectMapper = new ObjectMapper();
+    this.responseCache = responseCache;
+    this.oauth2TokenStore = oauth2TokenStore;
+    checkConfiguration();
+    initializeHttpClient();
+  }
+
+  protected void checkConfiguration() {
+    if (configuration == null) {
+      throw new IdentityProviderException("Failed to check SCIM configuration: configuration is empty.");
+    }   
+    if (configuration.getServerUrl() == null || configuration.getServerUrl().isEmpty()) {
+      throw new IdentityProviderException("Failed to check SCIM configuration: serverUrl is not set.");
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  protected void initializeHttpClient() {
+    try {
+      PoolingHttpClientConnectionManagerBuilder connectionManagerBuilder = PoolingHttpClientConnectionManagerBuilder.create();
+      if (configuration.isAcceptUntrustedCertificates()) {
+        try {
+            SSLContext sslContext = createTrustAllSSLContext();
+            SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(
+                sslContext, NoopHostnameVerifier.INSTANCE);
+            connectionManagerBuilder.setSSLSocketFactory(sslSocketFactory);
+        }
+        catch (KeyManagementException | NoSuchAlgorithmException e) {
+          throw new Exception("Failed to initialize trust-all ssl context", e);
+        }
+      }
+      
+      ConnectionConfig connectionConfig = ConnectionConfig.custom()
+        .setConnectTimeout(configuration.getConnectionTimeout(), TimeUnit.MILLISECONDS)
+        .setSocketTimeout(configuration.getSocketTimeout(), TimeUnit.MILLISECONDS)
+        .build();
+      
+      PoolingHttpClientConnectionManager connectionManager = connectionManagerBuilder.build();
+      connectionManager.setDefaultConnectionConfig(connectionConfig);
+      connectionManager.setMaxTotal(configuration.getMaxConnections());
+      connectionManager.setDefaultMaxPerRoute(configuration.getMaxConnections());
+      httpClient = HttpClients.custom()
+          .setConnectionManager(connectionManager)
+          .build();
+    } catch (Exception e) {
+      throw new IdentityProviderException("Failed to initialize SCIM HTTP client", e);
+    }
+  }
+
+  protected SSLContext createTrustAllSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
+    TrustManager[] trustAllCerts = new TrustManager[]{
+        new X509TrustManager() {
+          public X509Certificate[] getAcceptedIssuers() {
+            return null;
+          }
+
+          public void checkClientTrusted(X509Certificate[] certs, String authType) {
+          }
+
+          public void checkServerTrusted(X509Certificate[] certs, String authType) {
+          }
+        }
+    };
+
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+    return sslContext;
+  }
+
+  /**
+   * Search for users using SCIM filter.
+   */
+  public JsonNode searchUsers(String filter, int startIndex, int count, String sorting) {
+    StringBuilder url = new StringBuilder(configuration.getServerUrl());
+    url.append(configuration.getUsersEndpoint());
+    
+    boolean hasParams = false;
+    if (filter != null && !filter.isEmpty()) {
+      url.append("?filter=").append(encodeUrlParameter(filter));
+      hasParams = true;
+    }
+    
+    url.append(hasParams ? "&" : "?").append("startIndex=").append(startIndex);
+    url.append("&count=").append(count);
+    
+    // sorting, contains sortby and orderby
+    if (sorting != null) {
+      url.append("&").append(sorting);
+    }
+
+    ScimPluginLogger.INSTANCE.scimFilterQuery(filter);
+    return executeGet(url.toString());
+  }
+
+  /**
+   * Search for groups using SCIM filter.
+   */
+  public JsonNode searchGroups(String filter, int startIndex, int count, String sorting) {
+    StringBuilder url = new StringBuilder(configuration.getServerUrl());
+    url.append(configuration.getGroupsEndpoint());
+    
+    boolean hasParams = false;
+    if (filter != null && !filter.isEmpty()) {
+      url.append("?filter=").append(encodeUrlParameter(filter));
+      hasParams = true;
+    }
+    
+    url.append(hasParams ? "&" : "?").append("startIndex=").append(startIndex);
+    url.append("&count=").append(count);
+    
+   // sorting, contains sortby and orderby
+    if (sorting != null) {
+      url.append("&").append(sorting);
+    }
+
+    ScimPluginLogger.INSTANCE.scimFilterQuery(filter);
+    return executeGet(url.toString());
+  }
+
+  /**
+   * Get a specific user by scim ID.
+   */
+  public JsonNode getUserByScimId(String scimId) {
+    String url = configuration.getServerUrl() + configuration.getUsersEndpoint() + "/" + encodeUrlParameter(scimId);
+    return executeGet(url);
+  }
+  
+  /**
+   * Patch a specific user by scim ID.
+   */
+  public JsonNode patchUserByScimId(String scimId, JsonNode patchBody) {
+    String url = configuration.getServerUrl() + configuration.getUsersEndpoint() + "/" + encodeUrlParameter(scimId);
+    return executePatch(url, patchBody);
+  }
+   
+  /**
+   * Delete a specific user by scim ID.
+   */
+  public JsonNode deleteUserByScimId(String scimId) {
+    String url = configuration.getServerUrl() + configuration.getUsersEndpoint() + "/" + encodeUrlParameter(scimId);
+    return executeDel(url);
+  }
+
+  /**
+   * Get a specific group by scim ID.
+   */
+  public JsonNode getGroupByScimId(String scimId) {
+    String url = configuration.getServerUrl() + configuration.getGroupsEndpoint() + "/" + encodeUrlParameter(scimId);
+    return executeGet(url);
+  }
+  
+  /**
+   * Patch a specific group by scim ID.
+   */
+  public JsonNode patchGroupByScimId(String scimId, JsonNode patchBody) {
+    String url = configuration.getServerUrl() + configuration.getGroupsEndpoint() + "/" + encodeUrlParameter(scimId);
+    return executePatch(url, patchBody);
+  }
+  
+  /**
+   * Delete a specific group by scim ID.
+   */
+  public JsonNode deleteGroupByScimId(String scimId) {
+    String url = configuration.getServerUrl() + configuration.getGroupsEndpoint() + "/" + encodeUrlParameter(scimId);
+    return executeDel(url);
+  }
+
+  protected JsonNode executeGet(String url) {
+    if (responseCache != null) {
+      JsonNode cached = responseCache.get(url);
+      if (cached != null) {
+        return cached;
+      }
+    }
+    JsonNode result = executeHttpRequest(HttpMethod.GET, url, null, false);
+    if (responseCache != null && result != null) {
+      responseCache.put(url, result);
+    }
+    return result;
+  }
+  
+  protected JsonNode executePost(String url, JsonNode postBody) {
+    JsonNode result = executeHttpRequest(HttpMethod.POST, url, postBody, false);
+    if (responseCache != null) {
+      responseCache.invalidateAll();
+    }
+    return result;
+  }
+  
+  protected JsonNode executeDel(String url) {
+    JsonNode result = executeHttpRequest(HttpMethod.DEL, url, null, false);
+    if (responseCache != null) {
+      responseCache.invalidateAll();
+    }
+    return result;
+  }
+  
+  protected JsonNode executePatch(String url, JsonNode patchBody) {
+    JsonNode result = executeHttpRequest(HttpMethod.PATCH, url, patchBody, false);
+    if (responseCache != null) {
+      responseCache.invalidateAll();
+    }
+    return result;
+  }
+ 
+  @SuppressWarnings("deprecation")
+  protected JsonNode executeHttpRequest(HttpMethod method, String url, JsonNode body, boolean isRetry) {
+    HttpUriRequestBase request = 
+        method == HttpMethod.GET ? new HttpGet(url) :
+        method == HttpMethod.POST ? new HttpPost(url) : 
+        method == HttpMethod.PUT ? new HttpPut(url) :
+        method == HttpMethod.PATCH ? new HttpPatch(url) :
+        method == HttpMethod.DEL ? new HttpDelete(url) : null;
+       
+    addAuthenticationHeader(request);
+    addCustomHeaders(request);
+
+    if (body != null) {
+      request.setEntity(new StringEntity(
+          body.toString(),
+          ContentType.create("application/scim+json", StandardCharsets.UTF_8)
+      ));
+    }
+    
+    boolean verbose = configuration.isVerbose();
+    boolean hideBody = (method == HttpMethod.POST && url.endsWith(".search"));
+    ScimPluginLogger.INSTANCE.httpClientRequest(verbose, method.toString(), url, body != null ? body.toString() : "", hideBody);
+
+    try (CloseableHttpResponse response = httpClient.execute(request)) {
+      int statusCode = response.getCode();
+      String responseBody = response.getEntity() != null ? 
+          EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8) : "{}";
+
+      ScimPluginLogger.INSTANCE.httpClientResponse(verbose, method.toString(), statusCode);
+
+      if (statusCode == 200 || statusCode == 201 || statusCode == 204) {
+        return objectMapper.readTree(responseBody);
+      } else if (statusCode == 401 && isOAuth2Authentication() && !isRetry) {
+        // Try to refresh OAuth2 token and retry once
+        refreshOAuth2Token();
+        return executeHttpRequest(method, url, body, true);
+      } else {
+        ScimPluginLogger.INSTANCE.scimRequestError(statusCode, responseBody);
+        throw new IdentityProviderException("SCIM request failed with status: " + statusCode);
+      }
+    } catch (IOException | ParseException e) {
+      ScimPluginLogger.INSTANCE.httpClientException(method.toString() + " " + url, e);
+      throw new IdentityProviderException("SCIM HTTP request failed", e);
+    }
+  }
+
+  protected void addAuthenticationHeader(HttpUriRequestBase request) {
+    String authType = configuration.getAuthenticationType().toLowerCase();
+    
+    switch (authType) {
+      case "bearer":
+        if (configuration.getBearerToken() != null) {
+          request.setHeader("Authorization", "Bearer " + configuration.getBearerToken());
+        }
+        break;
+      case "basic":
+        if (configuration.getUsername() != null && configuration.getPassword() != null) {
+          String auth = configuration.getUsername() + ":" + configuration.getPassword();
+          String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+          request.setHeader("Authorization", "Basic " + encodedAuth);
+        }
+        break;
+      case "oauth2":
+        ensureOAuth2Token();
+        if (oauth2TokenStore != null && oauth2TokenStore.getToken() != null) {
+          request.setHeader("Authorization", "Bearer " + oauth2TokenStore.getToken());
+        }
+        break;
+    }
+  }
+
+  protected void addCustomHeaders(HttpUriRequestBase request) {
+    request.setHeader("Accept", "application/scim+json");
+    request.setHeader("Content-Type", "application/scim+json");
+    
+    for (Map.Entry<String, String> header : configuration.getCustomHeaders().entrySet()) {
+      request.setHeader(header.getKey(), header.getValue());
+    }
+  }
+
+  protected boolean isOAuth2Authentication() {
+    return "oauth2".equalsIgnoreCase(configuration.getAuthenticationType());
+  }
+
+  protected void ensureOAuth2Token() {
+    if (oauth2TokenStore == null || !oauth2TokenStore.isTokenValid()) {
+      refreshOAuth2Token();
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  protected void refreshOAuth2Token() {
+    if (oauth2TokenStore == null) {
+      throw new IdentityProviderException("OAuth2 token store not initialized");
+    }
+    if (configuration.getOauth2TokenUrl() == null) {
+      throw new IdentityProviderException("OAuth2 token URL not configured");
+    }
+
+    boolean verbose = configuration.isVerbose();
+    ScimPluginLogger.INSTANCE.oauth2TokenRefresh(verbose);
+
+    // Actually not a refresh process, but a request for a new access token (server-to-server auth)
+    HttpPost request = new HttpPost(configuration.getOauth2TokenUrl());
+    request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+
+    StringBuilder body = new StringBuilder();
+    body.append("grant_type=client_credentials");
+    body.append("&client_id=").append(encodeUrlParameter(configuration.getOauth2ClientId()));
+    body.append("&client_secret=").append(encodeUrlParameter(configuration.getOauth2ClientSecret()));
+    if (configuration.getOauth2Scope() != null) {
+      body.append("&scope=").append(encodeUrlParameter(configuration.getOauth2Scope()));
+    }
+
+    request.setEntity(new StringEntity(body.toString(), StandardCharsets.UTF_8));
+
+    try (CloseableHttpResponse response = httpClient.execute(request)) {
+      int statusCode = response.getCode();
+      String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode == 200) {
+        JsonNode tokenResponse = objectMapper.readTree(responseBody);
+        String accessToken = tokenResponse.get("access_token").asText();
+        int expiresIn = tokenResponse.has("expires_in") ? tokenResponse.get("expires_in").asInt() : 3600;
+        expiresIn = expiresIn > 120 ? expiresIn - 60 : expiresIn;  // Refresh 1 minute early if there is enough time
+        long expiryTime = System.currentTimeMillis() + expiresIn * 1000L; 
+        oauth2TokenStore.setToken(accessToken);
+        oauth2TokenStore.setExpiryTime(expiryTime);
+      } else {
+        ScimPluginLogger.INSTANCE.authenticationFailure("OAuth2 token request failed with status: " + statusCode + ", response: " + responseBody);
+        throw new IdentityProviderException("OAuth2 token request failed");
+      }
+    } catch (IOException | ParseException e) {
+      ScimPluginLogger.INSTANCE.httpClientException("OAuth2 token refresh", e);
+      throw new IdentityProviderException("OAuth2 token refresh failed", e);
+    }
+  }
+  
+  @SuppressWarnings("deprecation")
+  protected boolean checkUserPasswordWithOidc(String userName, String password) {
+    String url = configuration.getUserAuthenticationUrl();
+    if (url == null || url.isEmpty()) {
+      throw new IdentityProviderException("User authentication URL not configured");
+    }
+
+    boolean verbose = configuration.isVerbose();
+    ScimPluginLogger.INSTANCE.userAuthenticationRequest(verbose, "OIDC", url, userName);
+
+    // Actually not a refresh process, but a request for a new access token (server-to-server auth)
+    HttpPost request = new HttpPost(url);
+    request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+
+    StringBuilder body = new StringBuilder();
+    body.append("grant_type=password");
+    body.append("&client_id=").append(encodeUrlParameter(configuration.getOauth2ClientId()));
+    body.append("&client_secret=").append(encodeUrlParameter(configuration.getOauth2ClientSecret()));
+    body.append("&username=").append(userName);
+    body.append("&password=").append(encodeUrlParameter(password));
+
+    request.setEntity(new StringEntity(body.toString(), StandardCharsets.UTF_8));
+
+    try (CloseableHttpResponse response = httpClient.execute(request)) {
+      int statusCode = response.getCode();
+      String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+      ScimPluginLogger.INSTANCE.userAuthenticationResponse(verbose, "OIDC", userName, statusCode);
+
+      if (statusCode == 200) {
+        return true;
+      } else {
+        ScimPluginLogger.INSTANCE.authenticationFailure("User authentication failed with status: " + statusCode + ", response: " + responseBody );
+        return false;
+      }
+    } catch (IOException | ParseException e) {
+      ScimPluginLogger.INSTANCE.httpClientException("User authentication with OIDC failed", e);
+      throw new IdentityProviderException("User authentication failed", e);
+    }
+  }
+
+  protected boolean checkUserWithSearchFilter(String userId, String filter) {
+    String url = configuration.getServerUrl() + configuration.getUsersEndpoint() + "/.search";
+ 
+    boolean verbose = configuration.isVerbose();
+    ScimPluginLogger.INSTANCE.userAuthenticationRequest(verbose, "SCIM", url, userId);
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode root = mapper.createObjectNode();
+    ArrayNode schemas = mapper.createArrayNode().add("urn:ietf:params:scim:api:messages:2.0:SearchRequest");
+    root.set("schemas", schemas);
+    root.put("filter", filter);
+
+    JsonNode response = executeHttpRequest(HttpMethod.POST, url, root, false);
+    boolean result = (response != null && response.has("Resources") && response.get("Resources").size() == 1);
+    ScimPluginLogger.INSTANCE.userAuthenticationResponse(verbose, "SCIM", userId, result ? 200 : 401);
+    
+    return result;
+  }
+  
+  protected String encodeUrlParameter(String param) {
+    if (param == null) {
+      return "";
+    }
+    return URLEncoder.encode(param, StandardCharsets.UTF_8);
+  }
+
+  public void close() {
+    if (httpClient != null) {
+      try {
+        httpClient.close();
+      } catch (IOException e) {
+        ScimPluginLogger.INSTANCE.httpClientException("close", e);
+      }
+    }
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimConfiguration.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimConfiguration.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration class for SCIM Identity Provider.
+ */
+public class ScimConfiguration {
+
+  // SCIM server settings
+  protected String serverUrl;
+  protected String scimVersion = "2.0";
+  
+  // Authentication settings for the SCIM2 plugin (SCIM2 client)
+  protected String authenticationType = "bearer"; // bearer, basic, oauth2
+  protected String bearerToken;
+  protected String username;
+  protected String password;
+  protected String oauth2TokenUrl;
+  protected String oauth2ClientId;
+  protected String oauth2ClientSecret;
+  protected String oauth2Scope;
+
+  // Authentication settings for authenticating users
+  protected boolean userAuthenticationEnabled = false;
+  protected String userAuthenticationProtocol = "oidc";
+  protected String userAuthenticationUrl;
+  
+  // Endpoint configuration
+  protected String usersEndpoint = "/Users";
+  protected String groupsEndpoint = "/Groups";
+  
+  // User attribute mapping: our ScimUserEntity attributes to real scim attributes
+  protected final String userScimIdAttribute = "id";
+  protected final String userEmailsAttribute = "emails";
+  protected final String userPasswordAttribute = "password";
+  protected String userIdAttribute = "userName";
+  protected String userFirstnameAttribute = "name.givenName";
+  protected String userLastnameAttribute = "name.familyName";
+
+  // Group attribute mapping
+  protected final String groupScimIdAttribute = "id";
+  protected String groupIdAttribute = "externalId";
+  protected String groupNameAttribute = "displayName";
+  protected String groupMembersAttribute = "members";
+  
+  // base filters for users and groups
+  protected String userBaseFilter = "";
+  protected String groupBaseFilter = "";
+  
+  // Connection settings
+  protected int connectionTimeout = 30000; // milliseconds
+  protected int socketTimeout = 30000; // milliseconds
+  protected int maxConnections = 100;
+  
+  // SSL/TLS settings
+  // Note: SSL/TLS is determined by the serverUrl scheme (https://)
+  protected boolean acceptUntrustedCertificates = false;
+  
+  // Authorization settings
+  protected boolean authorizationCheckEnabled = true;
+  
+  // Pagination
+  protected Integer pageSize = 100;
+  
+  // Read only session
+  protected boolean allowModifications = false;
+  
+  // Additional custom headers
+  protected Map<String, String> customHeaders = new HashMap<>();
+  
+  // Output scim requests
+  protected boolean verbose = false;
+  
+  // Cache settings
+  protected boolean cacheEnabled = false;
+  protected int maxCacheSize = 250;
+  protected long cacheExpirationTimeoutMin = 5;
+
+  // Getters and Setters
+
+  public String getServerUrl() {
+    return serverUrl;
+  }
+
+  public void setServerUrl(String serverUrl) {
+    this.serverUrl = serverUrl;
+  }
+
+  public String getScimVersion() {
+    return scimVersion;
+  }
+
+  public void setScimVersion(String scimVersion) {
+    this.scimVersion = scimVersion;
+  }
+
+  public String getAuthenticationType() {
+    return authenticationType;
+  }
+
+  public void setAuthenticationType(String authenticationType) {
+    this.authenticationType = authenticationType;
+  }
+
+  public String getBearerToken() {
+    return bearerToken;
+  }
+
+  public void setBearerToken(String bearerToken) {
+    this.bearerToken = bearerToken;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getOauth2TokenUrl() {
+    return oauth2TokenUrl;
+  }
+
+  public void setOauth2TokenUrl(String oauth2TokenUrl) {
+    this.oauth2TokenUrl = oauth2TokenUrl;
+  }
+
+  public String getOauth2ClientId() {
+    return oauth2ClientId;
+  }
+
+  public void setOauth2ClientId(String oauth2ClientId) {
+    this.oauth2ClientId = oauth2ClientId;
+  }
+
+  public String getOauth2ClientSecret() {
+    return oauth2ClientSecret;
+  }
+
+  public void setOauth2ClientSecret(String oauth2ClientSecret) {
+    this.oauth2ClientSecret = oauth2ClientSecret;
+  }
+
+  public String getOauth2Scope() {
+    return oauth2Scope;
+  }
+
+  public void setOauth2Scope(String oauth2Scope) {
+    this.oauth2Scope = oauth2Scope;
+  }
+
+  public boolean getUserAuthenticationEnabled() {
+    return userAuthenticationEnabled;
+  }
+
+  public void setUserAuthenticationEnabled(boolean userAuthenticationEnabled) {
+   this.userAuthenticationEnabled = userAuthenticationEnabled;
+  }
+ 
+  public String getUserAuthenticationProtocol() {
+    return userAuthenticationProtocol;
+  }
+
+  public void setUserAuthenticationProtocol(String userAuthenticationProtocol) {
+   this.userAuthenticationProtocol = userAuthenticationProtocol;
+  }
+  
+  public String getUserAuthenticationUrl() {
+    return userAuthenticationUrl;
+  }
+
+  public void setUserAuthenticationUrl(String userAuthenticationUrl) {
+   this.userAuthenticationUrl = userAuthenticationUrl;
+  }
+
+  public String getUsersEndpoint() {
+    return usersEndpoint;
+  }
+
+  public void setUsersEndpoint(String usersEndpoint) {
+    this.usersEndpoint = usersEndpoint.replaceAll ("/+$", "");
+  }
+
+  public String getGroupsEndpoint() {
+    return groupsEndpoint;
+  }
+
+  public void setGroupsEndpoint(String groupsEndpoint) {
+    this.groupsEndpoint = groupsEndpoint.replaceAll ("/+$", "");
+  }
+
+  public String getUserScimIdAttribute() {
+    return userScimIdAttribute;
+  }
+
+  public String getUserIdAttribute() {
+    return userIdAttribute;
+  }
+
+  public void setUserIdAttribute(String userIdAttribute) {
+    this.userIdAttribute = userIdAttribute;
+  }
+  
+  public String getUserFirstnameAttribute() {
+    return userFirstnameAttribute;
+  }
+
+  public void setUserFirstnameAttribute(String userFirstnameAttribute) {
+    this.userFirstnameAttribute = userFirstnameAttribute;
+  }
+
+  public String getUserLastnameAttribute() {
+    return userLastnameAttribute;
+  }
+
+  public void setUserLastnameAttribute(String userLastnameAttribute) {
+    this.userLastnameAttribute = userLastnameAttribute;
+  }
+ 
+  public String getUserEmailsAttribute() {
+    return userEmailsAttribute;
+  }
+
+  public String getUserPasswordAttribute() {
+    return userPasswordAttribute;
+  }
+
+  public String getGroupScimIdAttribute() {
+    return groupScimIdAttribute;
+  }
+  
+  public String getGroupIdAttribute() {
+    return groupIdAttribute;
+  }
+
+  public void setGroupIdAttribute(String groupIdAttribute) {
+    this.groupIdAttribute = groupIdAttribute;
+  }
+
+  public String getGroupNameAttribute() {
+    return groupNameAttribute;
+  }
+
+  public void setGroupNameAttribute(String groupNameAttribute) {
+    this.groupNameAttribute = groupNameAttribute;
+  }
+
+  public String getGroupMembersAttribute() {
+    return groupMembersAttribute;
+  }
+
+  public void setGroupMembersAttribute(String groupMembersAttribute) {
+    this.groupMembersAttribute = groupMembersAttribute;
+  }
+
+  public int getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public void setConnectionTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
+  public int getSocketTimeout() {
+    return socketTimeout;
+  }
+
+  public void setSocketTimeout(int socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
+
+  public int getMaxConnections() {
+    return maxConnections;
+  }
+
+  public void setMaxConnections(int maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  public boolean isAcceptUntrustedCertificates() {
+    return acceptUntrustedCertificates;
+  }
+
+  public void setAcceptUntrustedCertificates(boolean acceptUntrustedCertificates) {
+    this.acceptUntrustedCertificates = acceptUntrustedCertificates;
+  }
+
+  public boolean isAuthorizationCheckEnabled() {
+    return authorizationCheckEnabled;
+  }
+
+  public void setAuthorizationCheckEnabled(boolean authorizationCheckEnabled) {
+    this.authorizationCheckEnabled = authorizationCheckEnabled;
+  }
+  
+  public boolean isVerbose() {
+    return verbose;
+  }
+
+  public void setVerbose(boolean verbose) {
+    this.verbose = verbose;
+  }
+
+  public boolean getAllowModifications() {
+    return allowModifications;
+  }
+
+  public void setAllowModifications(boolean allowModifications) {
+    this.allowModifications = allowModifications;
+  }
+
+  public Integer getPageSize() {
+    return pageSize;
+  }
+
+  public void setPageSize(Integer pageSize) {
+    this.pageSize = pageSize;
+  }
+
+  public Map<String, String> getCustomHeaders() {
+    return customHeaders;
+  }
+
+  public void setCustomHeaders(Map<String, String> customHeaders) {
+    this.customHeaders = customHeaders;
+  }
+
+  public String getGroupBaseFilter() {
+    return groupBaseFilter;
+  }
+
+  public void setGroupBaseFilter(String groupBaseFilter) {
+    this.groupBaseFilter = groupBaseFilter;
+  }
+
+  public String getUserBaseFilter() {
+    return userBaseFilter;
+  }
+
+  public void setUserBaseFilter(String userBaseFilter) {
+    this.userBaseFilter = userBaseFilter;
+  }
+
+  public boolean isCacheEnabled() {
+    return cacheEnabled;
+  }
+
+  public void setCacheEnabled(boolean cacheEnabled) {
+    this.cacheEnabled = cacheEnabled;
+  }
+
+  public int getMaxCacheSize() {
+    return maxCacheSize;
+  }
+
+  public void setMaxCacheSize(int maxCacheSize) {
+    this.maxCacheSize = maxCacheSize;
+  }
+
+  public long getCacheExpirationTimeoutMin() {
+    return cacheExpirationTimeoutMin;
+  }
+
+  public void setCacheExpirationTimeoutMin(long cacheExpirationTimeoutMin) {
+    this.cacheExpirationTimeoutMin = cacheExpirationTimeoutMin;
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimGroupEntity.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimGroupEntity.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.impl.persistence.entity.GroupEntity;
+
+/**
+ * SCIM Group Entity.
+ */
+public class ScimGroupEntity extends GroupEntity {
+
+  private static final long serialVersionUID = 1L;
+
+  protected String scimId;
+  
+  public ScimGroupEntity() {
+    super();
+  }
+	  
+  public ScimGroupEntity(String groupID) {
+    super(groupID);
+  }
+
+  public String getScimId() {
+    return scimId;
+  }
+
+  public void setScimId(String scimId) {
+    this.scimId = scimId;
+  }
+  
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + " [scimId=" + scimId + ", id=" + id + ", name=" + name + ", type=" + type + "]";
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimGroupQuery.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimGroupQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.identity.Group;
+import org.operaton.bpm.engine.impl.GroupQueryImpl;
+import org.operaton.bpm.engine.impl.Page;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.engine.impl.interceptor.CommandExecutor;
+
+import java.util.List;
+
+/**
+ * SCIM Group Query Implementation.
+ */
+public class ScimGroupQuery extends GroupQueryImpl {
+
+  private static final long serialVersionUID = 1L;
+  
+  private int totalResults = 0;
+  
+  public int getTotalResults() {
+    return totalResults;
+  }
+  
+  public void setTotalResults(int totalResults) {
+    this.totalResults = totalResults;
+  }
+
+  public ScimGroupQuery() {
+    super();
+  }
+
+  public ScimGroupQuery(CommandExecutor commandExecutor) {
+    super(commandExecutor);
+  }
+  
+  @Override
+  public long executeCount(CommandContext commandContext) {
+    final ScimIdentityProviderReadOnly provider = getScimIdentityProvider(commandContext);
+    return provider.findGroupCountByQueryCriteria(this);
+  }
+
+  @Override
+  public List<Group> executeList(CommandContext commandContext, Page page) {
+    final ScimIdentityProviderReadOnly provider = getScimIdentityProvider(commandContext);
+    return provider.findGroupByQueryCriteria(this);
+  }
+
+  protected ScimIdentityProviderReadOnly getScimIdentityProvider(CommandContext commandContext) {
+    return (ScimIdentityProviderReadOnly) commandContext.getReadOnlyIdentityProvider();
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderFactory.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.impl.identity.ReadOnlyIdentityProvider;
+import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
+import org.operaton.bpm.engine.impl.interceptor.Session;
+import org.operaton.bpm.engine.impl.interceptor.SessionFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+/**
+ * Factory for SCIM Identity Provider Sessions.
+ */
+public class ScimIdentityProviderFactory implements SessionFactory {
+
+  protected ScimConfiguration scimConfiguration;
+  protected ScimSimpleCache<JsonNode> responseCache;
+  protected ScimSimpleCache<String> userCache;
+  protected ScimOAuth2TokenStore oauth2TokenStore;
+
+  @Override
+  public Class<?> getSessionType() {
+    if (scimConfiguration != null && scimConfiguration.getAllowModifications()) {
+      return WritableIdentityProvider.class;
+    } else {
+      return ReadOnlyIdentityProvider.class;
+    }
+  }
+
+  @Override
+  public Session openSession() {
+    if (scimConfiguration != null && scimConfiguration.getAllowModifications()) {
+      return new ScimIdentityProviderWritable(scimConfiguration, getResponseCache(), getUserCache(), getOAuth2TokenStore());
+    } else {
+      return new ScimIdentityProviderReadOnly(scimConfiguration, getResponseCache(), getUserCache(), getOAuth2TokenStore());
+    }
+  }
+
+  public ScimConfiguration getScimConfiguration() {
+    return scimConfiguration;
+  }
+
+  public void setScimConfiguration(ScimConfiguration scimConfiguration) {
+    this.scimConfiguration = scimConfiguration;
+  }
+
+  protected ScimSimpleCache<JsonNode> getResponseCache() {
+    if (scimConfiguration != null && scimConfiguration.isCacheEnabled()) {
+      if (responseCache == null) {
+        responseCache = new ScimSimpleCache<JsonNode>(
+            scimConfiguration.getMaxCacheSize(),
+            scimConfiguration.getCacheExpirationTimeoutMin());
+      }
+      return responseCache;
+    }
+    return null;
+  }
+
+  protected ScimSimpleCache<String> getUserCache() {
+    if (scimConfiguration != null && scimConfiguration.isCacheEnabled()) {
+      if (userCache == null) {
+        userCache = new ScimSimpleCache<String>(
+            scimConfiguration.getMaxCacheSize(),
+            scimConfiguration.getCacheExpirationTimeoutMin());
+      }
+      return userCache;
+    }
+    return null;
+  }
+
+  protected ScimOAuth2TokenStore getOAuth2TokenStore() {
+    if (scimConfiguration != null && "oauth2".equalsIgnoreCase(scimConfiguration.getAuthenticationType())) {
+      if (oauth2TokenStore == null) {
+        oauth2TokenStore = new ScimOAuth2TokenStore();
+      }
+      return oauth2TokenStore;
+    }
+    return null;
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderReadOnly.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderReadOnly.java
@@ -1,0 +1,721 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.operaton.bpm.engine.BadUserRequestException;
+import org.operaton.bpm.engine.authorization.Resource;
+import org.operaton.bpm.engine.identity.Group;
+import org.operaton.bpm.engine.identity.GroupQuery;
+import org.operaton.bpm.engine.identity.NativeUserQuery;
+import org.operaton.bpm.engine.identity.Tenant;
+import org.operaton.bpm.engine.identity.TenantQuery;
+import org.operaton.bpm.engine.identity.User;
+import org.operaton.bpm.engine.identity.UserQuery;
+import org.operaton.bpm.engine.impl.Direction;
+import org.operaton.bpm.engine.impl.GroupQueryProperty;
+import org.operaton.bpm.engine.impl.QueryOrderingProperty;
+import org.operaton.bpm.engine.impl.UserQueryProperty;
+import org.operaton.bpm.engine.impl.identity.ReadOnlyIdentityProvider;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.identity.impl.scim.ScimClient.HttpMethod;
+import org.operaton.bpm.identity.impl.scim.util.ScimPluginLogger;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Resources.GROUP;
+import static org.operaton.bpm.engine.authorization.Resources.USER;
+import static org.operaton.bpm.engine.impl.context.Context.getCommandContext;
+import static org.operaton.bpm.engine.impl.context.Context.getProcessEngineConfiguration;
+
+/**
+ * SCIM Identity Provider Session implementing ReadOnlyIdentityProvider.
+ */
+public class ScimIdentityProviderReadOnly implements ReadOnlyIdentityProvider {
+
+  protected ScimConfiguration scimConfiguration;
+  protected ScimSimpleCache<String> userCache;
+  protected ScimClient scimClient;
+  
+  public ScimIdentityProviderReadOnly(ScimConfiguration scimConfiguration) {
+    this(scimConfiguration, null, null, null);
+  }
+
+  public ScimIdentityProviderReadOnly(ScimConfiguration scimConfiguration, ScimSimpleCache<JsonNode> responseCache, 
+      ScimSimpleCache<String> userCache) {
+    this(scimConfiguration, responseCache, userCache, null);
+  }
+
+  public ScimIdentityProviderReadOnly(ScimConfiguration scimConfiguration, ScimSimpleCache<JsonNode> responseCache, 
+      ScimSimpleCache<String> userCache, ScimOAuth2TokenStore oauth2TokenStore) {
+    this.scimConfiguration = scimConfiguration;
+    this.userCache = userCache;
+    this.scimClient = new ScimClient(scimConfiguration, responseCache, oauth2TokenStore);
+  }
+
+  // Session Lifecycle
+
+  @Override
+  public void flush() {
+    // nothing to do for read-only provider
+  }
+
+  @Override
+  public void close() {
+    if (scimClient != null) {
+      scimClient.close();
+    }
+  }
+
+  // Users
+
+  @Override
+  public User findUserById(String userId) {
+    return createUserQuery(getCommandContext()).userId(userId).singleResult();
+  }
+
+  @Override
+  public UserQuery createUserQuery() {
+    return new ScimUserQuery(getProcessEngineConfiguration().getCommandExecutorTxRequired());
+  }
+
+  @Override
+  public UserQuery createUserQuery(CommandContext commandContext) {
+    return new ScimUserQuery();
+  }
+
+  @Override
+  public NativeUserQuery createNativeUserQuery() {
+    throw new BadUserRequestException("Native user queries are not supported for SCIM identity service provider.");
+  }
+
+  public long findUserCountByQueryCriteria(ScimUserQuery query) {
+    // SCIM 2.0 returns total number of filtered resources as a parameter of the response
+    // therefore restrict the number of returned elements to decrease network usage
+    if (query.getMaxResults() >= Short.MAX_VALUE) {
+      query.setMaxResults(scimConfiguration.getPageSize());
+    }
+    List<User> users = findUserByQueryCriteria(query);
+    return Math.max(users.size(), query.getTotalResults());
+  }
+
+  public List<User> findUserByQueryCriteria(ScimUserQuery query) {
+    if (query.getGroupId() != null) {
+      return findUsersByGroupId(query);
+    } else {
+      return findUsersWithoutGroupId(query);
+    }
+  }
+
+  protected List<User> findUsersWithoutGroupId(ScimUserQuery query) {
+    String filter = buildUserFilter(query);
+    String sorting = buildUserSorting(query);
+    int startIndex = query.getFirstResult() + 1; // SCIM uses 1-based indexing
+    int count = query.getMaxResults();
+
+    List<User> users = new ArrayList<>();
+    JsonNode response = scimClient.searchUsers(filter, startIndex, count, sorting);    
+    if (response != null && response.has("Resources")) {
+      JsonNode resources = response.get("Resources");
+      for (JsonNode resource : resources) {
+        ScimUserEntity user = transformUser(resource);
+        if (user.getScimId() == null || user.getScimId().isEmpty()) {
+          ScimPluginLogger.INSTANCE.invalidScimEntityReturned("User", user.toString());    
+        } else if (isAuthenticatedAndAuthorizedToRead(user.getId())) {
+          users.add(user);
+        }
+      }
+    }
+    
+    // set total result
+    if (response != null && response.has("totalResults")) {
+      query.setTotalResults(response.get("totalResults").asInt());
+    }
+
+    return users;
+  }
+
+  protected List<User> findUsersByGroupId(ScimUserQuery query) {
+    // First find the group to get its members
+    ScimGroupEntity group = (ScimGroupEntity)findGroupById(query.getGroupId());
+    if (group == null) {
+      return new ArrayList<>();
+    }
+
+    // Get group details with members
+    JsonNode groupData = scimClient.getGroupByScimId(group.getScimId());
+    List<User> users = new ArrayList<>();
+
+    String membersAttrib = scimConfiguration.getGroupMembersAttribute();
+    if (groupData != null && groupData.has(membersAttrib)) {
+      int resultCount = 0;
+      JsonNode members = groupData.get(membersAttrib);
+      for (JsonNode member : members) {
+        if (resultCount >= query.getFirstResult() && users.size() < query.getMaxResults()) {
+          String memberType = getJsonValue(member, "type"); // treat as user type by default if the type is absent
+          if (memberType == null || memberType.isEmpty() || memberType.equals("User")) {
+            String userScimId = getJsonValue(member, "value");
+            if (userScimId != null) {
+              ScimUserEntity user = transformUser(scimClient.getUserByScimId(userScimId));
+              if (user.getScimId() == null || user.getScimId().isEmpty()) {
+                ScimPluginLogger.INSTANCE.invalidScimEntityReturned("User", user.toString()); 
+              } else if (isAuthenticatedAndAuthorizedToRead(user.getId())) {
+                users.add(user);         
+              }
+            }
+          }
+        }
+        resultCount++;
+      }
+
+      // set total result
+      query.setTotalResults(members.size());
+    }
+
+    return users;
+  }
+
+  protected String buildUserFilter(ScimUserQuery query) {
+    List<String> filters = new ArrayList<>();
+
+    String baseFilter = scimConfiguration.getUserBaseFilter();
+    if (baseFilter != null && !baseFilter.isEmpty()) {
+      filters.add(baseFilter);
+    }
+    if (query.getId() != null) {
+      filters.add(scimConfiguration.getUserIdAttribute() + " eq \"" + escapeScimFilter(query.getId()) + "\"");
+    }
+    if (query.getIds() != null && query.getIds().length > 0) {
+      List<String> idFilters = new ArrayList<>();
+      for (String userId : query.getIds()) {
+        idFilters.add(scimConfiguration.getUserIdAttribute() + " eq \"" + escapeScimFilter(userId) + "\"");
+      }
+      filters.add("(" + String.join(" or ", idFilters) + ")");
+    }
+    if (query.getFirstName() != null) {
+      filters.add(scimConfiguration.getUserFirstnameAttribute() + " eq \"" + escapeScimFilter(query.getFirstName()) + "\"");
+    }
+    if (query.getFirstNameLike() != null) {
+      String nameLike = query.getFirstNameLike();
+      String op = nameLike.startsWith("%") && nameLike.endsWith("%") ? "co" : 
+          nameLike.startsWith("%") ? "sw" : nameLike.endsWith("%") ? "ew" : "eq";
+      
+      nameLike = nameLike.replaceAll("^%|%$", "");
+      filters.add(scimConfiguration.getUserFirstnameAttribute() + " " + op + " \"" +escapeScimFilter(nameLike) + "\"");
+    }
+    if (query.getLastName() != null) {
+      filters.add(scimConfiguration.getUserLastnameAttribute() + " eq \"" + escapeScimFilter(query.getLastName()) + "\"");
+    }
+    if (query.getLastNameLike() != null) {
+      String nameLike = query.getLastNameLike();
+      String op = nameLike.startsWith("%") && nameLike.endsWith("%") ? "co" : 
+          nameLike.startsWith("%") ? "sw" : nameLike.endsWith("%") ? "ew" : "eq";
+        
+      nameLike = nameLike.replaceAll("^%|%$", "");
+      filters.add(scimConfiguration.getUserLastnameAttribute() + " " + op + " \"" + escapeScimFilter(nameLike) + "\"");
+    }
+
+    // filter by user work email
+    String workEmailAttrib = scimConfiguration.getUserEmailsAttribute() + "[type eq \"work\"].value";
+    if (query.getEmail() != null) {
+      filters.add(workEmailAttrib + " eq \"" + escapeScimFilter(query.getEmail()) + "\"");
+    }
+    if (query.getEmailLike() != null) {
+      String emailLike = query.getEmailLike();
+      String op = emailLike.startsWith("%") && emailLike.endsWith("%") ? "co" : 
+          emailLike.startsWith("%") ? "sw" : emailLike.endsWith("%") ? "ew" : "eq";
+           
+      emailLike = emailLike.replaceAll("^%|%$", "");
+      filters.add(workEmailAttrib + " " + op + " \"" + escapeScimFilter(emailLike) + "\"");
+    }
+
+    return filters.isEmpty() ? null : String.join(" and ", filters);
+  }
+  
+  protected String buildUserSorting(ScimUserQuery query) {
+    String sorting = null;
+    List<QueryOrderingProperty> orderBy = query.getOrderingProperties();
+    if (orderBy != null) {
+      for (QueryOrderingProperty orderingProperty : orderBy) {
+        String key = null;
+        String direction = null;
+        String propertyName = orderingProperty.getQueryProperty().getName();
+
+        if (UserQueryProperty.USER_ID.getName().equals(propertyName)) {
+          key = scimConfiguration.getUserIdAttribute();
+          direction = Direction.ASCENDING.equals(orderingProperty.getDirection()) ? "ascending" : "descending";
+        } else if (UserQueryProperty.EMAIL.getName().equals(propertyName)) {
+          key = scimConfiguration.getUserEmailsAttribute() + "[type eq \"work\"].value";
+          direction = Direction.ASCENDING.equals(orderingProperty.getDirection()) ? "ascending" : "descending";
+        } else if (UserQueryProperty.FIRST_NAME.getName().equals(propertyName)) {
+          key = scimConfiguration.getUserFirstnameAttribute();
+          direction = Direction.ASCENDING.equals(orderingProperty.getDirection()) ? "ascending" : "descending";
+        } else if (UserQueryProperty.LAST_NAME.getName().equals(propertyName)) {
+           key = scimConfiguration.getUserLastnameAttribute();
+           direction = Direction.ASCENDING.equals(orderingProperty.getDirection()) ? "ascending" : "descending";
+        }
+        
+        // only single key is supported by SCIM for sorting
+        if (key != null && direction != null) {
+          sorting = "sortBy=" + key + "&sortOrder=" + direction;
+          break;
+        }
+      }
+    }
+    
+    return sorting;
+  }
+
+  protected ScimUserEntity transformUser(JsonNode resource) {
+    ScimUserEntity user = new ScimUserEntity();
+    user.setScimId(getJsonValue(resource, scimConfiguration.getUserScimIdAttribute()));
+    user.setId(getJsonValue(resource, scimConfiguration.getUserIdAttribute()));
+    if (user.getId() == null || user.getId().isEmpty()) {
+      user.setId(user.getScimId()); // use scim ID as a fallback
+    }
+    
+    user.setFirstName(getJsonValue(resource, scimConfiguration.getUserFirstnameAttribute()));
+    user.setLastName(getJsonValue(resource, scimConfiguration.getUserLastnameAttribute()));
+    
+    // Get user work email: the standard SCIM email attribute is an array
+    String emailsAttr = scimConfiguration.getUserEmailsAttribute();
+    if (resource.has(emailsAttr) && resource.get(emailsAttr).isArray()) {
+      JsonNode emailList = resource.get(emailsAttr);
+      for (JsonNode email : emailList) {
+        if (email.has("type") && "work".equals(email.get("type").asText())) {
+          user.setEmail(email.has("value") ? email.get("value").asText() : null);
+          break;
+        }
+      }
+      // Fallback to first email if no work email found
+      if (user.getEmail() == null && emailList.size() > 0) {
+        JsonNode firstEmail = resource.get(emailsAttr).get(0);
+        user.setEmail(firstEmail.has("value") ? firstEmail.get("value").asText() : null);
+      }
+    }
+
+    return user;
+  }
+
+  protected JsonNode transformUser(ScimUserEntity user) {
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode root = mapper.createObjectNode();
+    
+    ArrayNode schemas = root.putArray("schemas");
+    schemas.add("urn:ietf:params:scim:schemas:core:2.0:User");
+
+    String scimIdAttr = scimConfiguration.getUserScimIdAttribute();
+    setJsonValue(root, scimIdAttr, user.getScimId(), mapper);
+    
+    String idAttr = scimConfiguration.getUserIdAttribute();
+    setJsonValue(root, idAttr, user.getId(), mapper);
+
+    String firstNameAttr = scimConfiguration.getUserFirstnameAttribute();
+    setJsonValue(root, firstNameAttr, user.getFirstName(), mapper);
+
+    String lastNameAttr = scimConfiguration.getUserLastnameAttribute();
+    setJsonValue(root, lastNameAttr, user.getLastName(), mapper);
+    
+    String passwordAttr = scimConfiguration.getUserPasswordAttribute();
+    if (user.getPassword() != null) {
+      setJsonValue(root, passwordAttr, user.getPassword(), mapper);
+    }
+
+    // set email as work email in the SCIM email list
+    String emailsAttr = scimConfiguration.getUserEmailsAttribute();
+    ArrayNode emailsArray = root.putArray(emailsAttr);
+    ObjectNode emailObj = emailsArray.addObject();
+    emailObj.put("type", "work");
+    emailObj.put("value", user.getEmail());
+  
+    return root;
+  }
+   
+  // Groups
+
+  @Override
+  public Group findGroupById(String groupId) {
+    return createGroupQuery(getCommandContext()).groupId(groupId).singleResult();
+  }
+
+  @Override
+  public GroupQuery createGroupQuery() {
+    return new ScimGroupQuery(getProcessEngineConfiguration().getCommandExecutorTxRequired());
+  }
+
+  @Override
+  public GroupQuery createGroupQuery(CommandContext commandContext) {
+    return new ScimGroupQuery();
+  }
+
+  public long findGroupCountByQueryCriteria(ScimGroupQuery query) {
+    // SCIM 2.0 returns total number of filtered resources as a parameter of the response
+    // therefore restrict the number of returned elements to decrease network usage
+    if (query.getMaxResults() >= Short.MAX_VALUE) {
+      query.setMaxResults(scimConfiguration.getPageSize());
+    }
+    List<Group> groups = findGroupByQueryCriteria(query);
+    return Math.max(groups.size(), query.getTotalResults());
+  }
+
+  public List<Group> findGroupByQueryCriteria(ScimGroupQuery query) {
+    String filter = buildGroupFilter(query);
+    String sorting = buildGroupSorting(query);
+    int startIndex = query.getFirstResult() + 1; // SCIM uses 1-based indexing
+    int count = query.getMaxResults();
+
+    List<Group> groups = new ArrayList<>();
+    JsonNode response = scimClient.searchGroups(filter, startIndex, count, sorting);
+    if (response != null && response.has("Resources")) {
+      JsonNode resources = response.get("Resources");
+      for (JsonNode resource : resources) {
+        ScimGroupEntity group = transformGroup(resource);
+        if (group.getScimId() == null || group.getScimId().isEmpty()) {
+          ScimPluginLogger.INSTANCE.invalidScimEntityReturned("group", resource.toString());
+        } else if (isAuthorizedToReadGroup(group.getId())) {
+          groups.add(group);
+        }
+      }
+    }
+    
+    // set total result
+    if (response != null && response.has("totalResults")) {
+      query.setTotalResults(response.get("totalResults").asInt());
+    }
+    
+    //// TODO: remove this fallback for SCIMPLE, because it doesn't correctly filter by an users
+    //if (groups.isEmpty() && query.getUserId() != null) {
+    //  groups = findGroupByUserId(query);
+    //}
+
+    return groups;
+  }
+  
+//  // TODO: remove this fallback for SCIMPLE, because it doesn't correctly filter by an users 
+//  public List<Group> findGroupByUserId(ScimGroupQuery query) {
+//    List<Group> groups = new ArrayList<>();
+//    ScimUserEntity scimUser = (ScimUserEntity) findUserById(query.getUserId());
+//    if (scimUser != null) {
+//      ScimGroupQuery queryNew = new ScimGroupQuery();
+//      String filter = buildGroupFilter(queryNew);
+//      String sorting = buildGroupSorting(queryNew);
+//      int startIndex = queryNew.getFirstResult() + 1; // SCIM uses 1-based indexing
+//      int count = queryNew.getMaxResults();
+//      JsonNode response = scimClient.searchGroups(filter, startIndex, count, sorting);
+//      int groupCount = 0;
+//      if (response != null && response.has("Resources")) {
+//        JsonNode resources = response.get("Resources");
+//        for (JsonNode resource : resources) {
+//          JsonNode members = resource.get(scimConfiguration.getGroupMembersAttribute());
+//          if (members != null) {
+//            for (JsonNode member : members) {
+//              String userScimId = getJsonValue(member, "value");
+//              if (scimUser.getScimId().equals(userScimId)) {
+//                groups.add(transformGroup(resource));
+//                groupCount++;
+//                break;
+//              }  
+//            }
+//          }
+//        }
+//      }
+//      // set total result
+//      query.setTotalResults(groupCount);
+//    }
+//
+//    return groups;
+//  }
+
+  protected String buildGroupFilter(ScimGroupQuery query) {
+    List<String> filters = new ArrayList<>();
+    
+    String baseFilter = scimConfiguration.getGroupBaseFilter();
+    if (baseFilter != null && !baseFilter.isEmpty()) {
+      filters.add(escapeScimFilter(baseFilter));
+    }
+    if (query.getId() != null) {
+      filters.add(scimConfiguration.getGroupIdAttribute() + " eq \"" + escapeScimFilter(query.getId()) + "\"");
+    }
+    if (query.getIds() != null && query.getIds().length > 0) {
+      List<String> idFilters = new ArrayList<>();
+      for (String groupId : query.getIds()) {
+        idFilters.add(scimConfiguration.getGroupIdAttribute() + " eq \"" + escapeScimFilter(groupId) + "\"");
+      }
+      filters.add("(" + String.join(" or ", idFilters) + ")");
+    }
+    if (query.getName() != null) {
+      filters.add(scimConfiguration.getGroupNameAttribute() + " eq \"" + escapeScimFilter(query.getName()) + "\"");
+    }
+    if (query.getNameLike() != null) {
+      String nameLike = query.getNameLike();
+      String op = nameLike.startsWith("%") && nameLike.endsWith("%") ? "co" : 
+          nameLike.startsWith("%") ? "sw" : nameLike.endsWith("%") ? "ew" : "eq";
+      
+      nameLike = nameLike.replaceAll("^%|%$", "");
+      filters.add(scimConfiguration.getGroupNameAttribute() + " " + op + " \"" + escapeScimFilter(nameLike) + "\"");
+    }
+    if (query.getUserId() != null) {
+      ScimUserEntity scimUser = (ScimUserEntity)findUserById(query.getUserId());
+      String skimUserId = scimUser != null ? scimUser.getScimId() : "";
+      if (!skimUserId.isEmpty()) {
+        filters.add("members[value eq \"" + escapeScimFilter(skimUserId) + "\"]");
+      }
+      else { // should return empty list
+        filters.add("members[value eq \"0\"] and members[value eq \"1\"]");
+      }
+    }
+
+    return filters.isEmpty() ? null : String.join(" and ", filters);
+  }
+  
+  protected String buildGroupSorting(ScimGroupQuery query) {
+    String sorting = null;
+    List<QueryOrderingProperty> orderBy = query.getOrderingProperties();
+    if (orderBy != null) {
+      for (QueryOrderingProperty orderingProperty : orderBy) {
+        String key = null;
+        String direction = null;
+        String propertyName = orderingProperty.getQueryProperty().getName();
+
+        if (GroupQueryProperty.GROUP_ID.getName().equals(propertyName)) {
+          key = scimConfiguration.getGroupIdAttribute();
+          direction = Direction.ASCENDING.equals(orderingProperty.getDirection()) ? "ascending" : "descending";
+        } else if (GroupQueryProperty.NAME.getName().equals(propertyName)) {
+          key = scimConfiguration.getGroupNameAttribute();
+          direction = Direction.ASCENDING.equals(orderingProperty.getDirection()) ? "ascending" : "descending";
+        }
+
+        // only single key is supported by SCIM for sorting
+        if (key != null && direction != null) {
+          sorting = "sortBy=" + key + "&sortOrder=" + direction;
+          break;
+        }
+      }
+    }
+    
+    return sorting;
+  }
+
+  protected ScimGroupEntity transformGroup(JsonNode resource) {
+    ScimGroupEntity group = new ScimGroupEntity();
+    group.setScimId(getJsonValue(resource, scimConfiguration.getGroupScimIdAttribute()));
+    group.setId(getJsonValue(resource, scimConfiguration.getGroupIdAttribute()));
+    if (group.getId() == null || group.getId().isEmpty()) { 
+      group.setId(group.getScimId()); // use scim ID as a fallback
+    }
+    
+    group.setName(getJsonValue(resource, scimConfiguration.getGroupNameAttribute()));
+    group.setType("SCIM");
+    return group;
+  }
+
+  protected JsonNode transformGroup(ScimGroupEntity group) {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode root = mapper.createObjectNode();
+
+    ArrayNode schemas = root.putArray("schemas");
+    schemas.add("urn:ietf:params:scim:schemas:core:2.0:Group");
+    
+    String scimIdAttr = scimConfiguration.getGroupScimIdAttribute();
+    setJsonValue(root, scimIdAttr, group.getScimId(), mapper);
+
+    String idAttr = scimConfiguration.getGroupIdAttribute();
+    setJsonValue(root, idAttr, group.getId(), mapper);
+
+    String groupNameAttr = scimConfiguration.getGroupNameAttribute();
+    setJsonValue(root, groupNameAttr, group.getName(), mapper);
+    
+    return root;
+  }
+  
+  // Membership
+  boolean isGroupMember(ScimGroupEntity group, ScimUserEntity user) {
+    if (group == null || user == null) {
+      return false;
+    } 
+    
+    boolean found = false;
+    JsonNode groupData = scimClient.getGroupByScimId(group.getScimId());
+    String membersAttrib = scimConfiguration.getGroupMembersAttribute();
+    if (groupData != null && groupData.has(membersAttrib)) {
+      JsonNode members = groupData.get(membersAttrib);
+      for (JsonNode member : members) {
+        String memberId = getJsonValue(member, "value");
+        if (memberId != null && memberId.equals(user.getScimId())) {
+          found = true;
+          break;
+        }         
+      }
+    }
+    return found;
+  }
+  
+  // Tenants
+
+  @Override
+  public TenantQuery createTenantQuery() {
+    return new ScimTenantQuery(getProcessEngineConfiguration().getCommandExecutorTxRequired());
+  }
+
+  @Override
+  public TenantQuery createTenantQuery(CommandContext commandContext) {
+    return new ScimTenantQuery();
+  }
+
+  @Override
+  public Tenant findTenantById(String id) {
+    // Multi-tenancy is not supported for SCIM plugin
+    return null;
+  }
+
+  // Password check
+
+  @Override
+  public boolean checkPassword(String userId, String password) {
+
+    ScimPluginLogger.INSTANCE.userAuthentication(scimConfiguration.isVerbose(), userId);
+
+    // check if it is already cached
+    try {
+      if (userCache != null) {
+        String cached = userCache.get(userId);
+        if (cached != null && cached.equals(getSHA256Base64(userId + password))) {
+          return true;
+        }
+      }
+    } catch(NoSuchAlgorithmException e) {
+      ScimPluginLogger.INSTANCE.userCacheUnavailable();
+    }
+
+    // authenticate an user 
+    boolean result = false;
+    try {
+      if (!scimConfiguration.getUserAuthenticationEnabled()) {
+        // user authentication is disabled: simply check that the user really exists
+        ScimUserEntity scimUser = (ScimUserEntity) findUserById(userId);
+        result = scimUser != null && scimUser.getScimId() != null;
+      } else if ("scim".equalsIgnoreCase(scimConfiguration.getUserAuthenticationProtocol())) {
+        String userIdAttrib = scimConfiguration.getUserIdAttribute();
+        String filter = userIdAttrib + " eq \"" + escapeScimFilter(userId) + "\" and password eq \"" + escapeScimFilter(password) + "\"";
+        result = scimClient.checkUserWithSearchFilter(userId, filter);
+      } else if ("oidc".equalsIgnoreCase(scimConfiguration.getUserAuthenticationProtocol())) {
+        result = scimClient.checkUserPasswordWithOidc(userId, password);
+      } else {
+        throw new Exception("User authentication protocol is not set or not supported.");
+      }
+    } catch(Exception e) {
+      ScimPluginLogger.INSTANCE.httpClientException("authentication request", e);
+    }
+
+    // try to securely cache the successful authentication
+    try {
+      if (userCache != null && result == true) {
+        userCache.put(userId, getSHA256Base64(userId + password));
+      }
+    } catch(NoSuchAlgorithmException e) {
+      ScimPluginLogger.INSTANCE.userCacheUnavailable();
+    }
+
+    return result;
+  }
+
+  // Utility methods  
+
+  protected boolean isAuthenticatedAndAuthorizedToRead(String userId) {
+    return isAuthenticatedUser(userId) || isAuthorizedToRead(USER, userId);
+  }
+
+  protected boolean isAuthenticatedUser(String userId) {
+    if (userId == null) {
+      return false;
+    }
+    return userId.equalsIgnoreCase(getCommandContext().getAuthenticatedUserId());
+  }
+
+  protected boolean isAuthorizedToRead(Resource resource, String resourceId) {
+    return !scimConfiguration.isAuthorizationCheckEnabled() ||
+        getCommandContext().getAuthorizationManager()
+            .isAuthorized(READ, resource, resourceId);
+  }
+
+  protected boolean isAuthorizedToReadGroup(String groupId) {
+    return isAuthorizedToRead(GROUP, groupId);
+  }
+  
+  protected String getJsonValue(JsonNode node, String path) {
+    if (node == null || path == null) {
+      return null;
+    }
+
+    String[] parts = path.split("\\.");
+    JsonNode current = node;
+
+    for (String part : parts) {
+      if (current == null || !current.has(part)) {
+        return null;
+      }
+      current = current.get(part);
+    }
+
+    return current == null || current.isNull() ? null : current.asText();
+  }
+  
+  private void setJsonValue(ObjectNode root, String path, String value, ObjectMapper mapper) {
+    if (value == null) {
+        return;
+    }
+
+    String[] parts = path.split("\\.");
+    ObjectNode current = root;
+
+    for (int i = 0; i < parts.length - 1; i++) {
+        JsonNode child = current.get(parts[i]);
+        if (child == null || !child.isObject()) {
+            child = mapper.createObjectNode();
+            current.set(parts[i], child);
+        }
+        current = (ObjectNode) child;
+    }
+
+    current.put(parts[parts.length - 1], value);
+  }
+
+  protected String escapeScimFilter(String value) {
+    if (value == null) {
+      return "";
+    }
+    // Escape special characters in SCIM filter values
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  protected String getSHA256Base64(String input) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+    return Base64.getEncoder().encodeToString(hash);
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderWritable.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderWritable.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.operaton.bpm.engine.authorization.Permission;
+import org.operaton.bpm.engine.authorization.Permissions;
+import org.operaton.bpm.engine.authorization.Resource;
+import org.operaton.bpm.engine.authorization.Resources;
+import org.operaton.bpm.engine.identity.Group;
+import org.operaton.bpm.engine.identity.Tenant;
+import org.operaton.bpm.engine.identity.User;
+import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
+import org.operaton.bpm.engine.impl.identity.IdentityProviderException;
+import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import static org.operaton.bpm.engine.impl.context.Context.getCommandContext;
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+/**
+ * SCIM Identity Provider Session implementing ReadOnlyIdentityProvider.
+ */
+public class ScimIdentityProviderWritable extends ScimIdentityProviderReadOnly implements WritableIdentityProvider { 
+
+  public ScimIdentityProviderWritable(ScimConfiguration scimConfiguration) {
+    super(scimConfiguration);
+  }
+
+  public ScimIdentityProviderWritable(ScimConfiguration scimConfiguration, ScimSimpleCache<JsonNode> responseCache, 
+      ScimSimpleCache<String> userCache) {
+    super(scimConfiguration, responseCache, userCache);
+  }
+
+  public ScimIdentityProviderWritable(ScimConfiguration scimConfiguration, ScimSimpleCache<JsonNode> responseCache, 
+      ScimSimpleCache<String> userCache, ScimOAuth2TokenStore oauth2TokenStore) {
+    super(scimConfiguration, responseCache, userCache, oauth2TokenStore);
+  }
+
+  // Session Lifecycle
+
+  @Override
+  public void flush() {
+    super.flush();
+  }
+
+  @Override
+  public void close() {
+    super.close();
+  }
+
+  // Users
+  
+  @Override
+  public User createNewUser(String userId) {
+    return new ScimUserEntity(userId);
+  }
+ 
+  @Override
+  public IdentityOperationResult saveUser(User user) {
+    ScimUserEntity scimUserNew = (ScimUserEntity) user;
+    String operation = IdentityOperationResult.OPERATION_NONE;
+    if(scimUserNew.getScimId() == null || scimUserNew.getScimId().isEmpty()) {
+      operation = IdentityOperationResult.OPERATION_CREATE;
+      checkAuthorization(Permissions.CREATE, Resources.USER, null);
+      String postUrl = scimConfiguration.getServerUrl() + scimConfiguration.getUsersEndpoint();
+      JsonNode postBody = transformUser(scimUserNew);
+      scimClient.executePost(postUrl, postBody);
+      //createDefaultAuthorizations(user);
+    } else {
+      ScimUserEntity scimUserOld = (ScimUserEntity)findUserById(scimUserNew.getId());
+      if (scimUserOld != null) {
+        // use op_update for ID update and op_none for other attribs update to prevent not needed auth update
+        if (!scimUserNew.getId().equals(scimUserOld.getId())) {
+          operation = IdentityOperationResult.OPERATION_UPDATE;
+        }
+        checkAuthorization(Permissions.UPDATE, Resources.USER, user.getId());
+        JsonNode patchBody = createUserPatch(scimUserOld, scimUserNew);     
+        scimClient.patchUserByScimId(scimUserNew.getScimId(), patchBody);
+      }
+    }
+
+    return new IdentityOperationResult(user, operation);
+  }
+
+  @Override
+  public IdentityOperationResult deleteUser(String userId) {
+    checkAuthorization(Permissions.DELETE, Resources.USER, userId);
+    ScimUserEntity scimUser = (ScimUserEntity)findUserById(userId);
+    if(scimUser != null) {
+      // remove authorizations for the group from the database
+      getCommandContext().getAuthorizationManager().deleteAuthorizationsByResourceId(Resources.USER, userId);
+      // remove the user itself
+      scimClient.deleteUserByScimId(scimUser.getScimId());
+      return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_DELETE);
+    }
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  @Override
+  public IdentityOperationResult unlockUser(String userId) {
+    // Unlocking users is not supported via SCIM; treat as a no-op.
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  // Groups
+  
+  @Override
+  public Group createNewGroup(String groupId) {
+    return new ScimGroupEntity(groupId);
+  }
+
+  @Override
+  public IdentityOperationResult saveGroup(Group group) {
+    ScimGroupEntity scimGroupNew =  (ScimGroupEntity) group;
+    String operation = IdentityOperationResult.OPERATION_NONE;
+    if (scimGroupNew.getScimId() == null || scimGroupNew.getScimId().isEmpty()) {
+      operation = IdentityOperationResult.OPERATION_CREATE;
+      checkAuthorization(Permissions.CREATE, Resources.GROUP, null);
+      String postUrl = scimConfiguration.getServerUrl() + scimConfiguration.getGroupsEndpoint();
+      JsonNode postBody = transformGroup(scimGroupNew);
+      scimClient.executePost(postUrl, postBody);
+      // createDefaultAuthorizations(group);
+    } else {
+      ScimGroupEntity scimGroupOld = (ScimGroupEntity)findGroupById(scimGroupNew.getId());
+      if (scimGroupOld != null) {
+        // use op_update for ID update and op_none for other attribs update to prevent not needed auth update
+        if (!scimGroupNew.getId().equals(scimGroupOld.getId())) {
+          operation = IdentityOperationResult.OPERATION_UPDATE;
+        }
+        checkAuthorization(Permissions.UPDATE, Resources.GROUP, group.getId());
+        JsonNode patchBody = createGroupPatch(scimGroupOld, scimGroupNew);
+        scimClient.patchGroupByScimId(scimGroupNew.getScimId(), patchBody);
+      }
+    }
+
+    return new IdentityOperationResult(group, operation);
+  }
+
+  @Override
+  public IdentityOperationResult deleteGroup(String groupId) {
+    checkAuthorization(Permissions.DELETE, Resources.GROUP, groupId);
+    ScimGroupEntity scimGroup =  (ScimGroupEntity) findGroupById(groupId);
+    if(scimGroup != null) {
+      // remove authorizations for the group from the database
+      getCommandContext().getAuthorizationManager().deleteAuthorizationsByResourceId(Resources.GROUP, groupId);
+      // remove the group itself from the scim servcice
+      scimClient.deleteGroupByScimId(scimGroup.getScimId());
+      return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_DELETE);
+    }
+    
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  // Tenants: not used by SCIM identity provider
+  
+  @Override
+  public Tenant createNewTenant(String tenantId) {
+    throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+  }
+
+  @Override
+  public IdentityOperationResult saveTenant(Tenant tenant) {
+    throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+  }
+
+  @Override
+  public IdentityOperationResult deleteTenant(String tenantId) {
+    throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+  }
+
+  // Memberships
+  
+  @Override
+  public IdentityOperationResult createMembership(String userId, String groupId) {
+    checkAuthorization(Permissions.CREATE, Resources.GROUP_MEMBERSHIP, groupId);
+    ScimUserEntity user = (ScimUserEntity)findUserById(userId);
+    ensureNotNull("No user found with id '" + userId + "'.", "user", user);
+    ScimGroupEntity group = (ScimGroupEntity)findGroupById(groupId);
+    ensureNotNull("No group found with id '" + groupId + "'.", "group", group);
+    
+    if (!isGroupMember(group, user)) {
+      JsonNode patchBody = createMembershipPatch(user.getScimId(), "add", "User");
+      scimClient.patchGroupByScimId(group.getScimId(), patchBody);
+      //createDefaultMembershipAuthorizations(userId, groupId);
+      return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_CREATE);
+    }
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  @Override
+  public IdentityOperationResult deleteMembership(String userId, String groupId) {
+    checkAuthorization(Permissions.DELETE, Resources.GROUP_MEMBERSHIP, groupId);
+    ScimUserEntity user = (ScimUserEntity)findUserById(userId);
+    ensureNotNull("No user found with id '" + userId + "'.", "user", user);
+    ScimGroupEntity group = (ScimGroupEntity)findGroupById(groupId);
+    ensureNotNull("No group found with id '" + groupId + "'.", "group", group);
+    
+    if (isGroupMember(group, user)) {
+      JsonNode patchBody = createMembershipPatch(user.getScimId(), "remove", null);
+      scimClient.patchGroupByScimId(group.getScimId(), patchBody);
+      return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_DELETE);
+    }
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  public void deleteMembershipsByUserId(String userId) {
+    ScimGroupQuery groupQuery = (ScimGroupQuery) createGroupQuery();
+    groupQuery.groupMember(userId);
+    List<Group> userGroups = findGroupByQueryCriteria(groupQuery);
+    for (Group group : userGroups) {
+      deleteMembership(userId, group.getId());
+    }
+  }
+
+  @Override
+  public IdentityOperationResult createTenantUserMembership(String tenantId, String userId) {
+    throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+    // return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  @Override
+  public IdentityOperationResult createTenantGroupMembership(String tenantId, String groupId) {
+    throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+    //  return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  @Override
+  public IdentityOperationResult deleteTenantUserMembership(String tenantId, String userId) {
+    // throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+
+  @Override
+  public IdentityOperationResult deleteTenantGroupMembership(String tenantId, String groupId) {
+    // throw new IdentityProviderException("This operation is not supported for SCIM identity provider.");
+    return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
+  }
+  
+  protected JsonNode createUserPatch(ScimUserEntity before, ScimUserEntity after) {
+    // transform both to the Json and prepare simplest patch
+    return createDiffNode(transformUser(before), transformUser(after));
+  }
+
+  protected JsonNode createGroupPatch(ScimGroupEntity before, ScimGroupEntity after) {
+    // transform both to the Json and prepare simplest patch
+    return createDiffNode(transformGroup(before), transformGroup(after));
+  }
+  
+  // patch for a member: operation is add/remove/update, membership type is User/Group 
+  protected JsonNode createMembershipPatch(String memberScimId, String operation, String memberType) {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode root = mapper.createObjectNode();
+    ArrayNode schemas = mapper.createArrayNode().add("urn:ietf:params:scim:api:messages:2.0:PatchOp");
+    ArrayNode operations = mapper.createArrayNode();
+ 
+    root.set("schemas", schemas);
+    root.set("Operations", operations);
+
+    ObjectNode entry = operations.addObject();
+    entry.put("op", operation);
+    entry.put("path", "members");
+
+    ArrayNode members = mapper.createArrayNode();
+    ObjectNode membership = members.addObject();
+    membership.put("value", memberScimId);
+    if (!operation.equalsIgnoreCase("remove") && memberType != null && !memberType.isEmpty()) {
+      membership.put("type", memberType);
+    }
+    entry.set("value", members);
+
+    return root;
+  }
+  
+  protected JsonNode createDiffNode(JsonNode first, JsonNode second) {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode root = mapper.createObjectNode();
+    ArrayNode schemas = mapper.createArrayNode().add("urn:ietf:params:scim:api:messages:2.0:PatchOp");
+    ArrayNode operations = mapper.createArrayNode();
+    
+    root.set("schemas", schemas);
+    root.set("Operations", operations);
+    
+    // simplest for now: compare textual representation of the top-level values
+    HashSet<String> topLevelFields = new HashSet<>();
+    Iterator<Map.Entry<String, JsonNode>> itOld = first.fields();
+    while (itOld.hasNext()) {
+      topLevelFields.add(itOld.next().getKey());
+    }
+
+    Iterator<Map.Entry<String, JsonNode>> itNew = second.fields();
+    while (itNew.hasNext()) {
+      topLevelFields.add(itNew.next().getKey());
+    }
+     
+    for (String field : topLevelFields) {
+      JsonNode oldVal = first.get(field);
+      JsonNode newVal = second.get(field);
+
+      if (oldVal == null) {
+        ObjectNode entry = operations.addObject();
+        entry.put("op", "add");
+          entry.put("path", field);
+          entry.set("value", newVal);
+      } else if (newVal == null) {
+        ObjectNode entry = operations.addObject();
+        entry.put("op", "remove");
+          entry.put("path", field);
+      } else if (!oldVal.toString().equals(newVal.toString())) {
+        ObjectNode entry = operations.addObject();
+        entry.put("op", "replace");
+          entry.put("path", field);
+          entry.set("value", newVal);
+      }
+    }
+    
+    return root;
+  }
+  
+  protected void checkAuthorization(Permission permission, Resource resource, String resourceId) {
+  if (scimConfiguration.isAuthorizationCheckEnabled()) {
+         getCommandContext().getAuthorizationManager().checkAuthorization(permission, resource, resourceId);
+    }
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimOAuth2TokenStore.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimOAuth2TokenStore.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+/**
+ * Thread-safe store for OAuth2 token shared across ScimClient instances.
+ * This prevents token loss when new ScimClient objects are created per session.
+ */
+public class ScimOAuth2TokenStore {
+
+  private volatile String token;
+  private volatile long expiryTime;
+
+  public synchronized String getToken() {
+    return token;
+  }
+
+  public synchronized void setToken(String token) {
+    this.token = token;
+  }
+
+  public synchronized long getExpiryTime() {
+    return expiryTime;
+  }
+
+  public synchronized void setExpiryTime(long expiryTime) {
+    this.expiryTime = expiryTime;
+  }
+
+  public synchronized boolean isTokenValid() {
+    return token != null && System.currentTimeMillis() < expiryTime;
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimSimpleCache.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimSimpleCache.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe cache for SCIM GET responses with TTL-based expiration and max size eviction.
+ */
+public class ScimSimpleCache<T> {
+
+  protected final ConcurrentHashMap<String, CacheEntry<T>> cache = new ConcurrentHashMap<>();
+  protected final int maxSize;
+  protected final long expirationTimeoutMs;
+
+  protected static class CacheEntry<T> {
+    final T value;
+    final long createdAt;
+
+    CacheEntry(T value) {
+      this.value = value;
+      this.createdAt = System.currentTimeMillis();
+    }
+
+    boolean isExpired(long timeoutMs) {
+      return System.currentTimeMillis() - createdAt > timeoutMs;
+    }
+  }
+
+  public ScimSimpleCache(int maxSize, long expirationTimeoutMin) {
+    this.maxSize = maxSize;
+    this.expirationTimeoutMs = expirationTimeoutMin * 60 * 1000;
+  }
+
+  /**
+   * Get a cached value by key. Returns null if not found or expired.
+   */
+  public T get(String key) {
+    CacheEntry<T> entry = cache.get(key);
+    if (entry != null) {
+      if (!entry.isExpired(expirationTimeoutMs)) {
+        return entry.value;
+      }
+      cache.remove(key);
+    }
+    return null;
+  }
+
+  /**
+   * Put a value in cache.
+   */
+  public void put(String key, T value) {
+    if (value == null) {
+      return;
+    }
+    evictExpired();
+    if (cache.size() >= maxSize) {
+      evictOldest(cache.size() - maxSize + 1);
+    }
+    cache.put(key, new CacheEntry<>(value));
+  }
+
+  /**
+   * Invalidate all cache entries.
+   */
+  public void invalidateAll() {
+    cache.clear();
+  }
+
+  /**
+   * Get the current number of cached entries.
+   */
+  public int size() {
+    return cache.size();
+  }
+
+  protected void evictExpired() {
+    cache.entrySet().removeIf(entry -> entry.getValue().isExpired(expirationTimeoutMs));
+  }
+
+  protected void evictOldest(int count) {
+    for (int i = 0; i < count; ++i) {
+      cache.entrySet().stream()
+        .min((a, b) -> Long.compare(a.getValue().createdAt, b.getValue().createdAt))
+        .ifPresent(oldest -> cache.remove(oldest.getKey(), oldest.getValue()));
+    }
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimTenantQuery.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimTenantQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.identity.Tenant;
+import org.operaton.bpm.engine.impl.Page;
+import org.operaton.bpm.engine.impl.TenantQueryImpl;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.engine.impl.interceptor.CommandExecutor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * SCIM Tenant Query Implementation.
+ * Multi-tenancy is not supported for SCIM, so this always returns empty results.
+ */
+public class ScimTenantQuery extends TenantQueryImpl {
+
+  private static final long serialVersionUID = 1L;
+
+  public ScimTenantQuery() {
+    super();
+  }
+
+  public ScimTenantQuery(CommandExecutor commandExecutor) {
+    super(commandExecutor);
+  }
+
+  @Override
+  public long executeCount(CommandContext commandContext) {
+    return 0;
+  }
+
+  @Override
+  public List<Tenant> executeList(CommandContext commandContext, Page page) {
+    return Collections.emptyList();
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimUserEntity.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimUserEntity.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.impl.persistence.entity.UserEntity;
+
+/**
+ * SCIM User Entity.
+ */
+public class ScimUserEntity extends UserEntity {
+
+  private static final long serialVersionUID = 1L;
+
+  protected String scimId;
+
+  public ScimUserEntity() {
+    super();
+  }
+  
+  public ScimUserEntity(String userID) {
+    super(userID);
+  }
+  
+  public String getScimId() {
+    return scimId;
+  }
+
+  public void setScimId(String scimId) {
+    this.scimId = scimId;
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + " [scimId=" + scimId + ", id=" + id + ", firstName=" + firstName + ", lastName=" + lastName
+        + ", email=" + email + "]";
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimUserQuery.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/ScimUserQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.identity.User;
+import org.operaton.bpm.engine.impl.Page;
+import org.operaton.bpm.engine.impl.UserQueryImpl;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.engine.impl.interceptor.CommandExecutor;
+
+import java.util.List;
+
+/**
+ * SCIM User Query Implementation.
+ */
+public class ScimUserQuery extends UserQueryImpl {
+
+  private static final long serialVersionUID = 1L;
+  
+  private int totalResults = 0;
+  
+  public int getTotalResults() {
+    return totalResults;
+  }
+  
+  public void setTotalResults(int totalResults) {
+    this.totalResults = totalResults;
+  }
+
+  public ScimUserQuery() {
+    super();
+  }
+
+  public ScimUserQuery(CommandExecutor commandExecutor) {
+    super(commandExecutor);
+  }
+
+  @Override
+  public long executeCount(CommandContext commandContext) {
+    final ScimIdentityProviderReadOnly provider = getScimIdentityProvider(commandContext);
+    return provider.findUserCountByQueryCriteria(this);
+  }
+
+  @Override
+  public List<User> executeList(CommandContext commandContext, Page page) {
+    final ScimIdentityProviderReadOnly provider = getScimIdentityProvider(commandContext);
+    return provider.findUserByQueryCriteria(this);
+  }
+
+  protected ScimIdentityProviderReadOnly getScimIdentityProvider(CommandContext commandContext) {
+    return (ScimIdentityProviderReadOnly) commandContext.getReadOnlyIdentityProvider();
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/plugin/ScimIdentityProviderPlugin.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/plugin/ScimIdentityProviderPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim.plugin;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.operaton.bpm.identity.impl.scim.ScimConfiguration;
+import org.operaton.bpm.identity.impl.scim.ScimIdentityProviderFactory;
+import org.operaton.bpm.identity.impl.scim.util.ScimPluginLogger;
+
+/**
+ * Process Engine Plugin for SCIM Identity Provider.
+ * 
+ * This class extends ScimConfiguration so that configuration properties
+ * can be set directly on this class via the properties element
+ * in bpm-platform.xml / processes.xml
+ */
+public class ScimIdentityProviderPlugin extends ScimConfiguration implements ProcessEnginePlugin {
+
+  @Override
+  public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    ScimPluginLogger.INSTANCE.pluginActivated(getClass().getSimpleName(), 
+        processEngineConfiguration.getProcessEngineName());
+
+    if (isAcceptUntrustedCertificates()) {
+      ScimPluginLogger.INSTANCE.acceptingUntrustedCertificates();
+    }
+
+    ScimIdentityProviderFactory scimIdentityProviderFactory = new ScimIdentityProviderFactory();
+    scimIdentityProviderFactory.setScimConfiguration(this);
+    processEngineConfiguration.setIdentityProviderSessionFactory(scimIdentityProviderFactory);
+  }
+
+  @Override
+  public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    // nothing to do
+  }
+
+  @Override
+  public void postProcessEngineBuild(ProcessEngine processEngine) {
+    // nothing to do
+  }
+}

--- a/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/util/ScimPluginLogger.java
+++ b/engine-plugins/identity-scim/src/main/java/org/operaton/bpm/identity/impl/scim/util/ScimPluginLogger.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim.util;
+
+import org.operaton.commons.logging.BaseLogger;
+
+/**
+ * Logger for SCIM Identity Provider Plugin.
+ */
+public class ScimPluginLogger extends BaseLogger {
+
+  public static final String PROJECT_CODE = "SCIM";
+
+  public static final ScimPluginLogger INSTANCE = BaseLogger.createLogger(
+      ScimPluginLogger.class, PROJECT_CODE, "org.operaton.bpm.identity.impl.scim", "00");
+
+  public void pluginActivated(String pluginClassName, String engineName) {
+    logInfo("001", "PLUGIN {} activated on process engine {}", pluginClassName, engineName);
+  }
+
+  public void acceptingUntrustedCertificates() {
+    logWarn("002", "Enabling accept of untrusted certificates. Use at own risk.");
+  }
+
+  public void httpClientException(String operation, Exception e) {
+    logError("003", "HTTP client exception during {}: {}", operation, e.getMessage(), e);
+  }
+
+  public void invalidScimEntityReturned(String entityType, String resourceId) {
+    logError("004", "SCIM query returned a {} with id null. Resource ID: {}. This entity will be ignored.", entityType, resourceId);
+  }
+
+  public void queryResult(String result) {
+    logDebug("005", result);
+  }
+
+  public void oauth2TokenRefresh(boolean verbose) {
+    if (verbose) {
+      logInfo("006", "Refreshing OAuth2 access token");
+    } else {
+      logDebug("006", "Refreshing OAuth2 access token");
+    }
+  }
+
+  public void scimFilterQuery(String filter) {
+    logDebug("007", "SCIM filter query: {}", filter);
+  }
+
+  public void scimRequestError(int statusCode, String responseBody) {
+    logError("008", "SCIM request failed with status code {}: {}", statusCode, responseBody);
+  }
+
+  public void authenticationFailure(String message) {
+    logError("009", "SCIM authentication failure: {}", message);
+  }
+
+  public void httpClientRequest(boolean verbose, String method, String url, String body, boolean hideBody) {
+    body = (body == null) ? "empty" : (hideBody == true) ? "***" : body;
+    if (verbose) {
+      logInfo("010", ">>>>>>> ScimClient {}: {} => body: {}", method, url, (body != null ? body : "empty"));
+    } else {
+      logDebug("010", ">>>>>>> ScimClient {}: {} => body: {}", method, url, (body != null ? body : "empty"));
+    }
+  }
+
+  public void httpClientResponse(boolean verbose, String method, int code) {
+    if (verbose) {
+      logInfo("011", "<<<<<<< ScimClient {}: status code {}", method, code);
+    } else {
+      logDebug("011", "<<<<<<< ScimClient {}: status code {}", method, code);
+    }
+  }
+
+  public void userAuthentication(boolean verbose, String userName) {
+    if (verbose) {
+      logInfo("012", "SCIM authenticate user {}", userName);
+    } else {
+      logDebug("012", "SCIM authenticate user {}", userName);
+    }
+  }
+
+  public void userAuthenticationRequest(boolean verbose, String protocol, String url, String userName) {
+    if (verbose) {
+      logInfo("013", ">>>>>>> ScimClient {}: {} => user: {}", protocol, url, userName);
+    } else {
+      logDebug("013", ">>>>>>> ScimClient {}: {} => user: {}", protocol, url, userName);
+    }
+  }
+
+  public void userAuthenticationResponse(boolean verbose, String protocol, String userName, int code) {
+    if (verbose) {
+      logInfo("014", "<<<<<<< ScimClient {}: user {} status code {}", protocol, userName, code);
+    } else {
+      logDebug("014", "<<<<<<< ScimClient {}: user {} status code {}", protocol, userName, code);
+    }
+  }
+
+
+  public void userCacheUnavailable() {
+    logWarn("015", "SCIM can't cache authenticated user");
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimConfigurationTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimConfigurationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for SCIM Configuration.
+ */
+public class ScimConfigurationTest {
+
+  @Test
+  public void testDefaultConfiguration() {
+    ScimConfiguration config = new ScimConfiguration();
+
+    assertThat(config.getScimVersion()).isEqualTo("2.0");
+    assertThat(config.getAuthenticationType()).isEqualTo("bearer");
+    assertThat(config.getUsersEndpoint()).isEqualTo("/Users");
+    assertThat(config.getGroupsEndpoint()).isEqualTo("/Groups");
+    assertThat(config.getUserScimIdAttribute()).isEqualTo("id");
+    assertThat(config.getUserIdAttribute()).isEqualTo("userName");
+    assertThat(config.getUserFirstnameAttribute()).isEqualTo("name.givenName");
+    assertThat(config.getUserLastnameAttribute()).isEqualTo("name.familyName");
+    assertThat(config.getPageSize()).isEqualTo(100);
+    assertThat(config.isAuthorizationCheckEnabled()).isTrue();
+  }
+
+  @Test
+  public void testSetServerUrl() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setServerUrl("https://scim.example.com");
+
+    assertThat(config.getServerUrl()).isEqualTo("https://scim.example.com");
+  }
+
+  @Test
+  public void testSetBearerToken() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setBearerToken("test-token-123");
+
+    assertThat(config.getBearerToken()).isEqualTo("test-token-123");
+  }
+
+  @Test
+  public void testSetBasicAuth() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setAuthenticationType("basic");
+    config.setUsername("admin");
+    config.setPassword("password");
+
+    assertThat(config.getAuthenticationType()).isEqualTo("basic");
+    assertThat(config.getUsername()).isEqualTo("admin");
+    assertThat(config.getPassword()).isEqualTo("password");
+  }
+
+  @Test
+  public void testSetOAuth2Config() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setAuthenticationType("oauth2");
+    config.setOauth2TokenUrl("https://auth.example.com/token");
+    config.setOauth2ClientId("client-id");
+    config.setOauth2ClientSecret("client-secret");
+    config.setOauth2Scope("scim.read");
+
+    assertThat(config.getAuthenticationType()).isEqualTo("oauth2");
+    assertThat(config.getOauth2TokenUrl()).isEqualTo("https://auth.example.com/token");
+    assertThat(config.getOauth2ClientId()).isEqualTo("client-id");
+    assertThat(config.getOauth2ClientSecret()).isEqualTo("client-secret");
+    assertThat(config.getOauth2Scope()).isEqualTo("scim.read");
+  }
+
+  @Test
+  public void testSetUserAttributeMapping() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setUserIdAttribute("id");
+    config.setUserFirstnameAttribute("name.givenName");
+    config.setUserLastnameAttribute("name.familyName");
+
+    assertThat(config.getUserIdAttribute()).isEqualTo("id");
+    assertThat(config.getUserFirstnameAttribute()).isEqualTo("name.givenName");
+    assertThat(config.getUserLastnameAttribute()).isEqualTo("name.familyName");
+  }
+
+  @Test
+  public void testSetConnectionSettings() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setConnectionTimeout(60000);
+    config.setSocketTimeout(60000);
+    config.setMaxConnections(200);
+
+    assertThat(config.getConnectionTimeout()).isEqualTo(60000);
+    assertThat(config.getSocketTimeout()).isEqualTo(60000);
+    assertThat(config.getMaxConnections()).isEqualTo(200);
+  }
+
+  @Test
+  public void testSetPagination() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setPageSize(50);
+
+    assertThat(config.getPageSize()).isEqualTo(50);
+  }
+
+  @Test
+  public void testDisableAuthorizationCheck() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setAuthorizationCheckEnabled(false);
+
+    assertThat(config.isAuthorizationCheckEnabled()).isFalse();
+  }
+
+  @Test
+  public void testAcceptUntrustedCertificates() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setAcceptUntrustedCertificates(true);
+
+    assertThat(config.isAcceptUntrustedCertificates()).isTrue();
+  }
+
+  @Test
+  public void testDefaultCacheConfiguration() {
+    ScimConfiguration config = new ScimConfiguration();
+
+    assertThat(config.isCacheEnabled()).isFalse();
+    assertThat(config.getMaxCacheSize()).isEqualTo(250);
+    assertThat(config.getCacheExpirationTimeoutMin()).isEqualTo(5);
+  }
+
+  @Test
+  public void testSetCacheConfiguration() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setCacheEnabled(true);
+    config.setMaxCacheSize(200);
+    config.setCacheExpirationTimeoutMin(10);
+
+    assertThat(config.isCacheEnabled()).isTrue();
+    assertThat(config.getMaxCacheSize()).isEqualTo(200);
+    assertThat(config.getCacheExpirationTimeoutMin()).isEqualTo(10);
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimGroupModifyTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimGroupModifyTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironment;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironmentExtension;
+
+/**
+ * Tests for SCIM group queries.
+ */
+class ScimGroupModifyTest {
+
+  @RegisterExtension
+  @Order(1)
+  static ScimTestEnvironmentExtension scimExtension = new ScimTestEnvironmentExtension();
+
+  @RegisterExtension
+  @Order(2)
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
+      .configurationResource("operaton.modify.cfg.xml")
+      .configurator(scimExtension::injectScimUrlWithExternalGroupIds)
+      .closeEngineAfterAllTests()
+      .build();
+
+  IdentityService identityService;
+  ScimTestEnvironment scimTestEnvironment;
+
+  @BeforeEach
+  void setup() {
+    scimTestEnvironment = scimExtension.getScimTestEnvironment();
+  }
+
+  @Test
+  public void testCreateGroup() {
+    assertThat(!identityService.isReadOnly());   
+    ScimGroupEntity group = (ScimGroupEntity) identityService.newGroup("group-development");
+    group.setName("development");
+    identityService.saveGroup(group);
+  }
+
+  @Test
+  public void testUpdateGroup() {
+    assertThat(!identityService.isReadOnly());
+    ScimGroupEntity group = (ScimGroupEntity) identityService.newGroup("group-development");
+    group.setScimId("group-development");
+    group.setName("DEVELOPMENT");
+    identityService.saveGroup(group);
+  }
+
+  @Test
+  public void testDeleteGroup() {
+	assertThat(!identityService.isReadOnly());  
+    identityService.deleteGroup("group-development");
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimGroupQueryTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimGroupQueryTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.identity.Group;
+import org.operaton.bpm.engine.identity.GroupQuery;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironment;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironmentExtension;
+
+/**
+ * Tests for SCIM group queries.
+ */
+class ScimGroupQueryTest {
+
+  @RegisterExtension
+  @Order(1)
+  static ScimTestEnvironmentExtension scimExtension = new ScimTestEnvironmentExtension();
+
+  @RegisterExtension
+  @Order(2)
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
+      .configurationResource("operaton.cfg.xml")
+      .configurator(scimExtension::injectScimUrlWithExternalGroupIds)
+      .closeEngineAfterAllTests()
+      .build();
+
+  IdentityService identityService;
+  ScimTestEnvironment scimTestEnvironment;
+
+  @BeforeEach
+  void setup() {
+    scimTestEnvironment = scimExtension.getScimTestEnvironment();
+  }
+
+  @Test
+  public void testCountGroups() {
+    // when
+    GroupQuery groupQuery = identityService.createGroupQuery();
+
+    // then
+    long count = groupQuery.count();
+    assertThat(count).isEqualTo(scimTestEnvironment.getTotalNumberOfGroupsCreated());
+  }
+
+  @Test
+  public void testQueryNoFilter() {
+    // when
+    List<Group> result = identityService.createGroupQuery().list();
+
+    // then
+    assertThat(result).hasSize(scimTestEnvironment.getTotalNumberOfGroupsCreated());
+  }
+
+  @Test
+  public void testFilterByGroupId() {
+    // when
+    Group group = identityService.createGroupQuery().groupId("group-development").singleResult();
+
+    // then
+    assertThat(group).isNotNull();
+    assertThat(group.getId()).isEqualTo("group-development");
+    assertThat(group.getName()).isEqualTo("development");
+  }
+
+  @Test
+  public void testFilterByNonexistentGroupId() {
+    // when
+    Group group = identityService.createGroupQuery().groupId("non-existing").singleResult();
+
+    // then
+    assertThat(group).isNull();
+  }
+
+  @Test
+  public void testFilterByGroupName() {
+    // when
+    Group group = identityService.createGroupQuery().groupName("management").singleResult();
+
+    // then
+    assertThat(group).isNotNull();
+    assertThat(group.getId()).isEqualTo("group-management");
+    assertThat(group.getName()).isEqualTo("management");
+  }
+
+  @Test
+  public void testFilterGroupsByMemberId() {
+    // when
+    List<Group> groups = identityService.createGroupQuery().groupMember("oscar").list();
+
+    // then
+    assertThat(groups).hasSize(1);
+    assertThat(groups.get(0).getId()).isEqualTo("group-development");
+  }
+
+  @Test
+  public void testFilterGroupsByMemberIdMultipleGroups() {
+    // when - daniel is member of both groups
+    List<Group> groups = identityService.createGroupQuery().groupMember("daniel").list();
+
+    // then
+    assertThat(groups).hasSize(2);
+    assertThat(groups).extracting("id").containsOnly("group-development", "group-management");
+  }
+
+  @Test
+  public void testFindGroupById() {
+    // when
+    Group group = identityService.createGroupQuery().groupId("group-development").singleResult();
+
+    // then
+    assertThat(group).isNotNull();
+    assertThat(group.getId()).isEqualTo("group-development");
+    assertThat(group.getName()).isEqualTo("development");
+  }
+
+  @Test
+  public void testFindGroupByName() {
+    // when
+    Group group = identityService.createGroupQuery().groupName("development").singleResult();
+
+    // then
+    assertThat(group).isNotNull();
+    assertThat(group.getId()).isEqualTo("group-development");
+    assertThat(group.getName()).isEqualTo("development");
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderPluginTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimIdentityProviderPluginTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for SCIM Identity Provider Plugin.
+ */
+public class ScimIdentityProviderPluginTest {
+
+  private ScimIdentityProviderPlugin plugin;
+  private ProcessEngineConfigurationImpl processEngineConfiguration;
+
+  @BeforeEach
+  public void setup() {
+    plugin = new ScimIdentityProviderPlugin();
+    processEngineConfiguration = mock(ProcessEngineConfigurationImpl.class);
+    when(processEngineConfiguration.getProcessEngineName()).thenReturn("default");
+  }
+
+  @Test
+  public void testPluginExtendsConfiguration() {
+    assertThat(plugin).isInstanceOf(ScimConfiguration.class);
+  }
+
+  @Test
+  public void testPreInit() {
+    plugin.setServerUrl("https://scim.example.com");
+    plugin.setBearerToken("test-token");
+
+    plugin.preInit(processEngineConfiguration);
+
+    verify(processEngineConfiguration).setIdentityProviderSessionFactory(
+        org.mockito.ArgumentMatchers.any(ScimIdentityProviderFactory.class));
+  }
+
+  @Test
+  public void testPostInitDoesNothing() {
+    // Should not throw any exceptions
+    plugin.postInit(processEngineConfiguration);
+  }
+
+  @Test
+  public void testPostProcessEngineBuildDoesNothing() {
+    // Should not throw any exceptions
+    plugin.postProcessEngineBuild(null);
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimOAuth2TokenStoreTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimOAuth2TokenStoreTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for ScimOAuth2TokenStore.
+ */
+public class ScimOAuth2TokenStoreTest {
+
+  @Test
+  public void testInitialState() {
+    ScimOAuth2TokenStore store = new ScimOAuth2TokenStore();
+    assertThat(store.getToken()).isNull();
+    assertThat(store.getExpiryTime()).isEqualTo(0);
+    assertThat(store.isTokenValid()).isFalse();
+  }
+
+  @Test
+  public void testValidToken() {
+    ScimOAuth2TokenStore store = new ScimOAuth2TokenStore();
+    store.setToken("test-token");
+    store.setExpiryTime(System.currentTimeMillis() + 60000); // expires in 1 minute
+
+    assertThat(store.getToken()).isEqualTo("test-token");
+    assertThat(store.isTokenValid()).isTrue();
+  }
+
+  @Test
+  public void testExpiredToken() {
+    ScimOAuth2TokenStore store = new ScimOAuth2TokenStore();
+    store.setToken("test-token");
+    store.setExpiryTime(System.currentTimeMillis() - 1000); // expired 1 second ago
+
+    assertThat(store.getToken()).isEqualTo("test-token");
+    assertThat(store.isTokenValid()).isFalse();
+  }
+
+  @Test
+  public void testTokenSharedAcrossReferences() {
+    ScimOAuth2TokenStore store = new ScimOAuth2TokenStore();
+    store.setToken("shared-token");
+    store.setExpiryTime(System.currentTimeMillis() + 60000);
+
+    // Simulate two ScimClient instances sharing the same store
+    ScimOAuth2TokenStore ref1 = store;
+    ScimOAuth2TokenStore ref2 = store;
+
+    assertThat(ref1.getToken()).isEqualTo("shared-token");
+    assertThat(ref2.getToken()).isEqualTo("shared-token");
+
+    // Update token through one reference
+    ref1.setToken("updated-token");
+    assertThat(ref2.getToken()).isEqualTo("updated-token");
+  }
+
+  @Test
+  public void testFactorySharesTokenStore() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setServerUrl("https://scim.example.com");
+    config.setAuthenticationType("oauth2");
+
+    ScimIdentityProviderFactory factory = new ScimIdentityProviderFactory();
+    factory.setScimConfiguration(config);
+
+    // The factory should create a single shared token store for oauth2
+    ScimOAuth2TokenStore store1 = factory.getOAuth2TokenStore();
+    ScimOAuth2TokenStore store2 = factory.getOAuth2TokenStore();
+    assertThat(store1).isNotNull();
+    assertThat(store1).isSameAs(store2);
+  }
+
+  @Test
+  public void testFactoryNoTokenStoreForBearer() {
+    ScimConfiguration config = new ScimConfiguration();
+    config.setServerUrl("https://scim.example.com");
+    config.setAuthenticationType("bearer");
+
+    ScimIdentityProviderFactory factory = new ScimIdentityProviderFactory();
+    factory.setScimConfiguration(config);
+
+    assertThat(factory.getOAuth2TokenStore()).isNull();
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimResponseCacheTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimResponseCacheTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for SCIM Response Cache.
+ */
+public class ScimResponseCacheTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testPutAndGet() throws Exception {
+    ScimSimpleCache<JsonNode> cache = new ScimSimpleCache<JsonNode>(10, 5);
+    JsonNode node = mapper.readTree("{\"id\":\"123\"}");
+    cache.put("http://example.com/Users?filter=test", node);
+
+    JsonNode result = cache.get("http://example.com/Users?filter=test");
+    assertThat(result).isNotNull();
+    assertThat(result.get("id").asText()).isEqualTo("123");
+  }
+
+  @Test
+  public void testGetMissingKey() {
+    ScimSimpleCache<JsonNode> cache = new ScimSimpleCache<JsonNode>(10, 5);
+
+    JsonNode result = cache.get("http://example.com/Users?filter=test");
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void testNullValueNotCached() {
+    ScimSimpleCache<JsonNode> cache = new ScimSimpleCache<JsonNode>(10, 5);
+    cache.put("http://example.com/Users?filter=test", null);
+
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testMaxSizeEviction() throws Exception {
+    ScimSimpleCache<JsonNode> cache = new ScimSimpleCache<JsonNode>(3, 5);
+
+    cache.put("key1", mapper.readTree("{\"id\":\"1\"}"));
+    cache.put("key2", mapper.readTree("{\"id\":\"2\"}"));
+    cache.put("key3", mapper.readTree("{\"id\":\"3\"}"));
+    assertThat(cache.size()).isEqualTo(3);
+
+    // Adding a 4th entry should evict the oldest
+    cache.put("key4", mapper.readTree("{\"id\":\"4\"}"));
+    assertThat(cache.size()).isEqualTo(3);
+    assertThat(cache.get("key1")).isNull();
+    assertThat(cache.get("key4")).isNotNull();
+  }
+
+  @Test
+  public void testInvalidateAll() throws Exception {
+    ScimSimpleCache<JsonNode> cache = new ScimSimpleCache<JsonNode>(10, 5);
+
+    cache.put("key1", mapper.readTree("{\"id\":\"1\"}"));
+    cache.put("key2", mapper.readTree("{\"id\":\"2\"}"));
+
+    cache.invalidateAll();
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testExpirationEviction() throws Exception {
+    // Cache with 0 minute expiration (immediate expiry)
+    ScimSimpleCache<JsonNode> cache = new ScimSimpleCache<JsonNode>(10, 0);
+
+    cache.put("key1", mapper.readTree("{\"id\":\"1\"}"));
+
+    // Wait briefly to ensure the entry expires (timeout is 0ms)
+    Thread.sleep(10);
+
+    // Entry should be expired
+    JsonNode result = cache.get("key1");
+    assertThat(result).isNull();
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimUserModifyTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimUserModifyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironment;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironmentExtension;
+
+/**
+ * Tests for SCIM user queries.
+ */
+class ScimUserModifyTest {
+
+  @RegisterExtension
+  @Order(1)
+  static ScimTestEnvironmentExtension scimExtension = new ScimTestEnvironmentExtension();
+
+  @RegisterExtension
+  @Order(2)
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
+      .configurationResource("operaton.modify.cfg.xml")
+      .configurator(scimExtension::injectScimUrlIntoProcessEngineConfiguration)
+      .closeEngineAfterAllTests()
+      .build();
+
+  IdentityService identityService;
+  ScimTestEnvironment scimTestEnvironment;
+
+  @BeforeEach
+  void setup() {
+    scimTestEnvironment = scimExtension.getScimTestEnvironment();
+  }
+
+  @Test
+  public void testCreateUser() {
+    assertThat(!identityService.isReadOnly());
+    ScimUserEntity user = (ScimUserEntity) identityService.newUser("oscar");
+    user.setFirstName("Oscar");
+    user.setLastName("The Crouch");
+    user.setEmail("oscar@operaton.org");
+    identityService.saveUser(user);
+  }
+
+  @Test
+  public void testUpdateUser() {
+    assertThat(!identityService.isReadOnly());
+    ScimUserEntity user = (ScimUserEntity) identityService.newUser("oscar");
+    user.setScimId("user-oscar");
+    user.setFirstName("Oscar");
+    user.setLastName("The (Even Cleaner) Crouch");
+    user.setEmail("oscar@operaton.org");
+    identityService.saveUser(user);
+  }
+
+  @Test
+  public void testDeleteUser() {
+    assertThat(!identityService.isReadOnly());  
+    identityService.deleteUser("oscar");
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimUserQueryTest.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/impl/scim/ScimUserQueryTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.impl.scim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.identity.User;
+import org.operaton.bpm.engine.identity.UserQuery;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironment;
+import org.operaton.bpm.identity.scim.util.ScimTestEnvironmentExtension;
+
+/**
+ * Tests for SCIM user queries.
+ */
+class ScimUserQueryTest {
+
+  @RegisterExtension
+  @Order(1)
+  static ScimTestEnvironmentExtension scimExtension = new ScimTestEnvironmentExtension();
+
+  @RegisterExtension
+  @Order(2)
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
+      .configurationResource("operaton.cfg.xml")
+      .configurator(scimExtension::injectScimUrlIntoProcessEngineConfiguration)
+      .closeEngineAfterAllTests()
+      .build();
+
+  IdentityService identityService;
+  ScimTestEnvironment scimTestEnvironment;
+
+  @BeforeEach
+  void setup() {
+    scimTestEnvironment = scimExtension.getScimTestEnvironment();
+  }
+
+  @Test
+  public void testCountUsers() {
+    // when
+    UserQuery userQuery = identityService.createUserQuery();
+
+    // then
+    long count = userQuery.count();
+    assertThat(count).isEqualTo(scimTestEnvironment.getTotalNumberOfUsersCreated());
+  }
+
+  @Test
+  public void testQueryNoFilter() {
+    // when
+    List<User> result = identityService.createUserQuery().list();
+
+    // then
+    assertThat(result).hasSize(scimTestEnvironment.getTotalNumberOfUsersCreated());
+  }
+
+  @Test
+  public void testFilterByUserId() {
+    // when
+    User user = identityService.createUserQuery().userId("oscar").singleResult();
+
+    // then
+    assertThat(user).isNotNull();
+    assertThat(user.getId()).isEqualTo("oscar");
+    assertThat(user.getFirstName()).isEqualTo("Oscar");
+    assertThat(user.getLastName()).isEqualTo("The Crouch");
+    assertThat(user.getEmail()).isEqualTo("oscar@operaton.org");
+  }
+
+  @Test
+  public void testFilterByNonexistentUserId() {
+    // when
+    User user = identityService.createUserQuery().userId("non-existing").singleResult();
+
+    // then
+    assertThat(user).isNull();
+  }
+
+  @Test
+  public void testFilterByUserIdIn() {
+    // when
+    List<User> users = identityService.createUserQuery().userIdIn("oscar", "monster").list();
+
+    // then
+    assertThat(users).hasSize(2);
+    assertThat(users).extracting("id").containsOnly("oscar", "monster");
+  }
+
+  @Test
+  public void testFilterByUserFirstName() {
+    // when
+    List<User> users = identityService.createUserQuery().userFirstName("Oscar").list();
+
+    // then
+    assertThat(users).hasSize(1);
+    assertThat(users.get(0).getId()).isEqualTo("oscar");
+    assertThat(users.get(0).getFirstName()).isEqualTo("Oscar");
+  }
+
+  @Test
+  public void testFilterByUserLastName() {
+    // when
+    List<User> users = identityService.createUserQuery().userLastName("Monster").list();
+
+    // then
+    assertThat(users).hasSize(1);
+    assertThat(users.get(0).getId()).isEqualTo("monster");
+    assertThat(users.get(0).getLastName()).isEqualTo("Monster");
+  }
+
+  @Test
+  public void testFilterByUserEmail() {
+    // when
+    List<User> users = identityService.createUserQuery().userEmail("oscar@operaton.org").list();
+
+    // then
+    assertThat(users).hasSize(1);
+    assertThat(users.get(0).getId()).isEqualTo("oscar");
+    assertThat(users.get(0).getEmail()).isEqualTo("oscar@operaton.org");
+  }
+
+  @Test
+  public void testPagination() {
+    // when - get first 2 users
+    List<User> firstPage = identityService.createUserQuery()
+        .listPage(0, 2);
+
+    // then
+    assertThat(firstPage).hasSize(2);
+
+    // when - get next page
+    List<User> secondPage = identityService.createUserQuery()
+        .listPage(2, 2);
+
+    // then
+    assertThat(secondPage).hasSize(1);
+  }
+
+  @Test
+  public void testFindUserById() {
+    // when
+    User user = identityService.createUserQuery().userId("oscar").singleResult();
+
+    // then
+    assertThat(user).isNotNull();
+    assertThat(user.getId()).isEqualTo("oscar");
+    assertThat(user.getFirstName()).isEqualTo("Oscar");
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/scim/util/ScimTestEnvironment.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/scim/util/ScimTestEnvironment.java
@@ -1,0 +1,761 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.scim.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * SCIM test environment using WireMock to simulate a SCIM 2.0 server.
+ */
+public class ScimTestEnvironment {
+
+  protected WireMockServer wireMockServer;
+  protected int port;
+  protected String serverUrl;
+
+  private Map<String, JsonNode> users = new HashMap<>();
+  private Map<String, JsonNode> groups = new HashMap<>();
+
+  public ScimTestEnvironment() {
+    this.port = 8443; // Use fixed port by default
+  }
+
+  public ScimTestEnvironment(int port) {
+    this.port = port;
+  }
+
+  public void init() throws Exception {
+    WireMockConfiguration config = WireMockConfiguration.wireMockConfig();
+    if (port > 0) {
+      config.port(port);
+    } else {
+      config.dynamicPort();
+    }
+    
+    wireMockServer = new WireMockServer(config);
+    wireMockServer.start();
+    
+    this.port = wireMockServer.port();
+    this.serverUrl = "http://localhost:" + this.port;
+    
+    setupScimEndpoints();
+  }
+
+  protected void setupScimEndpoints() throws Exception {
+    // Setup test data
+    setupUsers();
+    setupGroups();
+  }
+
+  protected void setupUsers() throws JsonMappingException, JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    MappingBuilder currMapping = null;
+
+    String emptyResponseDescr = "{\n" +
+            "  \"schemas\": [\"urn:ietf:params:scim:api:messages:2.0:ListResponse\"],\n" +
+            "  \"totalResults\": 0,\n" +
+            "  \"Resources\": []}";
+
+    // User 1: Oscar
+    String userOscarDescr = "{\n" +
+            "  \"id\": \"user-oscar\",\n" +
+            "  \"userName\": \"oscar\",\n" +
+            "  \"name\": {\n" +
+            "    \"givenName\": \"Oscar\",\n" +
+            "    \"familyName\": \"The Crouch\"\n" +
+            "  },\n" +
+            "  \"emails\": [{\n" +
+            "    \"value\": \"oscar@operaton.org\",\n" +
+            "    \"type\": \"work\"\n" +
+            "  }],\n" +
+            "  \"displayName\": \"Oscar The Crouch\"\n" +
+            "}";
+    
+    // User 2: Monster
+    String userMonsterDescr = "{\n" +
+            "  \"id\": \"user-monster\",\n" +
+            "  \"userName\": \"monster\",\n" +
+            "  \"name\": {\n" +
+            "    \"givenName\": \"Cookie\",\n" +
+            "    \"familyName\": \"Monster\"\n" +
+            "  },\n" +
+            "  \"emails\": [{\n" +
+            "    \"value\": \"monster@operaton.org\",\n" +
+            "    \"type\": \"work\"\n" +
+            "  }],\n" +
+            "  \"displayName\": \"Cookie Monster\"\n" +
+            "}";
+
+    // User 3: Daniel       
+    String userDanielDescr = "{\n" +
+            "  \"id\": \"user-daniel\",\n" +
+            "  \"userName\": \"daniel\",\n" +
+            "  \"name\": {\n" +
+            "    \"givenName\": \"Daniel\",\n" +
+            "    \"familyName\": \"Meyer\"\n" +
+            "  },\n" +
+            "  \"emails\": [{\n" +
+            "    \"value\": \"daniel@operaton.org\",\n" +
+            "    \"type\": \"work\"\n" +
+            "  }],\n" +
+            "  \"displayName\": \"Daniel Meyer\"\n" +
+            "}";
+    
+    users.clear();
+    users.put("user-oscar", objectMapper.readTree(userOscarDescr)); 
+    users.put("user-monster", objectMapper.readTree(userMonsterDescr)); 
+    users.put("user-daniel", objectMapper.readTree(userDanielDescr));
+
+    // User 1: Oscar
+
+    // Stub for GET /Users: oscar by userName (id-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("userName eq \"oscar\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+
+      wireMockServer.stubFor(currMapping);
+    }
+        
+    // Stub for POST /Users: oscar
+    currMapping = post(urlPathEqualTo("/Users"))
+        .withHeader("Content-Type", containing("application/scim+json"))
+        .withRequestBody(matchingJsonPath("$.schemas[?(@ == 'urn:ietf:params:scim:schemas:core:2.0:User')]"))
+        .withRequestBody(matchingJsonPath("$.id", absent()))
+        .withRequestBody(matchingJsonPath("$.userName", equalTo("oscar")))
+        .withRequestBody(matchingJsonPath("$.name.givenName", equalTo("Oscar")))
+        .withRequestBody(matchingJsonPath("$.name.familyName", equalTo("The Crouch")));   
+    if (currMapping != null) { 
+      // configure and set response: return existing user-oscar, 
+      // it should match the user in the post request
+      currMapping.willReturn(aResponse()
+          .withStatus(201)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(users.get("user-oscar").toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    } 
+    
+    // Stub for PATCH /Users (oscar)
+    currMapping = patch(urlPathEqualTo("/Users/user-oscar"))
+        .withHeader("Content-Type", containing("application/scim+json"))
+        .withRequestBody(matchingJsonPath("$.schemas[?(@ == 'urn:ietf:params:scim:api:messages:2.0:PatchOp')]"))
+        .withRequestBody(matchingJsonPath("$.Operations[0].op", equalTo("replace")))
+        .withRequestBody(matchingJsonPath("$.Operations[0].path", equalTo("name")))
+        .withRequestBody(matchingJsonPath("$.Operations[0].value.givenName", equalTo("Oscar")))
+        .withRequestBody(matchingJsonPath("$.Operations[0].value.familyName", equalTo("The (Even Cleaner) Crouch")));
+    if (currMapping != null) { 
+      // configure and set response: return patched copy of the existing user 
+      ObjectNode patchedUser = users.get("user-oscar").deepCopy();
+      ((ObjectNode)patchedUser.get("name")).put("givenName", "Oscar");
+      ((ObjectNode)patchedUser.get("name")).put("familyName", "The (Even Cleaner) Crouch");
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(patchedUser.toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    }
+    
+    // Stub for DELETE /Users/user-oscar (delete user)
+    wireMockServer.stubFor(delete(urlPathEqualTo("/Users/user-oscar"))
+        .withHeader("Content-Type", containing("application/scim+json"))
+        .willReturn(aResponse()
+            .withStatus(204))); // SCIM DELETE = 204 No Content by default
+
+    // Stub for GET /Users: oscar by id (scimId-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+            .withQueryParam("filter", equalTo("id eq \"user-oscar\""))
+            .withQueryParam("startIndex", equalTo("1"))
+            .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+
+      wireMockServer.stubFor(currMapping);
+    } 
+
+    // Stub for GET /Users: oscar by givenName (firstName-attribute)    
+    currMapping = get(urlPathEqualTo("/Users"))
+            .withQueryParam("filter", equalTo("name.givenName eq \"Oscar\""))
+            .withQueryParam("startIndex", equalTo("1"))
+            .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+
+      wireMockServer.stubFor(currMapping);
+    } 
+    
+    currMapping = get(urlPathEqualTo("/Users"))
+            .withQueryParam("filter", equalTo("emails[type eq \"work\"].value eq \"oscar@operaton.org\""))
+            .withQueryParam("startIndex", equalTo("1"))
+            .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+
+      wireMockServer.stubFor(currMapping);
+    }     
+    
+    // User 2: Monster    
+
+    // Stub for GET /Users: monster by userName (id-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("userName eq \"monster\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-monster"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+
+      wireMockServer.stubFor(currMapping);
+    }
+    
+    // Stub for GET /Users: monster by id (scimId-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("id eq \"user-monster\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+        // configure and set response
+        ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+        currResponse.withArray("Resources").add(users.get("user-monster"));
+        currResponse.put("totalResults", currResponse.withArray("Resources").size());
+        currResponse.put("startIndex", 1);
+        currMapping.willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/scim+json")
+            .withBody(currResponse.toString()));
+        
+        wireMockServer.stubFor(currMapping);
+    }
+    
+    // Stub for GET /Users: monster by givenName (firstName-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("name.givenName eq \"Cookie\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-monster"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                
+      wireMockServer.stubFor(currMapping);
+    }         
+
+    // Stub for GET /Users: monster by familyName (lastName-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("name.familyName eq \"Monster\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-monster"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                          
+      wireMockServer.stubFor(currMapping);
+    }
+    
+    // User 3: Daniel
+    
+    // Stub for GET /Users: daniel by userName (id-attribute)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("userName eq \"daniel\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));  
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-daniel"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                            
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Other stubs
+    
+    // All users query (no filter or empty filter)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", absent())
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*")); 
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      for (var user : users.entrySet()) {
+        currResponse.withArray("Resources").add(user.getValue());
+      }
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    }
+        
+    // Non-existing user
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("userName eq \"non-existing\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                    
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Non-existing user
+    currMapping = get(urlPathEqualTo("/Users"))
+            .withQueryParam("filter", equalTo("id eq \"non-existing\""))
+            .withQueryParam("startIndex", equalTo("1"))
+            .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                      
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Multiple user IDs (OR query)
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", equalTo("(userName eq \"oscar\" or userName eq \"monster\")"))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-monster"));
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                              
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Multiple user IDs (OR query)
+    currMapping = get(urlPathEqualTo("/Users"))
+            .withQueryParam("filter", equalTo("(id eq \"user-oscar\" or id eq \"user-monster\")"))
+            .withQueryParam("startIndex", equalTo("1"))
+            .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-monster"));
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Pagination sub-query 1
+    currMapping = get(urlPathEqualTo("/Users"))
+            .withQueryParam("filter", absent())
+            .withQueryParam("startIndex", equalTo("1"))
+            .withQueryParam("count", equalTo("2"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-monster"));
+      currResponse.withArray("Resources").add(users.get("user-oscar"));
+      currResponse.put("totalResults", users.size());
+      currResponse.put("startIndex", 1);
+      currResponse.put("itemsPerPage", 2);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                
+      wireMockServer.stubFor(currMapping);
+    }    
+  
+    // Pagination sub-query 2
+    currMapping = get(urlPathEqualTo("/Users"))
+        .withQueryParam("filter", absent())
+        .withQueryParam("startIndex", equalTo("3"))
+        .withQueryParam("count", equalTo("2"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(users.get("user-daniel"));
+      currResponse.put("totalResults", users.size());
+      currResponse.put("startIndex", 3);
+      currResponse.put("itemsPerPage", 2);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    }  
+  }
+
+  protected void setupGroups() throws JsonMappingException, JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    MappingBuilder currMapping = null;
+
+    String emptyResponseDescr = "{\n" +
+           "  \"schemas\": [\"urn:ietf:params:scim:api:messages:2.0:ListResponse\"],\n" +
+           "  \"totalResults\": 0,\n" +
+           "  \"Resources\": []}";
+
+    // Group 1: development
+    String devGroupDescr = "{\n" +
+            "  \"id\": \"group-development\",\n" +
+            "  \"externalId\": \"group-development\",\n" +
+            "  \"displayName\": \"development\",\n" +
+            "  \"members\": [\n" +
+            "    {\"value\": \"user-oscar\", \"$ref\": \"/Users/user-oscar\"},\n" +
+            "    {\"value\": \"user-daniel\", \"$ref\": \"/Users/user-daniel\"}\n" +
+            "  ]\n" +
+            "}";
+    
+    // Group 2: management
+    String mgmGroupDescr = "{\n" +
+            "  \"id\": \"group-management\",\n" +
+            "  \"externalId\": \"group-management\",\n" +
+            "  \"displayName\": \"management\",\n" +
+            "  \"members\": [\n" +
+            "    {\"value\": \"user-daniel\", \"$ref\": \"/Users/user-daniel\"}\n" +
+            "  ]\n" +
+            "}";
+
+    groups.clear();
+    groups.put("group-development", objectMapper.readTree(devGroupDescr)); 
+    groups.put("group-management", objectMapper.readTree(mgmGroupDescr)); 
+    
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("displayName eq \"development\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));   
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(groups.get("group-development"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                              
+      wireMockServer.stubFor(currMapping);
+    }
+    
+    // Stub for POST /Groups (development)
+    currMapping = post(urlPathEqualTo("/Groups"))
+        .withHeader("Content-Type", containing("application/scim+json"))
+        .withRequestBody(matchingJsonPath("$.schemas[?(@ == 'urn:ietf:params:scim:schemas:core:2.0:Group')]"))
+        .withRequestBody(matchingJsonPath("$.id", absent()))
+        .withRequestBody(matchingJsonPath("$.externalId", equalTo("group-development")))
+        .withRequestBody(matchingJsonPath("$.displayName", equalTo("development")));
+    if (currMapping != null) { 
+      // configure and set response: return existing group-development, 
+      // it should match the group in the post request
+      currMapping.willReturn(aResponse()
+          .withStatus(201)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(groups.get("group-development").toString()));
+                                
+      wireMockServer.stubFor(currMapping);
+    }    
+    
+    // Stub for PATCH /Groups (development)
+    currMapping = patch(urlPathEqualTo("/Groups/group-development"))
+        .withHeader("Content-Type", containing("application/scim+json"))
+        .withRequestBody(matchingJsonPath("$.schemas[?(@ == 'urn:ietf:params:scim:api:messages:2.0:PatchOp')]"))
+        .withRequestBody(matchingJsonPath("$.Operations[0].op", equalTo("replace")))
+        .withRequestBody(matchingJsonPath("$.Operations[0].path", equalTo("displayName")))
+        .withRequestBody(matchingJsonPath("$.Operations[0].value", equalTo("DEVELOPMENT")));   
+    if (currMapping != null) { 
+      // configure and set response: return patched copy of the existing group-development
+      ObjectNode patchedGroup = groups.get("group-development").deepCopy();
+      patchedGroup.put("displayName", "DEVELOPMENT");
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(patchedGroup.toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Stub for DELETE /Groups/group-development (delete group)
+    wireMockServer.stubFor(delete(urlPathEqualTo("/Groups/group-development"))
+        .withHeader("Content-Type", containing("application/scim+json"))
+        .willReturn(aResponse()
+            .withStatus(204))); // SCIM DELETE = 204 No Content by default
+
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("externalId eq \"group-development\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(groups.get("group-development"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                
+      wireMockServer.stubFor(currMapping);
+    }    
+    
+    // Group 2: management
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("displayName eq \"management\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*")); 
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(groups.get("group-management"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    } 
+ 
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("externalId eq \"group-management\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(groups.get("group-management"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                  
+      wireMockServer.stubFor(currMapping);
+    }    
+
+    // Non existing group
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("externalId eq \"non-existing\""))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                    
+      wireMockServer.stubFor(currMapping);
+    } 
+ 
+    // All groups query
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", absent())
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+        // configure and set response
+        ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+        for (var group : groups.entrySet()) {
+          currResponse.withArray("Resources").add(group.getValue());
+        }
+        currResponse.put("totalResults", currResponse.withArray("Resources").size());
+        currResponse.put("startIndex", 1);
+        currMapping.willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/scim+json")
+            .withBody(currResponse.toString()));
+                                    
+        wireMockServer.stubFor(currMapping);
+      }
+
+    // Groups by user filter - oscar
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("members[value eq \"user-oscar\"]"))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));   
+    if (currMapping != null) { 
+      // configure and set response
+      ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+      currResponse.withArray("Resources").add(groups.get("group-development"));
+      currResponse.put("totalResults", currResponse.withArray("Resources").size());
+      currResponse.put("startIndex", 1);
+      currMapping.willReturn(aResponse()
+          .withStatus(200)
+          .withHeader("Content-Type", "application/scim+json")
+          .withBody(currResponse.toString()));
+                                
+      wireMockServer.stubFor(currMapping);
+    }
+
+    // Groups by user filter - daniel (member of both)
+    currMapping = get(urlPathEqualTo("/Groups"))
+        .withQueryParam("filter", equalTo("members[value eq \"user-daniel\"]"))
+        .withQueryParam("startIndex", equalTo("1"))
+        .withQueryParam("count", matching(".*"));
+    if (currMapping != null) { 
+        // configure and set response
+        ObjectNode currResponse = (ObjectNode) objectMapper.readTree(emptyResponseDescr);
+        currResponse.withArray("Resources").add(groups.get("group-development"));
+        currResponse.withArray("Resources").add(groups.get("group-management"));
+        currResponse.put("totalResults", currResponse.withArray("Resources").size());
+        currResponse.put("startIndex", 1);
+        currMapping.willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/scim+json")
+            .withBody(currResponse.toString()));
+                                  
+        wireMockServer.stubFor(currMapping);
+      }
+   
+
+    // Get group by ID
+    /*wireMockServer.stubFor(get(urlPathEqualTo("/Groups/development"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/scim+json")
+            .withBody("{\n" +
+                "  \"id\": \"group-development\",\n" +
+                "  \"displayName\": \"development\",\n" +
+                "  \"members\": [\n" +
+                "    {\"value\": \"user-oscar\", \"$ref\": \"/Users/user-oscar\"},\n" +
+                "    {\"value\": \"user-daniel\", \"$ref\": \"/Users/user-daniel\"}\n" +
+                "  ]\n" +
+                "}")));*/
+  }
+
+  public void shutdown() {
+    if (wireMockServer != null) {
+      wireMockServer.stop();
+    }
+  }
+
+  public String getServerUrl() {
+    return serverUrl;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public int getTotalNumberOfUsersCreated() {
+    return users.size();
+  }
+
+  public int getTotalNumberOfGroupsCreated() {
+    return groups.size();
+  }
+}

--- a/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/scim/util/ScimTestEnvironmentExtension.java
+++ b/engine-plugins/identity-scim/src/test/java/org/operaton/bpm/identity/scim/util/ScimTestEnvironmentExtension.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements.
+ * Modifications Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.identity.scim.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin;
+
+/**
+ * JUnit 5 extension for managing the SCIM test server lifecycle.
+ */
+public class ScimTestEnvironmentExtension implements BeforeAllCallback, AfterAllCallback {
+
+  protected ScimTestEnvironment scimTestEnvironment;
+
+  public ScimTestEnvironmentExtension() {
+    this.scimTestEnvironment = new ScimTestEnvironment(0);
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    scimTestEnvironment.init();
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    scimTestEnvironment.shutdown();
+  }
+
+  public void injectScimUrlIntoProcessEngineConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    configureScimPlugin(processEngineConfiguration, "id");
+  }
+
+  public void injectScimUrlWithExternalGroupIds(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    configureScimPlugin(processEngineConfiguration, "externalId");
+  }
+
+  public ScimTestEnvironment getScimTestEnvironment() {
+    return scimTestEnvironment;
+  }
+
+  protected void configureScimPlugin(ProcessEngineConfigurationImpl processEngineConfiguration, String groupIdAttribute) {
+    ScimIdentityProviderPlugin scimPlugin = findOrCreateScimPlugin(processEngineConfiguration);
+    scimPlugin.setServerUrl(scimTestEnvironment.getServerUrl());
+    scimPlugin.setAuthenticationType("bearer");
+    scimPlugin.setBearerToken("test-token");
+    scimPlugin.setUserIdAttribute("userName");
+    scimPlugin.setUserFirstnameAttribute("name.givenName");
+    scimPlugin.setUserLastnameAttribute("name.familyName");
+    scimPlugin.setGroupIdAttribute(groupIdAttribute);
+    scimPlugin.setGroupNameAttribute("displayName");
+    scimPlugin.setAuthorizationCheckEnabled(false);
+  }
+
+  protected ScimIdentityProviderPlugin findOrCreateScimPlugin(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    List<ProcessEnginePlugin> plugins = processEngineConfiguration.getProcessEnginePlugins();
+    if (plugins == null) {
+      plugins = new ArrayList<>();
+      processEngineConfiguration.setProcessEnginePlugins(plugins);
+    }
+    final List<ProcessEnginePlugin> processEnginePlugins = plugins;
+
+    return processEnginePlugins.stream()
+        .filter(ScimIdentityProviderPlugin.class::isInstance)
+        .map(ScimIdentityProviderPlugin.class::cast)
+        .findFirst()
+        .orElseGet(() -> {
+          ScimIdentityProviderPlugin plugin = new ScimIdentityProviderPlugin();
+          processEnginePlugins.add(plugin);
+          return plugin;
+        });
+  }
+}

--- a/engine-plugins/identity-scim/src/test/resources/operaton.cfg.xml
+++ b/engine-plugins/identity-scim/src/test/resources/operaton.cfg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+  
+    <property name="processEngineName" value="ScimIdentityServiceTest-engine" />
+  
+    <property name="jdbcUrl" value="jdbc:h2:mem:ScimIdentityServiceTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcDriver" value="org.h2.Driver" />
+    <property name="jdbcUsername" value="sa" />
+    <property name="jdbcPassword" value="" />
+  
+    <!-- Database configurations -->
+    <property name="history" value="audit" />
+    <property name="databaseSchemaUpdate" value="create-drop" />
+    
+    <!-- job executor configurations -->
+    <property name="jobExecutorActivate" value="false" />
+    
+    <property name="createDiagramOnDeploy" value="true" />
+    <property name="enforceHistoryTimeToLive" value="false" />
+    
+    <property name="processEnginePlugins">
+      <list>
+        <ref bean="scimIdentityProviderPlugin" />
+      </list>
+    </property>
+    
+  </bean>
+  
+  <bean id="scimIdentityProviderPlugin" class="org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin">
+  
+    <property name="serverUrl" value="http://localhost:8443" />
+    
+  </bean>
+
+</beans>

--- a/engine-plugins/identity-scim/src/test/resources/operaton.modify.cfg.xml
+++ b/engine-plugins/identity-scim/src/test/resources/operaton.modify.cfg.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+  
+    <property name="processEngineName" value="ScimIdentityServiceTest-engine" />
+  
+    <property name="jdbcUrl" value="jdbc:h2:mem:ScimIdentityServiceModifyTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcDriver" value="org.h2.Driver" />
+    <property name="jdbcUsername" value="sa" />
+    <property name="jdbcPassword" value="" />
+  
+    <!-- Database configurations -->
+    <property name="history" value="audit" />
+    <property name="databaseSchemaUpdate" value="create-drop" />
+    
+    <!-- job executor configurations -->
+    <property name="jobExecutorActivate" value="false" />
+    
+    <property name="createDiagramOnDeploy" value="true" />
+    <property name="enforceHistoryTimeToLive" value="false" />
+
+    <property name="groupResourceWhitelistPattern" value="[a-zA-Z0-9\-]+" />
+    
+    <property name="processEnginePlugins">
+      <list>
+        <ref bean="scimIdentityProviderPlugin" />
+      </list>
+    </property>
+    
+  </bean>
+  
+  <bean id="scimIdentityProviderPlugin" class="org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin">
+  
+    <property name="serverUrl" value="http://localhost:8443" />
+    <property name="allowModifications" value="true" />
+    
+  </bean>
+
+</beans>

--- a/engine-plugins/identity-scim/src/test/resources/scim-example-config.xml
+++ b/engine-plugins/identity-scim/src/test/resources/scim-example-config.xml
@@ -1,0 +1,94 @@
+<!--
+  Example configuration for SCIM Identity Provider Plugin
+  
+  This file demonstrates different configuration options for integrating
+  Operaton with SCIM 2.0 identity providers.
+-->
+
+<!-- Example 1: Basic configuration with Bearer Token -->
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://scim.example.com</property>
+    <property name="authenticationType">bearer</property>
+    <property name="bearerToken">${SCIM_BEARER_TOKEN}</property>
+  </properties>
+</plugin>
+
+<!-- Example 2: Azure AD SCIM Configuration -->
+<!--
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://graph.microsoft.com/v1.0</property>
+    <property name="authenticationType">oauth2</property>
+    <property name="oauth2TokenUrl">https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token</property>
+    <property name="oauth2ClientId">${AZURE_CLIENT_ID}</property>
+    <property name="oauth2ClientSecret">${AZURE_CLIENT_SECRET}</property>
+    <property name="oauth2Scope">https://graph.microsoft.com/.default</property>
+    
+    <property name="usersEndpoint">/users</property>
+    <property name="groupsEndpoint">/groups</property>
+    
+    <property name="userIdAttribute">userPrincipalName</property>
+    <property name="userFirstnameAttribute">givenName</property>
+    <property name="userLastnameAttribute">surname</property>
+    
+    <property name="groupIdAttribute">id</property>
+    <property name="groupNameAttribute">displayName</property>
+  </properties>
+</plugin>
+-->
+
+<!-- Example 3: Okta SCIM Configuration -->
+<!--
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://{your-okta-domain}.okta.com/api/v1/scim/v2</property>
+    <property name="authenticationType">bearer</property>
+    <property name="bearerToken">${OKTA_API_TOKEN}</property>
+    
+    <property name="userIdAttribute">userName</property>
+    <property name="userFirstnameAttribute">name.givenName</property>
+    <property name="userLastnameAttribute">name.familyName</property>
+    
+    <property name="groupIdAttribute">displayName</property>
+    <property name="groupNameAttribute">displayName</property>
+    
+    <property name="pageSize">100</property>
+  </properties>
+</plugin>
+-->
+
+<!-- Example 4: Development configuration with self-signed certificates -->
+<!--
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://localhost:8443/scim/v2</property>
+    <property name="authenticationType">basic</property>
+    <property name="username">admin</property>
+    <property name="password">admin123</property>
+    
+    <property name="acceptUntrustedCertificates">true</property>
+    <property name="authorizationCheckEnabled">false</property>
+  </properties>
+</plugin>
+-->
+
+<!-- Example 5: Configuration with response caching -->
+<!--
+<plugin>
+  <class>org.operaton.bpm.identity.impl.scim.plugin.ScimIdentityProviderPlugin</class>
+  <properties>
+    <property name="serverUrl">https://scim.example.com</property>
+    <property name="authenticationType">bearer</property>
+    <property name="bearerToken">${SCIM_BEARER_TOKEN}</property>
+    
+    <property name="cacheEnabled">true</property>
+    <property name="maxCacheSize">200</property>
+    <property name="cacheExpirationTimeoutMin">10</property>
+  </properties>
+</plugin>
+-->

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -24,6 +24,7 @@
   </dependencyManagement>
   <modules>
     <module>identity-ldap</module>
+    <module>identity-scim</module>
     <module>connect-plugin</module>
     <module>spin-plugin</module>
   </modules>


### PR DESCRIPTION
## Summary

This replaces the previous design-only draft with a full code backport of the CIBSeven SCIM 2.0 identity provider plugin.

The PR adds a new `engine-plugins/identity-scim` module and wires it into Operaton's build and distributions:

- SCIM identity provider plugin, configuration, HTTP client, read-only and writable provider implementations
- user, group and tenant query support with SCIM filters, pagination, membership lookup and authorization checks
- Bearer, Basic and OAuth2 client-credentials support, OAuth2 token storage and optional response caching
- Run configuration via `operaton.bpm.run.scim.*`
- Tomcat and WildFly distribution packaging, including the WildFly module descriptor
- SCIM documentation and example configuration
- JUnit 5 tests with a WireMock-based SCIM test environment

## Source And Attribution

Backported from CIBSeven:

- Source PR: https://github.com/cibseven/cibseven/pull/214
- Source merge commit: https://github.com/cibseven/cibseven/commit/9c793e6d6f98a687bcfe68911cfc37f73f618a7f
- Source title: `Add SCIM 2.0 Identity Provider plugin with comprehensive tests (#214)`
- Original author: `Copilot <198982749+Copilot@users.noreply.github.com>`

Source co-authors retained in the Operaton commit trailers:

- `copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>`
- `OlegCIB <183531323+OlegCIB@users.noreply.github.com>`
- `vladimirg <vladimir.gribko@cib.de>`
- `serge-krot <182079319+serge-krot@users.noreply.github.com>`
- `vladgrind <156691737+vladgrind@users.noreply.github.com>`
- `Copilot <175728472+Copilot@users.noreply.github.com>`

## Operaton Adaptations

- Renamed packages, artifacts and examples from `org.cibseven` / `cibseven-*` to `org.operaton` / `operaton-*`.
- Added the module to `engine-plugins/pom.xml` and the public Operaton BOM.
- Added `operaton-identity-scim` to Run, Tomcat assembly and WildFly assembly/modules.
- Added `OperatonBpmRunScimProperties` and a conditional Run bean for `operaton.bpm.run.scim.enabled=true`.
- Migrated imported engine tests from JUnit 4 rules to JUnit 5 extensions.
- Switched tests to `org.wiremock:wiremock-standalone` to match Operaton's dependency style and avoid unresolved Jetty transitives.
- Kept WireMock Java imports under `com.github.tomakehurst.wiremock`, which is still the WireMock API package.
- Changed the test SCIM server to a dynamic port and inject it before engine startup.
- Omitted CIBSeven-only `wildfly28` and `qa/tomcat9-runtime` wiring because those paths do not exist in Operaton.
- Kept CIBSeven copyright headers on imported source files; new Operaton integration files use the Operaton contributor header.

## Reviewer Notes

This is intentionally still a **Draft** because SCIM is a new identity-provider product surface, not a small bugfix. The code now exists for concrete review, but maintainers should explicitly decide whether SCIM should ship in the monorepo and in which distributions.

Areas worth reviewing carefully:

- Whether the writable provider should be shipped at all, or only documented for test/dev use. `allowModifications` remains `false` by default.
- Whether Run should expose SCIM as `operaton.bpm.run.scim.*` exactly as adapted here.
- Security expectations for outbound SCIM HTTP calls, credential handling, OAuth2 token storage, cache behavior and `acceptUntrustedCertificates`.
- Real provider compatibility. The backport includes tests against mocked SCIM behavior; it does not prove Azure AD/Okta/OneLogin interoperability.
- The upstream docs implied configurable email attribute names, but the imported configuration currently reads the standard SCIM `emails` array without a setter. The Operaton README/examples were adjusted to document the implemented behavior instead of a non-existing property.

## Verification

- `./mvnw -pl engine-plugins/identity-scim test -Dskip.frontend.build=true`
  - 53 tests, 0 failures, 0 errors
- `./mvnw -pl distro/run/core compile -DskipTests -Dskip.frontend.build=true`
- `./mvnw -P distro -pl :operaton-tomcat-assembly validate -DskipTests -Dskip.frontend.build=true`
- `./mvnw -P distro-wildfly -pl :operaton-wildfly-modules,:operaton-wildfly-assembly validate -DskipTests -Dskip.frontend.build=true`

Note: a broad `-pl engine-plugins/identity-scim -am test` run stopped before reaching SCIM in an existing DMN ArchUnit violation unrelated to this backport, so the final verification uses targeted module/distribution checks.
