### PR TITLE
feat(engine): expose job failure throwable to incident context

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
@@ -51,6 +51,7 @@ public abstract class JobRetryCmd implements Command<Object> {
     if(exception != null) {
       job.setExceptionMessage(exception.getMessage());
       job.setExceptionStacktrace(getExceptionStacktrace());
+      job.setException(exception);
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/incident/IncidentContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/incident/IncidentContext.java
@@ -31,6 +31,7 @@ public class IncidentContext {
   protected String jobDefinitionId;
   protected String historyConfiguration;
   protected String failedActivityId;
+  private transient Throwable throwable;
 
   public IncidentContext() {}
 
@@ -105,6 +106,14 @@ public class IncidentContext {
 
   public void setFailedActivityId(String failedActivityId) {
     this.failedActivityId = failedActivityId;
+  }
+
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  public void setThrowable(Throwable throwable) {
+    this.throwable = throwable;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobEntity.java
@@ -105,6 +105,8 @@ public abstract class JobEntity extends AcquirableJobEntity
 
   protected String batchId;
 
+  private transient Throwable exception;
+
   public void execute(CommandContext commandContext) {
     if (executionId != null) {
       ensureNotNull("Cannot find execution with id '%s' referenced from job '%s'".formatted(executionId, this), "execution", getExecution());
@@ -343,6 +345,7 @@ public abstract class JobEntity extends AcquirableJobEntity
       incidentContext.setActivityId(getActivityId());
       incidentContext.setHistoryConfiguration(getLastFailureLogId());
       incidentContext.setFailedActivityId(getFailedActivityId());
+      incidentContext.setThrowable(getException());
 
       IncidentHandling.createIncident(FAILED_JOB_HANDLER_TYPE, incidentContext, exceptionMessage);
     }
@@ -474,6 +477,14 @@ public abstract class JobEntity extends AcquirableJobEntity
     return exceptionMessage;
   }
 
+  public Throwable getException() {
+    return exception;
+  }
+
+  public void setException(Throwable exception) {
+    this.exception = exception;
+  }
+
   @Override
   public String getJobDefinitionId() {
     return jobDefinitionId;
@@ -543,6 +554,7 @@ public abstract class JobEntity extends AcquirableJobEntity
 
     this.exceptionByteArrayId = null;
     this.exceptionMessage = null;
+    this.exception = null;
   }
 
   @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentMultipleProcessingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentMultipleProcessingTest.java
@@ -97,6 +97,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
    @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncident.bpmn"})
    @Test
+   void shouldExposeThrowableOnIncidentCreation() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("failingProcess");
+
+    testRule.executeAvailableJobs();
+
+    List<Incident> incidents = runtimeService.createIncidentQuery().processInstanceId(processInstance.getId()).list();
+
+    assertThat(incidents).hasSize(1);
+    assertThat(JOB_HANDLER.getCreateEvents()).hasSize(1);
+
+    IncidentContext createContext = JOB_HANDLER.getCreateEvents().get(0);
+    assertThat(createContext.getThrowable())
+      .isNotNull()
+      .hasMessageContaining(AlwaysFailingDelegate.MESSAGE);
+
+    assertThat(JOB_HANDLER.getResolveEvents()).isEmpty();
+    assertThat(JOB_HANDLER.getDeleteEvents()).isEmpty();
+  }
+
+   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncident.bpmn"})
+   @Test
    void shouldResolveIncidentAfterJobRetriesRefresh() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("failingProcess");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
@@ -30,10 +30,12 @@ import org.operaton.bpm.engine.history.HistoricJobLog;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.DeleteJobCmd;
 import org.operaton.bpm.engine.impl.db.DbEntity;
+import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.JobQuery;
 import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.api.mgmt.AlwaysFailingDelegate;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
@@ -208,6 +210,34 @@ class JobExecutorCmdExceptionTest {
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
     assertThat(stacktrace).isNotNull().contains("java.lang.RuntimeException: exception in transaction listener");
+  }
+
+  @Test
+  void shouldNotPersistTransientExceptionAfterJobFailure() {
+    testRule.deploy(Bpmn.createExecutableProcess("testProcess")
+      .operatonHistoryTimeToLive(180)
+      .startEvent()
+      .serviceTask("theServiceTask")
+      .operatonAsyncBefore()
+      .operatonClass(AlwaysFailingDelegate.class)
+      .operatonFailedJobRetryTimeCycle("R0/PT30S")
+      .endEvent()
+      .done());
+
+    runtimeService.startProcessInstanceByKey("testProcess");
+    Job job = managementService.createJobQuery().singleResult();
+    assertThat(job).isNotNull();
+    assertThat(job.getExceptionMessage()).isNull();
+    assertThat(((JobEntity) job).getException()).isNull();
+
+    var jobId = job.getId();
+
+    assertThatCode(() -> managementService.executeJob(jobId)).isInstanceOf(RuntimeException.class);
+
+    job = managementService.createJobQuery().singleResult();
+    assertThat(job).isNotNull();
+    assertThat(job.getExceptionMessage()).isEqualTo(AlwaysFailingDelegate.MESSAGE);
+    assertThat(((JobEntity) job).getException()).isNull();
   }
 
   protected void createJob(final String handlerType) {


### PR DESCRIPTION
## Summary

Backports the smaller Fluxnova incident-context change so failed-job incident handlers can inspect the original job execution `Throwable` while the incident is created.

This PR provides an Operaton-adapted implementation of the Fluxnova incident context extension.

## What Changed

- Store the job execution failure transiently on `JobEntity` when `JobRetryCmd` records the failure.
- Copy that transient failure into the failed-job `IncidentContext` before invoking incident handling.
- Expose `IncidentContext#getThrowable()` / `setThrowable(...)` for custom incident handlers.
- Keep the failure non-persistent: reloading the failed job from persistence still yields no transient `Throwable`.
- Add tests for both custom incident-handler visibility and non-persistence after reload.

## Reviewer Notes

The previous discussion PR grouped two Fluxnova change units. This PR intentionally implements only the smaller transient `Throwable` propagation change. The larger `HistoricIncident#rootCauseIncidentMessage` API/REST/SQL extension is not included here and remains a separate design decision.

The new behavior is limited to failed-job incident creation. It does not add a database column, REST field, or historic incident field. The test in `IncidentMultipleProcessingTest` exercises the real job failure and custom incident handler path, and the test in `JobExecutorCmdExceptionTest` verifies the transient exception is not persisted when the job is queried again.

## Attribution

Backported-adapted from Fluxnova commits:

- https://github.com/finos/fluxnova-bpm-platform/commit/b1e7abb50f4fe88788d5047b1c8e388ddd6a70c9
- https://github.com/finos/fluxnova-bpm-platform/commit/de6d3ca04663c92bf8754e155a2a0875ff0c6659

Both Fluxnova commits carry the same logical patch.

Original author: Palanisamy, Prakash <prakash.palanisamy@fmr.com>

## Verification

- `./mvnw -pl engine -Dtest=IncidentMultipleProcessingTest,JobExecutorCmdExceptionTest test`
- `.devenv/scripts/maintenance/code-cleanup.sh` completed successfully; it produced broad unrelated mechanical cleanup churn, which was removed from this PR diff. The run also reported existing OpenRewrite recipe validation warnings/errors from `rewrite.yml`, but Maven exited successfully.

