### PR TITLE
feat(engine): support BPMN error code provider exceptions

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/delegate/BpmnErrorCodeProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/delegate/BpmnErrorCodeProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.delegate;
+
+/**
+ * Provides a BPMN error code for exceptions that should be propagated as BPMN errors.
+ */
+public interface BpmnErrorCodeProvider {
+
+  /**
+   * Returns the BPMN error code associated with this exception.
+   */
+  String getErrorCode();
+
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnExceptionHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnExceptionHandler.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.bpmn.helper;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.BpmnError;
+import org.operaton.bpm.engine.delegate.BpmnErrorCodeProvider;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.bpmn.behavior.BpmnBehaviorLogger;
 import org.operaton.bpm.engine.impl.bpmn.parser.ErrorEventDefinition;
@@ -60,7 +61,9 @@ public final class BpmnExceptionHandler {
       throw exception;
     }
     else {
-      propagateError(null, exception.getMessage(),exception, execution);
+      BpmnErrorCodeProvider errorCodeProvider = checkIfCauseOfExceptionIsBpmnErrorCodeProvider(exception);
+      String errorCode = errorCodeProvider != null ? errorCodeProvider.getErrorCode() : null;
+      propagateError(errorCode, exception.getMessage(), exception, execution);
     }
   }
 
@@ -88,6 +91,15 @@ public final class BpmnExceptionHandler {
       return null;
     }
     return checkIfCauseOfExceptionIsBpmnError(e.getCause());
+  }
+
+  protected static BpmnErrorCodeProvider checkIfCauseOfExceptionIsBpmnErrorCodeProvider(Throwable e) {
+    if (e instanceof BpmnErrorCodeProvider errorCodeProvider) {
+      return errorCodeProvider;
+    } else if (e.getCause() == null) {
+      return null;
+    }
+    return checkIfCauseOfExceptionIsBpmnErrorCodeProvider(e.getCause());
   }
 
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/ErrorDeclarationForProcessInstanceFinder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/ErrorDeclarationForProcessInstanceFinder.java
@@ -42,7 +42,7 @@ public class ErrorDeclarationForProcessInstanceFinder implements TreeVisitor<Pvm
     List<ErrorEventDefinition> errorEventDefinitions = scope.getProperties().get(BpmnProperties.ERROR_EVENT_DEFINITIONS);
     for (ErrorEventDefinition definition : errorEventDefinitions) {
       PvmActivity activityHandler = scope.getProcessDefinition().findActivity(definition.getHandlerActivityId());
-      if ((!isReThrowingErrorEventSubprocess(activityHandler)) && ((exception != null && definition.catchesException(exception))
+      if ((!isReThrowingErrorEventSubprocess(activityHandler)) && ((exception != null && catchesExceptionOrErrorCode(definition))
         || (exception == null && definition.catchesError(errorCode)))) {
 
         errorHandlerActivity = activityHandler;
@@ -50,6 +50,10 @@ public class ErrorDeclarationForProcessInstanceFinder implements TreeVisitor<Pvm
         break;
       }
     }
+  }
+
+  protected boolean catchesExceptionOrErrorCode(ErrorEventDefinition definition) {
+    return definition.catchesException(exception) || (errorCode != null && definition.catchesError(errorCode));
   }
 
   protected boolean isReThrowingErrorEventSubprocess(PvmActivity activityHandler) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/behavior/BpmnErrorCodeProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/behavior/BpmnErrorCodeProviderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.test.bpmn.behavior;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.delegate.BpmnErrorCodeProvider;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
+import org.operaton.bpm.engine.delegate.JavaDelegate;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BpmnErrorCodeProviderTest {
+
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
+
+  RuntimeService runtimeService;
+  TaskService taskService;
+
+  @Test
+  @Deployment(resources = {
+      "org/operaton/bpm/engine/test/bpmn/behavior/BpmnErrorCodeProviderTest.bpmn20.xml"})
+  void shouldPropagateProviderErrorCodeToBoundaryEvent() {
+    runtimeService.startProcessInstanceByKey("bpmnErrorCodeProviderProcess");
+
+    assertThat(taskService.createTaskQuery().taskDefinitionKey("handledTask").count()).isOne();
+  }
+
+  public static class ErrorCodeProviderDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+      throw new CustomBpmnException();
+    }
+  }
+
+  static class CustomBpmnException extends Exception implements BpmnErrorCodeProvider {
+
+    @Override
+    public String getErrorCode() {
+      return "CUSTOM_ERROR_CODE";
+    }
+  }
+}

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/behavior/BpmnErrorCodeProviderTest.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/behavior/BpmnErrorCodeProviderTest.bpmn20.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+             targetNamespace="Examples">
+
+  <error id="customError" errorCode="CUSTOM_ERROR_CODE" />
+
+  <process id="bpmnErrorCodeProviderProcess" isExecutable="true">
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask" />
+    <serviceTask id="serviceTask"
+                 operaton:class="org.operaton.bpm.engine.test.bpmn.behavior.BpmnErrorCodeProviderTest$ErrorCodeProviderDelegate" />
+    <sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="end" />
+    <endEvent id="end" />
+
+    <boundaryEvent id="boundaryError" attachedToRef="serviceTask">
+      <errorEventDefinition errorRef="customError" />
+    </boundaryEvent>
+    <sequenceFlow id="flow3" sourceRef="boundaryError" targetRef="handledTask" />
+    <userTask id="handledTask" />
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="bpmnErrorCodeProviderProcess">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="100" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_di" bpmnElement="serviceTask">
+        <dc:Bounds x="190" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundaryError_di" bpmnElement="boundaryError">
+        <dc:Bounds x="220" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="handledTask_di" bpmnElement="handledTask">
+        <dc:Bounds x="190" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="340" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow1_di" bpmnElement="flow1">
+        <di:waypoint x="136" y="118" />
+        <di:waypoint x="190" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow2_di" bpmnElement="flow2">
+        <di:waypoint x="290" y="118" />
+        <di:waypoint x="340" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow3_di" bpmnElement="flow3">
+        <di:waypoint x="238" y="176" />
+        <di:waypoint x="238" y="220" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
## Summary

This PR backports and hardens the Fluxnova BPMN error-code provider idea for Operaton.

It adds a public `BpmnErrorCodeProvider` interface for exceptions that want to provide a BPMN error code, then lets BPMN error propagation use that code when matching error handlers. The Operaton adaptation also updates `ErrorDeclarationForProcessInstanceFinder` so an exception can still be preserved while matching a provided BPMN error code.

## Change unit

- `336` [fluxnova:e6344e7c1c64, fluxnova:fe6e2d5ec332] feat(engine) - add BpmnErrorCodeProvider interface and implement custom error code handling

## Attribution

Backported-adapted from Fluxnova commit `e6344e7c1c647fccd6c2c0c4fc75d7455bf43dc1`.

Equivalent Fluxnova source commit: `fe6e2d5ec3329b865b95d615b3fe4456085ded4f`.

Original author: Sowmya H L <Sowmya.HL@fmr.com>

## Reviewer notes

The upstream test only asserted the provider getter. This PR adds an engine behavior test proving that a delegate exception implementing `BpmnErrorCodeProvider` is caught by a matching BPMN boundary error event.

## Verification

- `git diff --check origin/main...HEAD`
- `./mvnw -pl engine -Dtest=BpmnErrorCodeProviderTest test -Dskip.frontend.build=true`
