### PR TITLE
fix(engine): defer child history cleanup until root completion

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1872,6 +1872,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       properties.put("dbSpecificIfNullFunction", DbSqlSessionFactory.getDatabaseSpecificIfNull().get(databaseType));
 
       properties.put("dayComparator", DbSqlSessionFactory.getDatabaseSpecificDaysComparator().get(databaseType));
+      properties.put("coalesceForEndDate", DbSqlSessionFactory.getDatabaseSpecificCoalesceForEndDate().get(databaseType));
 
       properties.put("collationForCaseSensitivity", DbSqlSessionFactory.getDatabaseSpecificCollationForCaseSensitivity().get(databaseType));
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -95,6 +95,8 @@ public class DbSqlSessionFactory implements SessionFactory {
 
   private static final Map<String, String> databaseSpecificDaysComparator = new HashMap<>();
 
+  private static final Map<String, String> databaseSpecificCoalesceForEndDate = new HashMap<>();
+
   private static final Map<String, String> databaseSpecificCollationForCaseSensitivity = new HashMap<>();
 
   private static final Map<String, String> databaseSpecificAuthJoinStart = new HashMap<>();
@@ -188,6 +190,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificIfNull.put(H2, "IFNULL");
 
     databaseSpecificDaysComparator.put(H2, "DATEDIFF(DAY, ${date}, #{currentTimestamp}) >= ${days}");
+    databaseSpecificCoalesceForEndDate.put(H2, "DATEDIFF(DAY, COALESCE(${preferredDate}, ${date}), #{currentTimestamp}) >= ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(H2, "");
 
@@ -254,6 +257,7 @@ public class DbSqlSessionFactory implements SessionFactory {
       databaseSpecificIfNull.put(mysqlLikeDatabase, "IFNULL");
 
       databaseSpecificDaysComparator.put(mysqlLikeDatabase, "DATEDIFF(#{currentTimestamp}, ${date}) >= ${days}");
+      databaseSpecificCoalesceForEndDate.put(mysqlLikeDatabase, "DATEDIFF(#{currentTimestamp}, COALESCE(${preferredDate}, ${date})) >= ${days}");
 
       databaseSpecificCollationForCaseSensitivity.put(mysqlLikeDatabase, "");
 
@@ -513,6 +517,7 @@ public class DbSqlSessionFactory implements SessionFactory {
       dbSpecificConstants.put(postgresLikeDatabase, constants);
     }
     databaseSpecificDaysComparator.put(POSTGRES, "EXTRACT (DAY FROM #{currentTimestamp} - ${date}) >= ${days}");
+    databaseSpecificCoalesceForEndDate.put(POSTGRES, "EXTRACT (DAY FROM #{currentTimestamp} - COALESCE(${preferredDate}, ${date})) >= ${days}");
     databaseSpecificNumericCast.put(POSTGRES, "");
 
     // oracle
@@ -552,6 +557,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificIfNull.put(ORACLE, "NVL");
 
     databaseSpecificDaysComparator.put(ORACLE, "${date} <= #{currentTimestamp} - ${days}");
+    databaseSpecificCoalesceForEndDate.put(ORACLE, "COALESCE(${preferredDate}, ${date}) <= #{currentTimestamp} - ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(ORACLE, "");
 
@@ -645,6 +651,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificIfNull.put(DB2, "NVL");
 
     databaseSpecificDaysComparator.put(DB2, "${date} + ${days} DAYS <= #{currentTimestamp}");
+    databaseSpecificCoalesceForEndDate.put(DB2, "COALESCE(${preferredDate}, ${date}) + ${days} DAYS <= #{currentTimestamp}");
 
     databaseSpecificCollationForCaseSensitivity.put(DB2, "");
 
@@ -744,6 +751,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificIfNull.put(MSSQL, "ISNULL");
 
     databaseSpecificDaysComparator.put(MSSQL, "DATEDIFF(DAY, ${date}, #{currentTimestamp}) >= ${days}");
+    databaseSpecificCoalesceForEndDate.put(MSSQL, "DATEDIFF(DAY, COALESCE(${preferredDate}, ${date}), #{currentTimestamp}) >= ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(MSSQL, "COLLATE Latin1_General_CS_AS");
 
@@ -995,6 +1003,10 @@ public class DbSqlSessionFactory implements SessionFactory {
 
   public static Map<String, String> getDatabaseSpecificDaysComparator() {
     return Collections.unmodifiableMap(databaseSpecificDaysComparator);
+  }
+
+  public static Map<String, String> getDatabaseSpecificCoalesceForEndDate() {
+    return Collections.unmodifiableMap(databaseSpecificCoalesceForEndDate);
   }
 
   public static Map<String, String> getDatabaseSpecificCollationForCaseSensitivity() {

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricDecisionInstance.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricDecisionInstance.xml
@@ -534,25 +534,30 @@
   <!-- Select ids for async history cleanup -->
   <sql id="selectHistoricDecisionInstanceIdsForCleanupSql">
     <bind name="days" value="'dd.HISTORY_TTL_'"/>
-    <bind name="date" value="'di.EVAL_TIME_'"/>
+    <bind name="preferredDate" value="'his_root_di.EVAL_TIME_'"/>
+    <bind name="date" value="'his_di.EVAL_TIME_'"/>
     <bind name="currentTimestamp" value="parameter.currentTimestamp"/>
     <bind name="reportPeriodUnitName" value="'MINUTE'"/>
-    FROM ${prefix}ACT_HI_DECINST di, ${prefix}ACT_RE_DECISION_DEF dd
-    where
-        di.DEC_DEF_ID_ = dd.ID_
-        AND not dd.HISTORY_TTL_ is NULL
-        AND ${dayComparator}
+    FROM ${prefix}ACT_HI_DECINST his_di
+    JOIN ${prefix}ACT_RE_DECISION_DEF dd ON his_di.DEC_DEF_ID_ = dd.ID_
+    LEFT JOIN ${prefix}ACT_RU_EXECUTION rpe ON rpe.ID_ = his_di.ROOT_PROC_INST_ID_
+    LEFT JOIN ${prefix}ACT_HI_DECINST his_root_di ON his_di.ROOT_PROC_INST_ID_ = his_root_di.ID_
+    WHERE
+      NOT his_di.EVAL_TIME_ IS NULL
+      AND NOT dd.HISTORY_TTL_ IS NULL
+      AND (his_root_di.EVAL_TIME_ IS NOT NULL OR rpe.ID_ IS NULL)
+      AND ${coalesceForEndDate}
   </sql>
 
   <select id="selectHistoricDecisionInstanceIdsForCleanup" parameterType="org.operaton.bpm.engine.impl.db.ListQueryParameterObject" resultType="string">
-    SELECT ${limitBeforeWithoutOffset} di.ID_, di.EVAL_TIME_
+    SELECT ${limitBeforeWithoutOffset} his_di.ID_, his_di.EVAL_TIME_
     <include refid="selectHistoricDecisionInstanceIdsForCleanupSql"/>
     <include refid="andWhereMinuteInDateBetweenSql"/>
     ${limitAfterWithoutOffset}
   </select>
 
   <select id="selectHistoricDecisionInstanceIdsForCleanup_oracle" parameterType="org.operaton.bpm.engine.impl.db.ListQueryParameterObject" resultType="string">
-    SELECT /*+ FIRST_ROWS(${maxResults}) NO_PARALLEL(di) NO_PARALLEL(dd) */ di.ID_, di.EVAL_TIME_
+    SELECT /*+ FIRST_ROWS(${maxResults}) NO_PARALLEL(di) NO_PARALLEL(dd) */ his_di.ID_, his_di.EVAL_TIME_
     <include refid="selectHistoricDecisionInstanceIdsForCleanupSql"/>
     <include refid="andWhereMinuteInDateBetweenSql_oracle"/>
     ${limitAfterWithoutOffset}

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -768,15 +768,19 @@
   <!-- Select ids for async history cleanup -->
   <sql id="selectHistoricProcessInstanceIdsForCleanupSql">
     <bind name="days" value="'pd.HISTORY_TTL_'"/>
-    <bind name="date" value="'pi.END_TIME_'"/>
+    <bind name="preferredDate" value="'his_root_pi.END_TIME_'"/>
+    <bind name="date" value="'his_pi.END_TIME_'"/>
     <bind name="currentTimestamp" value="parameter.currentTimestamp"/>
     <bind name="reportPeriodUnitName" value="'MINUTE'"/>
-    FROM ${prefix}ACT_HI_PROCINST pi, ${prefix}ACT_RE_PROCDEF pd
-    where
-        pi.PROC_DEF_ID_ = pd.ID_
-        AND not pi.END_TIME_ is NULL
-        AND not pd.HISTORY_TTL_ is NULL
-        AND ${dayComparator}
+    FROM ${prefix}ACT_HI_PROCINST his_pi
+    JOIN ${prefix}ACT_RE_PROCDEF pd ON his_pi.PROC_DEF_ID_ = pd.ID_
+    LEFT JOIN ${prefix}ACT_RU_EXECUTION rpe ON rpe.ID_ = his_pi.ROOT_PROC_INST_ID_
+    LEFT JOIN ${prefix}ACT_HI_PROCINST his_root_pi ON his_pi.ROOT_PROC_INST_ID_ = his_root_pi.ID_
+    WHERE
+      NOT his_pi.END_TIME_ IS NULL
+      AND NOT pd.HISTORY_TTL_ IS NULL
+      AND (his_root_pi.END_TIME_ IS NOT NULL OR rpe.ID_ IS NULL)
+      AND ${coalesceForEndDate}
   </sql>
 
   <sql id="andWhereMinuteInDateBetweenSql">
@@ -794,14 +798,14 @@
   </sql>
 
   <select id="selectHistoricProcessInstanceIdsForCleanup" parameterType="org.operaton.bpm.engine.impl.db.ListQueryParameterObject" resultType="string">
-    SELECT ${limitBeforeWithoutOffset} pi.PROC_INST_ID_, pi.END_TIME_
+    SELECT ${limitBeforeWithoutOffset} his_pi.PROC_INST_ID_, his_pi.END_TIME_
     <include refid="selectHistoricProcessInstanceIdsForCleanupSql"/>
     <include refid="andWhereMinuteInDateBetweenSql"/>
     ${limitAfterWithoutOffset}
   </select>
 
   <select id="selectHistoricProcessInstanceIdsForCleanup_oracle" parameterType="org.operaton.bpm.engine.impl.db.ListQueryParameterObject" resultType="string">
-    SELECT /*+ FIRST_ROWS(${maxResults}) NO_PARALLEL(pi) NO_PARALLEL(pd) */ pi.PROC_INST_ID_, pi.END_TIME_
+    SELECT /*+ FIRST_ROWS(${maxResults}) NO_PARALLEL(pi) NO_PARALLEL(pd) */ his_pi.PROC_INST_ID_, his_pi.END_TIME_
     <include refid="selectHistoricProcessInstanceIdsForCleanupSql"/>
     <include refid="andWhereMinuteInDateBetweenSql_oracle"/>
     ${limitAfterWithoutOffset}

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.java
@@ -48,6 +48,7 @@ import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.history.HistoricCaseInstance;
 import org.operaton.bpm.engine.history.HistoricDecisionInstance;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
@@ -72,6 +73,7 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.dmn.businessruletask.TestPojo;
@@ -103,6 +105,11 @@ class HistoryCleanupTest {
   protected static final String ONE_TASK_PROCESS = "oneTaskProcess";
   protected static final String DECISION = "decision";
   protected static final String ONE_TASK_CASE = "case";
+  protected static final String PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY = "parentProcess";
+  protected static final String SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY = "subProcess";
+  protected static final String PARENT_DMN_HISTORY_CLEANUP_PROCESS_KEY = "parentDMNProcess";
+  protected static final String CHILD_DMN_HISTORY_CLEANUP_PROCESS_KEY = "childDmnProcess";
+  protected static final String DECISION_TABLE_HISTORY_CLEANUP_ID = "decisionTable";
 
   private static final int NUMBER_OF_THREADS = 3;
   private static final String USER_ID = "demo";
@@ -150,6 +157,7 @@ class HistoryCleanupTest {
   private ManagementService managementService;
   private CaseService caseService;
   private RepositoryService repositoryService;
+  private TaskService taskService;
   private IdentityService identityService;
   private ProcessEngineConfigurationImpl processEngineConfiguration;
 
@@ -1401,6 +1409,113 @@ class HistoryCleanupTest {
     assertThat(cleanupJob.getRetries()).isZero();
   }
 
+  @Test
+  @Deployment(resources = {
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupAParentProcess.bpmn20.bpmn",
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupChild.bpmn20.bpmn" })
+  void shouldNotCleanFinishedSubProcessWhenRootProcessIsStillRunning() {
+    setTtlProcessDefinitions(HISTORY_TIME_TO_LIVE, PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY,
+        SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY);
+
+    ClockUtil.setCurrentTime(DateUtils.addDays(targetDate, DAYS_IN_THE_PAST));
+    ProcessInstance parentProcessInstance = runtimeService.startProcessInstanceByKey(PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY);
+    ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+        .processDefinitionKey(SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY)
+        .singleResult();
+
+    completeActiveTask(subProcessInstance.getId());
+    completeActiveTask(subProcessInstance.getId());
+
+    ClockUtil.setCurrentTime(targetDate);
+    runHistoryCleanup(true);
+
+    assertThat(historyService.createHistoricProcessInstanceQuery()
+        .processInstanceId(subProcessInstance.getId())
+        .singleResult()).isNotNull();
+
+    runtimeService.deleteProcessInstance(parentProcessInstance.getId(), null, true, true);
+  }
+
+  @Test
+  @Deployment(resources = {
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupAParentProcess.bpmn20.bpmn",
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupChild.bpmn20.bpmn" })
+  void shouldNotCleanFinishedSubProcessBeforeRootProcessTtlIsReached() {
+    setTtlProcessDefinitions(HISTORY_TIME_TO_LIVE, PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY,
+        SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY);
+
+    ClockUtil.setCurrentTime(DateUtils.addDays(targetDate, DAYS_IN_THE_PAST));
+    ProcessInstance parentProcessInstance = runtimeService.startProcessInstanceByKey(PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY);
+    ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+        .processDefinitionKey(SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY)
+        .singleResult();
+
+    completeActiveTask(subProcessInstance.getId());
+    completeActiveTask(subProcessInstance.getId());
+
+    ClockUtil.setCurrentTime(targetDate);
+    completeActiveTask(parentProcessInstance.getId());
+    runHistoryCleanup(true);
+
+    assertThat(historyService.createHistoricProcessInstanceQuery()
+        .processInstanceId(subProcessInstance.getId())
+        .singleResult()).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = {
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupAParentProcess.bpmn20.bpmn",
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupChild.bpmn20.bpmn" })
+  void shouldCleanFinishedSubProcessAfterRootProcessTtlIsReached() {
+    setTtlProcessDefinitions(HISTORY_TIME_TO_LIVE, PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY,
+        SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY);
+
+    ClockUtil.setCurrentTime(DateUtils.addDays(targetDate, DAYS_IN_THE_PAST));
+    ProcessInstance parentProcessInstance = runtimeService.startProcessInstanceByKey(PARENT_BPMN_HISTORY_CLEANUP_PROCESS_KEY);
+    ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+        .processDefinitionKey(SUBPROCESS_BPMN_HISTORY_CLEANUP_PROCESS_KEY)
+        .singleResult();
+
+    completeActiveTask(subProcessInstance.getId());
+    completeActiveTask(subProcessInstance.getId());
+    completeActiveTask(parentProcessInstance.getId());
+
+    ClockUtil.setCurrentTime(targetDate);
+    runHistoryCleanup(true);
+
+    assertThat(historyService.createHistoricProcessInstanceQuery()
+        .processInstanceId(subProcessInstance.getId())
+        .singleResult()).isNull();
+  }
+
+  @Test
+  @Deployment(resources = {
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDmnParentProcess.bpmn",
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDmnSubProcess.bpmn",
+      "org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDecisionTable.dmn" })
+  void shouldNotCleanDecisionInstanceWhenRootProcessIsStillRunning() {
+    setTtlProcessDefinitions(HISTORY_TIME_TO_LIVE, PARENT_DMN_HISTORY_CLEANUP_PROCESS_KEY,
+        CHILD_DMN_HISTORY_CLEANUP_PROCESS_KEY);
+    setTtlDecisionDefinition(HISTORY_TIME_TO_LIVE, DECISION_TABLE_HISTORY_CLEANUP_ID);
+
+    ClockUtil.setCurrentTime(DateUtils.addDays(targetDate, DAYS_IN_THE_PAST));
+    ProcessInstance parentProcessInstance = runtimeService.startProcessInstanceByKey(PARENT_DMN_HISTORY_CLEANUP_PROCESS_KEY,
+        Variables.createVariables().putValue("inputVariable", "A"));
+
+    HistoricDecisionInstance decisionInstance = historyService.createHistoricDecisionInstanceQuery()
+        .decisionDefinitionKey(DECISION_TABLE_HISTORY_CLEANUP_ID)
+        .singleResult();
+
+    ClockUtil.setCurrentTime(targetDate);
+    runHistoryCleanup(true);
+
+    assertThat(historyService.createHistoricDecisionInstanceQuery()
+        .decisionInstanceId(decisionInstance.getId())
+        .singleResult()).isNotNull();
+
+    runtimeService.deleteProcessInstance(parentProcessInstance.getId(), null, true, true);
+  }
+
 
   private Date getNextRunWithinBatchWindow(Date currentTime) {
     return processEngineConfiguration.getBatchWindowManager().getNextBatchWindow(currentTime, processEngineConfiguration).getStart();
@@ -1409,6 +1524,32 @@ class HistoryCleanupTest {
   private HistoryCleanupJobHandlerConfiguration getConfiguration(JobEntity jobEntity) {
     String jobHandlerConfigurationRaw = jobEntity.getJobHandlerConfigurationRaw();
     return HistoryCleanupJobHandlerConfiguration.fromJson(JsonUtil.asObject(jobHandlerConfigurationRaw));
+  }
+
+  private void setTtlProcessDefinitions(Integer timeToLive, String... processDefinitionKeys) {
+    for (String processDefinitionKey : processDefinitionKeys) {
+      List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
+          .processDefinitionKey(processDefinitionKey)
+          .list();
+      assertThat(processDefinitions).hasSize(1);
+      repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinitions.get(0).getId(), timeToLive);
+    }
+  }
+
+  private void setTtlDecisionDefinition(Integer timeToLive, String decisionDefinitionKey) {
+    List<DecisionDefinition> decisionDefinitions = repositoryService.createDecisionDefinitionQuery()
+        .decisionDefinitionKey(decisionDefinitionKey)
+        .list();
+    assertThat(decisionDefinitions).hasSize(1);
+    repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitions.get(0).getId(), timeToLive);
+  }
+
+  private void completeActiveTask(String processInstanceId) {
+    Task task = taskService.createTaskQuery()
+        .processInstanceId(processInstanceId)
+        .singleResult();
+    assertThat(task).isNotNull();
+    taskService.complete(task.getId());
   }
 
   private void prepareData(int instanceCount) {

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupAParentProcess.bpmn20.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupAParentProcess.bpmn20.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  id="Definitions_1ufbmz7"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="Operaton Modeler"
+                  exporterVersion="5.28.0"
+                  modeler:executionPlatform="Operaton Platform"
+                  modeler:executionPlatformVersion="2.2.0">
+  <bpmn:process id="parentProcess" isExecutable="true">
+    <bpmn:startEvent id="startEvent" />
+    <bpmn:callActivity id="callActivity" calledElement="subProcess" />
+    <bpmn:userTask id="additionalTask" name="Additional Task" />
+    <bpmn:endEvent id="endEvent" />
+    <bpmn:sequenceFlow id="flow1" sourceRef="startEvent" targetRef="callActivity" />
+    <bpmn:sequenceFlow id="flow2" sourceRef="callActivity" targetRef="additionalTask" />
+    <bpmn:sequenceFlow id="flow3" sourceRef="additionalTask" targetRef="endEvent" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupChild.bpmn20.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupChild.bpmn20.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  id="Definitions_10mpax3"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="Operaton Modeler"
+                  exporterVersion="5.28.0"
+                  modeler:executionPlatform="Operaton Platform"
+                  modeler:executionPlatformVersion="2.2.0">
+  <bpmn:process id="subProcess" isExecutable="true">
+    <bpmn:startEvent id="subStartEvent" />
+    <bpmn:userTask id="userTask" name="Approve Task" />
+    <bpmn:userTask id="additionalUserTask" name="Additional Task" />
+    <bpmn:endEvent id="subEndEvent" />
+    <bpmn:sequenceFlow id="flow1" sourceRef="subStartEvent" targetRef="userTask" />
+    <bpmn:sequenceFlow id="flow2" sourceRef="userTask" targetRef="additionalUserTask" />
+    <bpmn:sequenceFlow id="flow3" sourceRef="additionalUserTask" targetRef="subEndEvent" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDecisionTable.dmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDecisionTable.dmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+             xmlns:camunda="http://camunda.org/schema/1.0/dmn"
+             id="definitions"
+             name="definitions"
+             namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decisionTable" name="Decision Table">
+    <decisionTable id="decisionTable_1">
+      <input id="input1" label="Input">
+        <inputExpression id="inputExpression1" typeRef="string">
+          <text>inputVariable</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="Output" name="result" typeRef="string" />
+      <rule id="rule1">
+        <inputEntry id="inputEntry1">
+          <text>"A"</text>
+        </inputEntry>
+        <outputEntry id="outputEntry1">
+          <text>"Result A"</text>
+        </outputEntry>
+      </rule>
+      <rule id="rule2">
+        <inputEntry id="inputEntry2">
+          <text>"B"</text>
+        </inputEntry>
+        <outputEntry id="outputEntry2">
+          <text>"Result B"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDmnParentProcess.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDmnParentProcess.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="parentDMNProcess" name="Parent Process" isExecutable="true">
+    <startEvent id="startEvent" name="Start" />
+    <sequenceFlow id="flow1" sourceRef="startEvent" targetRef="callActivity" />
+    <callActivity id="callActivity" name="Call Subprocess" calledElement="childDmnProcess" />
+    <sequenceFlow id="flow2" sourceRef="callActivity" targetRef="userTask" />
+    <userTask id="userTask" name="User Task" />
+    <sequenceFlow id="flow3" sourceRef="userTask" targetRef="endEvent" />
+    <endEvent id="endEvent" name="End" />
+  </process>
+</definitions>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDmnSubProcess.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.testEndTimeCleanupDmnSubProcess.bpmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+             targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="childDmnProcess" name="Child DMN Process" isExecutable="true">
+    <startEvent id="startEvent" name="Start" />
+    <sequenceFlow id="flow1" sourceRef="startEvent" targetRef="businessRuleTask" />
+    <businessRuleTask id="businessRuleTask" name="DMN Decision" camunda:decisionRef="decisionTable" />
+    <sequenceFlow id="flow2" sourceRef="businessRuleTask" targetRef="endEvent" />
+    <endEvent id="endEvent" name="End" />
+  </process>
+</definitions>


### PR DESCRIPTION
## Summary

This PR backports the Fluxnova history cleanup root-process completion fix to Operaton.

The PR changes end-time-based history cleanup for historic process and decision instances that belong to a root process tree:

- Child process history is not selected for cleanup while the root process instance is still running.
- Decision history produced inside a child/root process tree is not selected while the root process instance is still running.
- Once the root process has completed, cleanup eligibility uses the root end/evaluation time as the effective date instead of cleaning child history only by the child end/evaluation time.

## Reviewer Notes

This is a behavior change in history retention semantics. It prevents cleanup from deleting historic data for completed child executions while their root process is still active, which keeps the process tree inspectable until the root has reached a cleanup-eligible end state.

The Operaton adaptation keeps the change local to the existing end-time cleanup SQL mappings and DB-specific SQL expression registry:

- Adds `${coalesceForEndDate}` as a DB-specific cleanup expression for H2, MySQL-compatible databases, PostgreSQL-compatible databases, Oracle, DB2 and MSSQL.
- Updates `HistoricProcessInstance.xml` cleanup selection to join runtime root execution and historic root process instance state.
- Updates `HistoricDecisionInstance.xml` with the same root-aware cleanup guard for decision instances.
- Adds focused BPMN and DMN tests instead of importing the full upstream test block verbatim.

## Attribution

Backported and adapted from Fluxnova:

- finos/fluxnova-bpm-platform@ac337f50c6d6e96143b8619f71f08cd6cae2b2f6
- finos/fluxnova-bpm-platform@d3dc1efe8579416d5390f0f39f4dbbdc94a9085b

Original author: Bhandari, Prajwol <prajwol.bhandari@fmr.com>

Related Fluxnova issue: https://github.com/finos/fluxnova-bpm-platform/issues/48

No original upstream PR URL was recorded in the backport database for this change unit.

## Backport Database

- CU 347 `feat(engine) update end-time history cleanup strategy to clean up process only on delete of root process instance`: `pr_opened`, linked to this PR and commit `c0e7e1871cb204fea391778b0a897ef9ed7b8972`.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -pl engine -Dtest=HistoryCleanupTest#shouldNotCleanFinishedSubProcessWhenRootProcessIsStillRunning+shouldNotCleanFinishedSubProcessBeforeRootProcessTtlIsReached+shouldCleanFinishedSubProcessAfterRootProcessTtlIsReached+shouldNotCleanDecisionInstanceWhenRootProcessIsStillRunning test`
  - Result: 4 tests, 0 failures, 0 errors, 0 skipped.
- `./mvnw -pl engine -Dtest=HistoryCleanupTest test`
  - Result: 56 tests, 0 failures, 0 errors, 2 skipped.
- Backport DB: `PRAGMA integrity_check` returns `ok`.
