### PR TITLE
feat(engine): support transient BPMN IO parameters

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParseUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParseUtil.java
@@ -135,6 +135,8 @@ public final class BpmnParseUtil {
    */
   public static void parseInputParameterElement(Element inputParameterElement, IoMapping ioMapping) {
     String nameAttribute = inputParameterElement.attribute("name");
+    boolean isTransient = Boolean.parseBoolean(
+        inputParameterElement.attributeNS(BpmnParse.OPERATON_BPMN_EXTENSIONS_NS, "isTransient"));
     if(nameAttribute == null || nameAttribute.isEmpty()) {
       throw new BpmnParseException("Missing attribute 'name' for inputParameter", inputParameterElement);
     }
@@ -142,7 +144,7 @@ public final class BpmnParseUtil {
     ParameterValueProvider valueProvider = parseNestedParamValueProvider(inputParameterElement);
 
     // add parameter
-    ioMapping.addInputParameter(new InputParameter(nameAttribute, valueProvider));
+    ioMapping.addInputParameter(new InputParameter(nameAttribute, valueProvider, isTransient));
   }
 
   /**
@@ -154,6 +156,8 @@ public final class BpmnParseUtil {
    */
   public static void parseOutputParameterElement(Element outputParameterElement, IoMapping ioMapping) {
     String nameAttribute = outputParameterElement.attribute("name");
+    boolean isTransient = Boolean.parseBoolean(
+        outputParameterElement.attributeNS(BpmnParse.OPERATON_BPMN_EXTENSIONS_NS, "isTransient"));
     if(nameAttribute == null || nameAttribute.isEmpty()) {
       throw new BpmnParseException("Missing attribute 'name' for outputParameter", outputParameterElement);
     }
@@ -161,7 +165,7 @@ public final class BpmnParseUtil {
     ParameterValueProvider valueProvider = parseNestedParamValueProvider(outputParameterElement);
 
     // add parameter
-    ioMapping.addOutputParameter(new OutputParameter(nameAttribute, valueProvider));
+    ioMapping.addOutputParameter(new OutputParameter(nameAttribute, valueProvider, isTransient));
   }
 
   /**

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/InputParameter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/InputParameter.java
@@ -41,6 +41,10 @@ public class InputParameter extends IoParameter {
     super(name, valueProvider);
   }
 
+  public InputParameter(String name, ParameterValueProvider valueProvider, boolean isTransient) {
+    super(name, valueProvider, isTransient);
+  }
+
   @Override
   protected void execute(AbstractVariableScope innerScope, AbstractVariableScope outerScope) {
 
@@ -50,7 +54,7 @@ public class InputParameter extends IoParameter {
     LOG.debugMappingValueFromOuterScopeToInnerScope(value,outerScope, name, innerScope);
 
     // set variable in inner scope
-    innerScope.setVariableLocal(name, value);
+    innerScope.setVariableLocal(name, getVariableValue(value));
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/IoParameter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/IoParameter.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.core.variable.mapping;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.core.variable.mapping.value.ParameterValueProvider;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
+import org.operaton.bpm.engine.variable.Variables;
 
 /**
  * An {@link IoParameter} creates a variable
@@ -34,14 +35,21 @@ public abstract class IoParameter {
    */
   protected String name;
 
+  protected boolean isTransient;
+
   /**
    * The provider of the parameter value.
    */
   protected ParameterValueProvider valueProvider;
 
   protected IoParameter(String name, ParameterValueProvider valueProvider) {
+    this(name, valueProvider, false);
+  }
+
+  protected IoParameter(String name, ParameterValueProvider valueProvider, boolean isTransient) {
     this.name = name;
     this.valueProvider = valueProvider;
+    this.isTransient = isTransient;
   }
 
   /**
@@ -56,6 +64,10 @@ public abstract class IoParameter {
    * @param outerScope
    */
   protected abstract void execute(AbstractVariableScope innerScope, AbstractVariableScope outerScope);
+
+  protected Object getVariableValue(Object value) {
+    return isTransient ? Variables.untypedValue(value, true) : value;
+  }
 
   // getters / setters ///////////////////////////
 
@@ -73,6 +85,14 @@ public abstract class IoParameter {
 
   public void setValueProvider(ParameterValueProvider valueProvider) {
     this.valueProvider = valueProvider;
+  }
+
+  public boolean isTransient() {
+    return isTransient;
+  }
+
+  public void setTransient(boolean isTransient) {
+    this.isTransient = isTransient;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/OutputParameter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/OutputParameter.java
@@ -42,6 +42,10 @@ public class OutputParameter extends IoParameter {
     super(name, valueProvider);
   }
 
+  public OutputParameter(String name, ParameterValueProvider valueProvider, boolean isTransient) {
+    super(name, valueProvider, isTransient);
+  }
+
   @Override
   protected void execute(AbstractVariableScope innerScope, AbstractVariableScope outerScope) {
 
@@ -51,7 +55,7 @@ public class OutputParameter extends IoParameter {
     LOG.debugMappingValueFromInnerScopeToOuterScope(value, innerScope, name, outerScope);
 
     // set variable in outer scope
-    outerScope.setVariable(name, value);
+    outerScope.setVariable(name, getVariableValue(value));
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
@@ -36,6 +36,8 @@ import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.delegate.BpmnError;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
+import org.operaton.bpm.engine.delegate.JavaDelegate;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.Job;
@@ -45,6 +47,8 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.variable.type.ValueType;
+import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
@@ -276,6 +280,14 @@ class InputOutputTest {
     assertThat(variable).isNotNull();
     assertThat(variable.getValue()).isEqualTo(2);
     assertThat(variable.getExecutionId()).isEqualTo(execution.getId());
+  }
+
+  @Deployment
+  @Test
+  void testTransientInputParameter() {
+    runtimeService.startProcessInstanceByKey("testProcess");
+
+    assertThat(runtimeService.createVariableInstanceQuery().variableName("var1").count()).isZero();
   }
 
   @Deployment
@@ -836,6 +848,14 @@ class InputOutputTest {
             .containsEntry("b", "tomato");
   }
 
+  @Deployment
+  @Test
+  void testTransientOutputParameter() {
+    runtimeService.startProcessInstanceByKey("testProcess");
+
+    assertThat(runtimeService.createVariableInstanceQuery().variableName("var1").count()).isZero();
+  }
+
   @Deployment(resources = "org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testOutputMapElKey.bpmn")
   @Test
   void testOutputMapElUndefinedKey() {
@@ -1320,5 +1340,25 @@ class InputOutputTest {
     assertThat(variable).isNotNull();
     assertThat(variable.getValue()).isEqualTo("baroque");
     assertThat(variable.getExecutionId()).isEqualTo(pi.getId());
+  }
+
+  public static class SetOutputParameterSourceDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) {
+      execution.setVariableLocal("sourceVar", "stringValue");
+    }
+  }
+
+  public static class AssertTransientVariableDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) {
+      TypedValue typedValue = execution.getVariableTyped("var1");
+      assertThat(typedValue).isNotNull();
+      assertThat(typedValue.getType()).isEqualTo(ValueType.STRING);
+      assertThat(typedValue.isTransient()).isTrue();
+      assertThat(typedValue.getValue()).isEqualTo("stringValue");
+    }
   }
 }

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testTransientInputParameter.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testTransientInputParameter.bpmn20.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 the Operaton contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at:
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             targetNamespace="Examples"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+
+  <process id="testProcess" isExecutable="true">
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="assertTransientInput" />
+    <serviceTask id="assertTransientInput"
+                 operaton:class="org.operaton.bpm.engine.test.bpmn.iomapping.InputOutputTest$AssertTransientVariableDelegate">
+      <extensionElements>
+        <operaton:inputOutput>
+          <operaton:inputParameter name="var1" operaton:isTransient="true">stringValue</operaton:inputParameter>
+        </operaton:inputOutput>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow2" sourceRef="assertTransientInput" targetRef="wait" />
+    <userTask id="wait" />
+    <sequenceFlow id="flow3" sourceRef="wait" targetRef="end" />
+    <endEvent id="end" />
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testTransientOutputParameter.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testTransientOutputParameter.bpmn20.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 the Operaton contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at:
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             targetNamespace="Examples"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+
+  <process id="testProcess" isExecutable="true">
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="setOutputSource" />
+    <serviceTask id="setOutputSource"
+                 operaton:class="org.operaton.bpm.engine.test.bpmn.iomapping.InputOutputTest$SetOutputParameterSourceDelegate">
+      <extensionElements>
+        <operaton:inputOutput>
+          <operaton:outputParameter name="var1" operaton:isTransient="true">${sourceVar}</operaton:outputParameter>
+        </operaton:inputOutput>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow2" sourceRef="setOutputSource" targetRef="assertTransientOutput" />
+    <serviceTask id="assertTransientOutput"
+                 operaton:class="org.operaton.bpm.engine.test.bpmn.iomapping.InputOutputTest$AssertTransientVariableDelegate" />
+    <sequenceFlow id="flow3" sourceRef="assertTransientOutput" targetRef="wait" />
+    <userTask id="wait" />
+    <sequenceFlow id="flow4" sourceRef="wait" targetRef="end" />
+    <endEvent id="end" />
+  </process>
+
+</definitions>

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelConstants.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelConstants.java
@@ -461,6 +461,7 @@ public final class BpmnModelConstants {
   public static final String OPERATON_ATTRIBUTE_LABEL = "label";
   public static final String OPERATON_ATTRIBUTE_LOCAL = "local";
   public static final String OPERATON_ATTRIBUTE_MAP_DECISION_RESULT = "mapDecisionResult";
+  public static final String OPERATON_ATTRIBUTE_IS_TRANSIENT = "isTransient";
   public static final String OPERATON_ATTRIBUTE_NAME = "name";
   public static final String OPERATON_ATTRIBUTE_PRIORITY = "priority";
   public static final String OPERATON_ATTRIBUTE_READABLE = "readable";

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/operaton/OperatonInputParameterImpl.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/operaton/OperatonInputParameterImpl.java
@@ -22,6 +22,7 @@ import org.operaton.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.operaton.bpm.model.xml.type.ModelElementTypeBuilder;
 import org.operaton.bpm.model.xml.type.attribute.Attribute;
 
+import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_ATTRIBUTE_IS_TRANSIENT;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_ATTRIBUTE_NAME;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_ELEMENT_INPUT_PARAMETER;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
@@ -34,6 +35,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 public class OperatonInputParameterImpl extends OperatonGenericValueElementImpl implements OperatonInputParameter {
 
   protected static Attribute<String> operatonNameAttribute;
+  protected static Attribute<Boolean> operatonTransientAttribute;
 
   public static void registerType(ModelBuilder modelBuilder) {
     ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(OperatonInputParameter.class, OPERATON_ELEMENT_INPUT_PARAMETER)
@@ -43,6 +45,11 @@ public class OperatonInputParameterImpl extends OperatonGenericValueElementImpl 
     operatonNameAttribute = typeBuilder.stringAttribute(OPERATON_ATTRIBUTE_NAME)
       .namespace(OPERATON_NS)
       .required()
+      .build();
+
+    operatonTransientAttribute = typeBuilder.booleanAttribute(OPERATON_ATTRIBUTE_IS_TRANSIENT)
+      .namespace(OPERATON_NS)
+      .defaultValue(false)
       .build();
 
     typeBuilder.build();
@@ -60,6 +67,16 @@ public class OperatonInputParameterImpl extends OperatonGenericValueElementImpl 
   @Override
   public void setOperatonName(String operatonName) {
     operatonNameAttribute.setValue(this, operatonName);
+  }
+
+  @Override
+  public boolean isOperatonTransient() {
+    return operatonTransientAttribute.getValue(this);
+  }
+
+  @Override
+  public void setOperatonTransient(boolean isTransient) {
+    operatonTransientAttribute.setValue(this, isTransient);
   }
 
 }

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/operaton/OperatonOutputParameterImpl.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/operaton/OperatonOutputParameterImpl.java
@@ -22,6 +22,7 @@ import org.operaton.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.operaton.bpm.model.xml.type.ModelElementTypeBuilder;
 import org.operaton.bpm.model.xml.type.attribute.Attribute;
 
+import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_ATTRIBUTE_IS_TRANSIENT;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_ATTRIBUTE_NAME;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_ELEMENT_OUTPUT_PARAMETER;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
@@ -34,6 +35,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 public class OperatonOutputParameterImpl extends OperatonGenericValueElementImpl implements OperatonOutputParameter {
 
   protected static Attribute<String> operatonNameAttribute;
+  protected static Attribute<Boolean> operatonTransientAttribute;
 
   public static void registerType(ModelBuilder modelBuilder) {
     ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(OperatonOutputParameter.class, OPERATON_ELEMENT_OUTPUT_PARAMETER)
@@ -43,6 +45,11 @@ public class OperatonOutputParameterImpl extends OperatonGenericValueElementImpl
     operatonNameAttribute = typeBuilder.stringAttribute(OPERATON_ATTRIBUTE_NAME)
       .namespace(OPERATON_NS)
       .required()
+      .build();
+
+    operatonTransientAttribute = typeBuilder.booleanAttribute(OPERATON_ATTRIBUTE_IS_TRANSIENT)
+      .namespace(OPERATON_NS)
+      .defaultValue(false)
       .build();
 
     typeBuilder.build();
@@ -60,5 +67,15 @@ public class OperatonOutputParameterImpl extends OperatonGenericValueElementImpl
   @Override
   public void setOperatonName(String operatonName) {
     operatonNameAttribute.setValue(this, operatonName);
+  }
+
+  @Override
+  public boolean isOperatonTransient() {
+    return operatonTransientAttribute.getValue(this);
+  }
+
+  @Override
+  public void setOperatonTransient(boolean isTransient) {
+    operatonTransientAttribute.setValue(this, isTransient);
   }
 }

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameter.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameter.java
@@ -29,4 +29,8 @@ public interface OperatonInputParameter extends BpmnModelElementInstance, Operat
 
   void setOperatonName(String operatonName);
 
+  boolean isOperatonTransient();
+
+  void setOperatonTransient(boolean isTransient);
+
 }

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameter.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameter.java
@@ -29,4 +29,8 @@ public interface OperatonOutputParameter extends BpmnModelElementInstance, Opera
 
   void setOperatonName(String operatonName);
 
+  boolean isOperatonTransient();
+
+  void setOperatonTransient(boolean isTransient);
+
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
 
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
@@ -44,7 +45,21 @@ class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {
-    return List.of(new AttributeAssumption(OPERATON_NS, "name", false, true));
+    return List.of(
+      new AttributeAssumption(OPERATON_NS, "name", false, true),
+      new AttributeAssumption(OPERATON_NS, "isTransient", false, false, false)
+    );
+  }
+
+  @Test
+  void testOperatonTransientAttribute() {
+    OperatonInputParameter inputParamElement = modelInstance.newInstance(OperatonInputParameter.class);
+
+    assertThat(inputParamElement.isOperatonTransient()).isFalse();
+
+    inputParamElement.setOperatonTransient(true);
+
+    assertThat(inputParamElement.isOperatonTransient()).isTrue();
   }
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
 
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
@@ -44,7 +45,21 @@ class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {
-    return List.of(new AttributeAssumption(OPERATON_NS, "name", false, true));
+    return List.of(
+      new AttributeAssumption(OPERATON_NS, "name", false, true),
+      new AttributeAssumption(OPERATON_NS, "isTransient", false, false, false)
+    );
+  }
+
+  @Test
+  void testOperatonTransientAttribute() {
+    OperatonOutputParameter outputParamElement = modelInstance.newInstance(OperatonOutputParameter.class);
+
+    assertThat(outputParamElement.isOperatonTransient()).isFalse();
+
+    outputParamElement.setOperatonTransient(true);
+
+    assertThat(outputParamElement.isOperatonTransient()).isTrue();
   }
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")


### PR DESCRIPTION
## Summary

This PR backports the Fluxnova transient BPMN IO parameter support to Operaton.

It adds `operaton:isTransient="true"` handling for `operaton:inputParameter` and `operaton:outputParameter` mappings. When the attribute is present, the mapped value is set through `Variables.untypedValue(value, true)`, so the created variable is transient and is not persisted to runtime variable storage or history.

The BPMN model API is updated as well: `OperatonInputParameter` and `OperatonOutputParameter` now expose `isOperatonTransient()` / `setOperatonTransient(boolean)` for the same `operaton:isTransient` attribute.

## Change unit

- `361` [fluxnova:a1b817ba818e] add support for transient input and output parameters in BPMN model

## Attribution

Backported-adapted from Fluxnova commit `a1b817ba818ecf2bff618a134602a29e23704fab`.

Original author: Sowmya, HL <Sowmya.HL@fmr.com>

## Reviewer Notes

- Fluxnova parses the attribute from the Camunda namespace; this Operaton adaptation uses `BpmnParse.OPERATON_BPMN_EXTENSIONS_NS` and the `operaton:isTransient` model constant.
- The implementation keeps the existing non-transient IO mapping path unchanged. Only parameters explicitly marked with `operaton:isTransient="true"` are wrapped as transient typed values.
- `Variables.untypedValue(value, true)` preserves existing `TypedValue` instances by updating their transient flag rather than nesting them as plain Java objects.
- Runtime tests cover both directions:
  - transient input parameter: the service task receives a transient variable created by the BPMN input parameter.
  - transient output parameter: the following service task receives a transient variable created by the BPMN output parameter.
- Both runtime tests also assert that the mapped variable is not present in the persisted variable-instance query after execution reaches the wait state.
- Model API tests cover the new attribute default (`false`) and setter/getter behavior on input and output parameters.

## Verification

- `./mvnw -pl engine -Dtest=InputOutputTest#testTransientInputParameter+testTransientOutputParameter test -Dskip.frontend.build=true`
- `./mvnw -pl model-api/bpmn-model -Dtest=OperatonInputParameterTest,OperatonOutputParameterTest test -Dskip.frontend.build=true`