### PR TITLE
build(rest): move OpenAPI docs out of default reactor

### DIFF
--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -33,10 +33,18 @@
 
   <modules>
     <module>engine-rest</module>
-    <module>engine-rest-openapi</module>
-    <module>engine-rest-openapi-generator</module>
     <module>assembly</module>
-    <module>docs</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>docs-engine-rest-openapi</id>
+      <modules>
+        <module>engine-rest-openapi</module>
+        <module>engine-rest-openapi-generator</module>
+        <module>docs</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
## Summary

Backports an Operaton-adapted version of CIBSeven's build change that removes REST OpenAPI/docs generation from the default `engine-rest` reactor.

After this change, the default `engine-rest` reactor builds only:

- `engine-rest`
- `assembly`

The OpenAPI generator, OpenAPI docs module, and REST docs module remain available through the explicit Maven profile `docs-engine-rest-openapi`.

## What Changes

The following modules move out of the default `<modules>` list in `engine-rest/pom.xml` and into the new profile:

- `engine-rest-openapi`
- `engine-rest-openapi-generator`
- `docs`

This keeps normal REST builds lighter while preserving a deliberate path for docs/OpenAPI generation.

## Scope

This PR intentionally implements only the CIBSeven build-profile change from commit `4fc37876a161786d26222d05dbf511d65d31d481`.

The earlier discussion PR also grouped large Fluxnova OpenAPI/template/generated-source and source-jar packaging changes. Those are intentionally not included here and remain tracked separately as `needs_design` in the backport database.

## Attribution

Backport adapted from CIBSeven:

- Source commit: `4fc37876a161786d26222d05dbf511d65d31d481`
- Source subject: `chore(pom): exclude open api docs generation from default build`
- Original author: Serge Krot <serge.krot@cib.de>

## Reviewer Notes

This is a build policy change, not a runtime fix. Reviewers should decide whether Operaton wants OpenAPI/docs generation outside the default `engine-rest` reactor. The profile keeps the modules available explicitly via `-Pdocs-engine-rest-openapi`.

## Verification

```bash
./mvnw -f engine-rest/pom.xml validate -DskipTests
./mvnw -f engine-rest/pom.xml -Pdocs-engine-rest-openapi validate -DskipTests
```

Both commands pass. The first reactor contains 3 modules; the profile reactor contains 6 modules including OpenAPI and docs.
