### PR TITLE
build(engine): make GraalJS dependencies available outside tests

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -334,19 +334,16 @@
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>js</artifactId>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary

This PR shows the Operaton-adapted version of the CIBSeven GraalJS dependency-scope change.

CIBSeven removed `test` scope from the engine JavaScript dependency so JavaScript engine classes are available from the engine artifact. Operaton no longer uses the exact same dependency coordinates; this PR applies the equivalent change to the current Graal dependencies:

- `org.graalvm.polyglot:js`
- `org.graalvm.polyglot:polyglot`
- `org.graalvm.js:js-scriptengine`

## Change unit

- `815` [cibseven:3d7da980f4f7] update pom for engine: enable js

## Attribution

Backported-adapted from CIBSeven commit `3d7da980f4f752f8a1fdb29917e217b350b5c092`.

Original author: vladimirg <vladimir.gribko@cib.de>

## Reviewer notes

The review decision is whether the engine artifact itself should carry GraalJS runtime dependencies, or whether JavaScript support should remain distro/runtime-provided. This PR makes the concrete dependency impact visible.

## Verification

- `git diff --check origin/main...HEAD`
- `./mvnw -pl engine -DskipTests install -Dskip.frontend.build=true`
