### PR TITLE
test(qa): verify SQL create/drop index symmetry

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -115,7 +115,7 @@
         <database.datasource.class>com.ibm.db2.jcc.DB2SimpleDataSource</database.datasource.class>
         <jboss.datasource.filename>db2-ds.xml</jboss.datasource.filename>
         <database.tc.url>operatondb2:12.1.2.0</database.tc.url>
-        <database.tc.params>/${database.name}</database.tc.params>
+        <database.tc.params>/${database.name}?TC_DAEMON=true</database.tc.params>
         <database.url>jdbc:tc:${database.tc.url}://localhost:${database.port}${database.tc.params}</database.url>
       </properties>
       <dependencies>

--- a/distro/sql-script/src/test/java/org/operaton/bpm/sql/test/SqlScriptTest.java
+++ b/distro/sql-script/src/test/java/org/operaton/bpm/sql/test/SqlScriptTest.java
@@ -214,6 +214,12 @@ class SqlScriptTest {
     String databaseUser = properties.getProperty("database.username");
     String databasePassword = properties.getProperty("database.password");
     String databaseClass = properties.getProperty("database.driver");
+    if (databaseUrl != null) {
+      databaseUrl = databaseUrl.replace("&amp;", "&");
+    }
+    if (databaseUrl != null && databaseUrl.startsWith("jdbc:tc:")) {
+      databaseClass = "org.testcontainers.jdbc.ContainerDatabaseDriver";
+    }
     return DatabaseFactory.getInstance().openDatabase(databaseUrl, databaseUser, databasePassword, databaseClass, null,
         null, null, new ClassLoaderResourceAccessor());
   }

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -55,6 +55,7 @@
   </dependencyManagement>
   <modules>
     <module>ensure-clean-db-plugin</module>
+    <module>test-db-indexes-in-scripts</module>
     <module>arquillian-extensions</module>
     <module>load-test</module>
   </modules>

--- a/qa/test-db-indexes-in-scripts/pom.xml
+++ b/qa/test-db-indexes-in-scripts/pom.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>operaton-qa</artifactId>
+    <groupId>org.operaton.bpm.qa</groupId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>operaton-qa-indexes-in-sql</artifactId>
+  <name>Operaton - QA - Check indexes in SQL scripts</name>
+  <description>${project.name}</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sql-scripts-index-checker</id>
+            <phase>test</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <classpathScope>test</classpathScope>
+              <mainClass>org.operaton.bpm.engine.database.IndexChecker</mainClass>
+              <arguments>
+                <argument>${project.basedir}/../../engine/src/main/resources/org/operaton/bpm/engine/db/create</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/qa/test-db-indexes-in-scripts/src/main/java/org/operaton/bpm/engine/database/IndexChecker.java
+++ b/qa/test-db-indexes-in-scripts/src/main/java/org/operaton/bpm/engine/database/IndexChecker.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.database;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public final class IndexChecker {
+
+  private static final Pattern CREATE_INDEX_PATTERN =
+      Pattern.compile("^\\s*create\\s+(unique\\s+)?index\\s+(\\S+).*", Pattern.CASE_INSENSITIVE);
+  private static final Pattern DROP_INDEX_PATTERN =
+      Pattern.compile("^\\s*drop\\s+index\\s+([^.]+\\.)?([^ ;]+).*", Pattern.CASE_INSENSITIVE);
+
+  private IndexChecker() {
+  }
+
+  public static void main(String[] args) throws IOException {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Must provide exactly one argument: <folder to SQL create scripts>");
+    }
+
+    Path createDir = Path.of(args[0]);
+    Path dropDir = createDir.resolveSibling("drop");
+
+    try (Stream<Path> createScripts = Files.walk(createDir)) {
+      createScripts
+          .filter(path -> path.toString().endsWith(".sql"))
+          .forEach(createScript -> checkMatchingDropScript(createDir, dropDir, createScript));
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static void checkMatchingDropScript(Path createDir, Path dropDir, Path createScript) {
+    Path dropScript = matchingDropScript(createDir, dropDir, createScript);
+
+    try {
+      Set<String> createdIndexes = extractIndexes(createScript, CREATE_INDEX_PATTERN, 2);
+      Set<String> droppedIndexes = extractIndexes(dropScript, DROP_INDEX_PATTERN, 2);
+
+      if (!createdIndexes.equals(droppedIndexes)) {
+        throw new IllegalStateException("""
+            Found index difference for:
+            %s
+            %s
+            Created indexes: %s
+            Dropped indexes: %s
+            """.formatted(createScript, dropScript, createdIndexes, droppedIndexes));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Error processing SQL scripts: " + createScript + " and " + dropScript, e);
+    }
+  }
+
+  private static Path matchingDropScript(Path createDir, Path dropDir, Path createScript) {
+    Path relativeCreateScript = createDir.relativize(createScript);
+    String dropFileName = relativeCreateScript.getFileName().toString().replace(".create.", ".drop.");
+    return dropDir.resolve(relativeCreateScript).resolveSibling(dropFileName);
+  }
+
+  private static Set<String> extractIndexes(Path scriptPath, Pattern pattern, int valueIndex) throws IOException {
+    if (!Files.exists(scriptPath)) {
+      throw new IOException("SQL script does not exist: " + scriptPath);
+    }
+
+    Set<String> indexes = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    try (BufferedReader reader = Files.newBufferedReader(scriptPath)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String indexName = extractIndexName(line, pattern, valueIndex);
+        if (indexName != null) {
+          indexes.add(indexName.toLowerCase(Locale.ROOT));
+        }
+      }
+    }
+
+    return indexes;
+  }
+
+  private static String extractIndexName(String input, Pattern pattern, int valueIndex) {
+    Matcher matcher = pattern.matcher(input);
+    if (matcher.matches()) {
+      return matcher.group(valueIndex);
+    }
+    return null;
+  }
+
+}


### PR DESCRIPTION
## Summary

Backports an Operaton-adapted version of CIBSeven's SQL script QA checks.

This PR adds a small QA module that runs during the module's Maven `test` phase and verifies that every index created by the engine SQL create scripts is also dropped by the matching SQL drop script.

It also adapts the SQL-script test setup for Testcontainers JDBC URLs:

- `jdbc:tc:` URLs now use `org.testcontainers.jdbc.ContainerDatabaseDriver`.
- Filtered `&amp;` URL parameters are unescaped before Liquibase opens the database.
- The DB2 Testcontainers URL keeps the container alive for the test lifecycle via `TC_DAEMON=true`.

## Operaton Adaptation

The original CIBSeven change removed a Jenkins shell check and replaced it with a Maven-backed Java checker. Operaton does not have the same `.ci` Jenkins files, so this backport only adds the Maven QA module and Java checker.

The new checker uses Operaton package names and an Operaton new-file license header. The `exec-maven-plugin` version is not pinned in the module because Operaton already manages it centrally.

## Attribution

Backport adapted from CIBSeven:

- CIBSeven PR: cibseven/cibseven#5
- Source commit: `9501defa42b8b5730d131fd6b04e5f9be5032d23`
- Source subject: `feat: check sql-indexes in create/drop sql-files during maven test (#5)`
- Original author: Serge Krot <serge.krot@cib.de>

And from CIBSeven:

- CIBSeven PR: cibseven/cibseven#305
- Source commit: `8733fb3a7590721ad18295b7335f019f709090eb`
- Source subject: `chore(test): allow sql-scripts testing with using testcontainers (#305)`
- Original author: Vladimir Gribko <156691737+vladgrind@users.noreply.github.com>

## Reviewer Notes

The new QA module is intentionally small and deterministic: it scans the checked-in engine SQL create/drop scripts directly and does not require Docker or a running database.

The SQL-script Testcontainers adjustments are included because they are part of the same CIBSeven QA path: when SQL-script tests are executed against `jdbc:tc:` database URLs, Liquibase must see a real `&`-separated URL and the Testcontainers JDBC driver class.

## Verification

```bash
./mvnw -pl qa/test-db-indexes-in-scripts test
./mvnw -pl distro/sql-script test-compile
```

Both commands pass.

I also tried:

```bash
./mvnw -pl distro/sql-script -Pcheck-sql test
```

That currently stops before executing the changed test logic because Maven cannot resolve the existing old SQL script artifact `org.operaton.bpm.distro:operaton-sql-scripts:jar:1.0.0` from the configured repositories.
