### PR TITLE
feat(engine-rest): add bulk deployment delete endpoint

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentResponse.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentResponse.ftl
@@ -1,0 +1,21 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto>
+
+    <@lib.property
+        name = "deploymentId"
+        type = "string"
+        desc = "The id of the deployment." />
+
+    <@lib.property
+        name = "status"
+        type = "string"
+        desc = "The status of the delete operation. Value is `SUCCESS` or `FAILURE`." />
+
+    <@lib.property
+        name = "errorMessage"
+        type = "string"
+        last = true
+        desc = "The error details if the delete operation failed." />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentsDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentsDto.ftl
@@ -1,0 +1,26 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto>
+
+    <@lib.property
+        name = "deploymentIds"
+        type = "array"
+        desc = "The list of deployment ids to be deleted." />
+
+    <@lib.property
+        name = "cascade"
+        type = "boolean"
+        desc = "A flag indicating if all process instances, historic process instances and jobs for this deployment should be deleted." />
+
+    <@lib.property
+        name = "skipCustomListeners"
+        type = "boolean"
+        desc = "A flag indicating if only the built-in ExecutionListeners should be notified with the end event." />
+
+    <@lib.property
+        name = "skipIoMappings"
+        type = "boolean"
+        last = true
+        desc = "A flag indicating if all input/output mappings should not be invoked." />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/deployment/delete/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/deployment/delete/post.ftl
@@ -57,7 +57,7 @@
                        "value": [
                          {
                            "status": "FAILURE",
-                           "errorMessage": "Deployment with id \u0027aDeploymentId\u0027 does not exist",
+                           "errorMessage": "Deployment with id \'aDeploymentId\' does not exist",
                            "deploymentId": "aDeploymentId"
                          },
                          {

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/deployment/delete/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/deployment/delete/post.ftl
@@ -1,0 +1,74 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "deleteDeployments"
+      tag = "Deployment"
+      summary = "Delete Deployments"
+      desc = "Deletes a list of deployments by the given ids." />
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "DeleteDeploymentsDto"
+      examples = [
+      '"example-1": {
+            "summary": "POST /delete",
+            "value": {
+              "deploymentIds": [
+                "deploymentId1",
+                "deploymentId2"
+              ],
+              "skipCustomListeners": true,
+              "skipIoMappings": true,
+              "cascade": true
+            }
+        }']
+  />
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        desc = "Request successful."
+        dto = "DeleteDeploymentResponse"
+        array = true
+        examples = ['"example-1": {
+                       "summary": "Status 200 Response",
+                       "value": [
+                         {
+                           "status": "SUCCESS",
+                           "errorMessage": null,
+                           "deploymentId": "aDeploymentId"
+                         },
+                         {
+                           "status": "SUCCESS",
+                           "errorMessage": null,
+                           "deploymentId": "anotherDeploymentId"
+                         }
+                       ]
+                     }'] />
+
+    <@lib.response
+        code = "207"
+        desc = "Multi-Status: Indicates that at least one delete operation has failed."
+        dto = "DeleteDeploymentResponse"
+        array = true
+        examples = ['"example-1": {
+                       "summary": "Status 207 Response",
+                       "value": [
+                         {
+                           "status": "FAILURE",
+                           "errorMessage": "Deployment with id \u0027aDeploymentId\u0027 does not exist",
+                           "deploymentId": "aDeploymentId"
+                         },
+                         {
+                           "status": "SUCCESS",
+                           "errorMessage": null,
+                           "deploymentId": "anotherDeploymentId"
+                         }
+                       ]
+                     }'] />
+
+    <@lib.errorResponses docsUrl=docsUrl last = true />
+  }
+}
+</#macro>

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/DeploymentRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/DeploymentRestService.java
@@ -21,9 +21,11 @@ import java.util.Set;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
+import org.operaton.bpm.engine.rest.dto.repository.DeleteDeploymentsDto;
 import org.operaton.bpm.engine.rest.dto.repository.DeploymentDto;
 import org.operaton.bpm.engine.rest.mapper.MultipartFormData;
 import org.operaton.bpm.engine.rest.sub.repository.DeploymentResource;
@@ -57,5 +59,11 @@ public interface DeploymentRestService {
   @Path("/registered")
   @Produces(MediaType.APPLICATION_JSON)
   Set<String> getRegisteredDeployments(@Context UriInfo uriInfo);
+
+  @POST
+  @Path("/delete")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  Response deleteDeployments(DeleteDeploymentsDto deleteDeploymentsDto);
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto.repository;
+
+public class DeleteDeploymentResponse {
+
+  public static final String SUCCESS = "SUCCESS";
+  public static final String FAILURE = "FAILURE";
+
+  protected String deploymentId;
+  protected String status;
+  protected String errorMessage;
+
+  public DeleteDeploymentResponse() {
+  }
+
+  public DeleteDeploymentResponse(String deploymentId, String status, String errorMessage) {
+    this.deploymentId = deploymentId;
+    this.status = status;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getDeploymentId() {
+    return deploymentId;
+  }
+
+  public void setDeploymentId(String deploymentId) {
+    this.deploymentId = deploymentId;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public boolean hasFailed() {
+    return FAILURE.equals(status);
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentsDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/repository/DeleteDeploymentsDto.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto.repository;
+
+import java.util.List;
+
+public class DeleteDeploymentsDto {
+
+  protected List<String> deploymentIds;
+  protected boolean cascade;
+  protected boolean skipCustomListeners;
+  protected boolean skipIoMappings;
+
+  public List<String> getDeploymentIds() {
+    return deploymentIds;
+  }
+
+  public void setDeploymentIds(List<String> deploymentIds) {
+    this.deploymentIds = deploymentIds;
+  }
+
+  public boolean isCascade() {
+    return cascade;
+  }
+
+  public void setCascade(boolean cascade) {
+    this.cascade = cascade;
+  }
+
+  public boolean isSkipCustomListeners() {
+    return skipCustomListeners;
+  }
+
+  public void setSkipCustomListeners(boolean skipCustomListeners) {
+    this.skipCustomListeners = skipCustomListeners;
+  }
+
+  public boolean isSkipIoMappings() {
+    return skipIoMappings;
+  }
+
+  public void setSkipIoMappings(boolean skipIoMappings) {
+    this.skipIoMappings = skipIoMappings;
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/DeploymentRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/DeploymentRestServiceImpl.java
@@ -22,13 +22,16 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriInfo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.impl.calendar.DateTimeUtil;
 import org.operaton.bpm.engine.repository.Deployment;
 import org.operaton.bpm.engine.repository.DeploymentBuilder;
@@ -36,6 +39,8 @@ import org.operaton.bpm.engine.repository.DeploymentQuery;
 import org.operaton.bpm.engine.repository.DeploymentWithDefinitions;
 import org.operaton.bpm.engine.rest.DeploymentRestService;
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
+import org.operaton.bpm.engine.rest.dto.repository.DeleteDeploymentResponse;
+import org.operaton.bpm.engine.rest.dto.repository.DeleteDeploymentsDto;
 import org.operaton.bpm.engine.rest.dto.repository.DeploymentDto;
 import org.operaton.bpm.engine.rest.dto.repository.DeploymentQueryDto;
 import org.operaton.bpm.engine.rest.dto.repository.DeploymentWithDefinitionsDto;
@@ -47,6 +52,8 @@ import org.operaton.bpm.engine.rest.sub.repository.impl.DeploymentResourceImpl;
 import org.operaton.bpm.engine.rest.util.QueryUtil;
 
 public class DeploymentRestServiceImpl extends AbstractRestProcessEngineAware implements DeploymentRestService {
+
+  protected static final int MULTI_STATUS_CODE = 207;
 
   public static final String DEPLOYMENT_NAME = "deployment-name";
   public static final String DEPLOYMENT_ACTIVATION_TIME = "deployment-activation-time";
@@ -198,5 +205,48 @@ public class DeploymentRestServiceImpl extends AbstractRestProcessEngineAware im
   @Override
   public Set<String> getRegisteredDeployments(final UriInfo uriInfo) {
     return getProcessEngine().getManagementService().getRegisteredDeployments();
+  }
+
+  @Override
+  public Response deleteDeployments(DeleteDeploymentsDto deleteDeploymentsDto) {
+    if (deleteDeploymentsDto == null || deleteDeploymentsDto.getDeploymentIds() == null) {
+      throw new InvalidRequestException(Status.BAD_REQUEST, "No deployment ids provided.");
+    }
+
+    boolean cascade = deleteDeploymentsDto.isCascade();
+    boolean skipCustomListeners = deleteDeploymentsDto.isSkipCustomListeners();
+    boolean skipIoMappings = deleteDeploymentsDto.isSkipIoMappings();
+
+    List<DeleteDeploymentResponse> responses = deleteDeploymentsDto.getDeploymentIds()
+      .stream()
+      .map(deploymentId -> deleteDeployment(deploymentId, cascade, skipCustomListeners, skipIoMappings))
+      .collect(Collectors.toList());
+
+    boolean hasFailures = responses.stream().anyMatch(DeleteDeploymentResponse::hasFailed);
+
+    if (hasFailures) {
+      return Response.status(MULTI_STATUS_CODE).entity(responses).build();
+    }
+
+    return Response.status(Status.OK).entity(responses).build();
+  }
+
+  private DeleteDeploymentResponse deleteDeployment(String deploymentId, boolean cascade, boolean skipCustomListeners, boolean skipIoMappings) {
+    RepositoryService repositoryService = getProcessEngine().getRepositoryService();
+
+    try {
+      verifyDeploymentExists(deploymentId, repositoryService);
+      repositoryService.deleteDeployment(deploymentId, cascade, skipCustomListeners, skipIoMappings);
+      return new DeleteDeploymentResponse(deploymentId, DeleteDeploymentResponse.SUCCESS, null);
+    } catch (Exception e) {
+      return new DeleteDeploymentResponse(deploymentId, DeleteDeploymentResponse.FAILURE, e.getMessage());
+    }
+  }
+
+  private void verifyDeploymentExists(String deploymentId, RepositoryService repositoryService) {
+    Deployment deployment = repositoryService.createDeploymentQuery().deploymentId(deploymentId).singleResult();
+    if (deployment == null) {
+      throw new InvalidRequestException(Status.NOT_FOUND, "Deployment with id '%s' does not exist".formatted(deploymentId));
+    }
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -65,6 +65,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
   protected static final String SINGLE_RESOURCE_DATA_URL = SINGLE_RESOURCE_URL + "/data";
   protected static final String CREATE_DEPLOYMENT_URL = RESOURCE_URL + "/create";
   protected static final String REDEPLOY_DEPLOYMENT_URL = DEPLOYMENT_URL + "/redeploy";
+  protected static final String DEPLOYMENT_DELETE_DEPLOYMENTS_URL = RESOURCE_URL + "/delete";
+  protected static final int MULTI_STATUS_CODE = 207;
 
   protected RepositoryService mockRepositoryService;
   protected Deployment mockDeployment;
@@ -1892,6 +1894,116 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .body("message", is(message))
     .when()
       .post(REDEPLOY_DEPLOYMENT_URL);
+  }
+
+  @Test
+  void testDeleteDeployments() {
+    Map<String, Object> requestBody = createDeleteDeploymentsRequest(List.of(EXAMPLE_DEPLOYMENT_ID), true, true, true);
+
+    Response response = given()
+      .body(requestBody)
+      .contentType(POST_JSON_CONTENT_TYPE)
+    .expect()
+      .statusCode(Status.OK.getStatusCode())
+      .contentType(ContentType.JSON)
+    .when()
+      .post(DEPLOYMENT_DELETE_DEPLOYMENTS_URL);
+
+    JsonPath path = response.jsonPath();
+    assertThat(path.<String>getList("deploymentId")).containsExactly(EXAMPLE_DEPLOYMENT_ID);
+    assertThat(path.<String>getList("status")).containsExactly("SUCCESS");
+    assertThat(path.getList("errorMessage")).containsExactly((Object) null);
+
+    verify(mockRepositoryService).deleteDeployment(EXAMPLE_DEPLOYMENT_ID, true, true, true);
+  }
+
+  @Test
+  void testDeleteDeploymentsAllFailures() {
+    String invalidDeploymentIdOne = "invalidDeploymentIdOne";
+    String invalidDeploymentIdTwo = "invalidDeploymentIdTwo";
+    Map<String, Object> requestBody = createDeleteDeploymentsRequest(List.of(invalidDeploymentIdOne, invalidDeploymentIdTwo), false, false, false);
+
+    when(mockDeploymentQuery.deploymentId(anyString())).thenReturn(mockDeploymentQuery);
+    when(mockDeploymentQuery.singleResult()).thenReturn(null);
+
+    Response response = given()
+      .body(requestBody)
+      .contentType(POST_JSON_CONTENT_TYPE)
+    .expect()
+      .statusCode(MULTI_STATUS_CODE)
+      .contentType(ContentType.JSON)
+    .when()
+      .post(DEPLOYMENT_DELETE_DEPLOYMENTS_URL);
+
+    JsonPath path = response.jsonPath();
+    assertThat(path.<String>getList("deploymentId")).containsExactly(invalidDeploymentIdOne, invalidDeploymentIdTwo);
+    assertThat(path.<String>getList("status")).containsExactly("FAILURE", "FAILURE");
+    assertThat(path.<String>getList("errorMessage"))
+      .containsExactly("Deployment with id '%s' does not exist".formatted(invalidDeploymentIdOne),
+        "Deployment with id '%s' does not exist".formatted(invalidDeploymentIdTwo));
+
+    verify(mockRepositoryService, never()).deleteDeployment(anyString(), anyBoolean(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  void testDeleteDeploymentsPartialFailures() {
+    String invalidDeploymentId = "invalidDeploymentId";
+    Map<String, Object> requestBody = createDeleteDeploymentsRequest(List.of(EXAMPLE_DEPLOYMENT_ID, invalidDeploymentId), false, false, false);
+
+    when(mockDeploymentQuery.deploymentId(anyString())).thenReturn(mockDeploymentQuery);
+    when(mockDeploymentQuery.singleResult()).thenReturn(mockDeployment).thenReturn(null);
+
+    Response response = given()
+      .body(requestBody)
+      .contentType(POST_JSON_CONTENT_TYPE)
+    .expect()
+      .statusCode(MULTI_STATUS_CODE)
+      .contentType(ContentType.JSON)
+    .when()
+      .post(DEPLOYMENT_DELETE_DEPLOYMENTS_URL);
+
+    JsonPath path = response.jsonPath();
+    assertThat(path.<String>getList("deploymentId")).containsExactly(EXAMPLE_DEPLOYMENT_ID, invalidDeploymentId);
+    assertThat(path.<String>getList("status")).containsExactly("SUCCESS", "FAILURE");
+    assertThat(path.getList("errorMessage")).containsExactly(null, "Deployment with id '%s' does not exist".formatted(invalidDeploymentId));
+
+    verify(mockRepositoryService).deleteDeployment(EXAMPLE_DEPLOYMENT_ID, false, false, false);
+  }
+
+  @Test
+  void testDeleteDeploymentsAuthorizationException() {
+    String message = "missing authorization";
+    Map<String, Object> requestBody = createDeleteDeploymentsRequest(List.of(EXAMPLE_DEPLOYMENT_ID), false, false, false);
+
+    doThrow(new AuthorizationException(message))
+      .when(mockRepositoryService)
+      .deleteDeployment(EXAMPLE_DEPLOYMENT_ID, false, false, false);
+
+    Response response = given()
+      .body(requestBody)
+      .contentType(POST_JSON_CONTENT_TYPE)
+    .expect()
+      .statusCode(MULTI_STATUS_CODE)
+      .contentType(ContentType.JSON)
+    .when()
+      .post(DEPLOYMENT_DELETE_DEPLOYMENTS_URL);
+
+    JsonPath path = response.jsonPath();
+    assertThat(path.<String>getList("deploymentId")).containsExactly(EXAMPLE_DEPLOYMENT_ID);
+    assertThat(path.<String>getList("status")).containsExactly("FAILURE");
+    assertThat(path.<String>getList("errorMessage")).containsExactly(message);
+
+    verify(mockRepositoryService).deleteDeployment(EXAMPLE_DEPLOYMENT_ID, false, false, false);
+  }
+
+  private Map<String, Object> createDeleteDeploymentsRequest(List<String> deploymentIds, boolean cascade,
+      boolean skipCustomListeners, boolean skipIoMappings) {
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("deploymentIds", deploymentIds);
+    requestBody.put("cascade", cascade);
+    requestBody.put("skipCustomListeners", skipCustomListeners);
+    requestBody.put("skipIoMappings", skipIoMappings);
+    return requestBody;
   }
 
   private void verifyDeployment(Deployment mockDeployment, Response response) {


### PR DESCRIPTION
## Summary

This PR backports Fluxnova's bulk deployment delete REST endpoint to Operaton.

The PR adds `POST /deployment/delete` to the deployment REST API. The endpoint accepts a list of deployment ids plus the existing deployment delete flags (`cascade`, `skipCustomListeners`, `skipIoMappings`) and processes every deployment independently.

Response behavior:

- `200 OK` when every deployment was deleted successfully.
- `207 Multi-Status` when at least one deployment failed.
- The response body contains one item per requested deployment with `deploymentId`, `status` (`SUCCESS` or `FAILURE`) and `errorMessage`.

## Reviewer Notes

This is intentionally limited to bulk deployment deletion. The originally grouped Fluxnova bulk task and bulk job APIs are not included here because they add broader product/API surface and remain `needs_design` in the backport database for separate review.

The implementation keeps the Fluxnova per-item result semantics: failures, including authorization failures from an individual delete call, are returned as `FAILURE` entries instead of aborting the whole request. Missing deployments are converted into per-item failures after checking the deployment query.

OpenAPI templates and REST interaction tests are included with the code change.

## Attribution

Backported and adapted from Fluxnova:

- finos/fluxnova-bpm-platform@43f94c124aa561bad5b82a54de220f17a0986f04
- finos/fluxnova-bpm-platform@a313c4689b042e1f6aba4f92dc9051dda140de73

Original author: Nandan <Nandan.shenoy@fmr.com>

No original upstream PR URL was recorded in the backport database for this change unit.

## Backport Database

- CU 306 `Bulk Delete Deployments`: `pr_opened`, linked to this PR and commit `fe8d16ca4f3e89d54d09dba43b8751e37a1a6fde`.
- CU 331 `Create bulk action api's for tasks`: split out, remains `needs_design`.
- CU 357 `Bulk job api - delete, suspend & activate`: split out, remains `needs_design`.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -f engine-rest/engine-rest/pom.xml -Dtest=DeploymentRestServiceInteractionTest test`
  - Runs the test class twice in this module configuration.
  - Result: 86 tests, 0 failures, 0 errors, 0 skipped in each run.
- Backport DB: `PRAGMA integrity_check` returns `ok`.
