### PR TITLE
feat(engine-rest): add process engine configuration endpoint

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/main.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/main.ftl
@@ -52,6 +52,11 @@
       "externalDocs": {"description": "Find out more", "url": "${docsUrl}/reference/rest/condition/"}
     },
     {
+      "name": "Configuration",
+      "description": "Exposes selected process engine configuration values such as the engine name, history level, authorization mode, and password policy flag.",
+      "externalDocs": {"description": "Find out more", "url": "${docsUrl}/reference/rest/configuration/"}
+    },
+    {
       "name": "Decision Definition",
       "description": "Represents a deployed DMN decision table or decision literal expression. Endpoints support listing, retrieving, evaluating, and querying the XML source of decision definitions. Decision definitions are created by deploying DMN resources.",
       "externalDocs": {"description": "Find out more", "url": "${docsUrl}/reference/rest/decision-definition/"}

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/ProcessEngineConfigurationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/ProcessEngineConfigurationDto.ftl
@@ -1,0 +1,26 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto>
+
+    <@lib.property
+        name = "engineName"
+        type = "string"
+        desc = "The name of the process engine." />
+
+    <@lib.property
+        name = "historyLevel"
+        type = "string"
+        desc = "The history level of the process engine, for example `full`, `audit`, or `none`." />
+
+    <@lib.property
+        name = "authorizationEnabled"
+        type = "boolean"
+        desc = "Whether authorization is enabled on the process engine." />
+
+    <@lib.property
+        name = "enablePasswordPolicy"
+        type = "boolean"
+        last = true
+        desc = "Whether the password policy is enabled on the process engine." />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/configuration/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/configuration/get.ftl
@@ -1,0 +1,28 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "getProcessEngineConfiguration"
+      tag = "Configuration"
+      summary = "Get process engine configuration"
+      desc = "Retrieves selected configuration values of the process engine." />
+
+  "responses" : {
+    <@lib.response
+        code = "200"
+        dto = "ProcessEngineConfigurationDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200 Response",
+                       "description": "The response content of a status 200",
+                       "value": {
+                           "engineName": "default",
+                           "historyLevel": "full",
+                           "authorizationEnabled": false,
+                           "enablePasswordPolicy": false
+                         }
+                     }'] />
+
+    <@lib.errorResponses docsUrl=docsUrl last = true />
+  }
+}
+</#macro>

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ProcessEngineConfigurationDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ProcessEngineConfigurationDto.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+
+public class ProcessEngineConfigurationDto {
+
+  protected String engineName;
+  protected String historyLevel;
+  protected boolean authorizationEnabled;
+  protected boolean enablePasswordPolicy;
+
+  public static ProcessEngineConfigurationDto fromProcessEngineConfiguration(ProcessEngineConfiguration configuration) {
+    ProcessEngineConfigurationDto dto = new ProcessEngineConfigurationDto();
+    dto.engineName = configuration.getProcessEngineName();
+    dto.historyLevel = configuration.getHistory();
+    dto.authorizationEnabled = configuration.isAuthorizationEnabled();
+    dto.enablePasswordPolicy = configuration.isEnablePasswordPolicy();
+    return dto;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(String engineName) {
+    this.engineName = engineName;
+  }
+
+  public String getHistoryLevel() {
+    return historyLevel;
+  }
+
+  public void setHistoryLevel(String historyLevel) {
+    this.historyLevel = historyLevel;
+  }
+
+  public boolean isAuthorizationEnabled() {
+    return authorizationEnabled;
+  }
+
+  public void setAuthorizationEnabled(boolean authorizationEnabled) {
+    this.authorizationEnabled = authorizationEnabled;
+  }
+
+  public boolean isEnablePasswordPolicy() {
+    return enablePasswordPolicy;
+  }
+
+  public void setEnablePasswordPolicy(boolean enablePasswordPolicy) {
+    this.enablePasswordPolicy = enablePasswordPolicy;
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/AbstractProcessEngineRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/AbstractProcessEngineRestServiceImpl.java
@@ -262,6 +262,13 @@ public abstract class AbstractProcessEngineRestServiceImpl {
     return subResource;
   }
 
+  public ConfigurationRestService getConfigurationRestService(String engineName) {
+    String rootResourcePath = getRelativeEngineUri(engineName).toASCIIString();
+    ConfigurationRestService subResource = new ConfigurationRestService(engineName, getObjectMapper());
+    subResource.setRelativeRootResourceUri(rootResourcePath);
+    return subResource;
+  }
+
   public SchemaLogRestService getSchemaLogRestService(String engineName) {
     String rootResourcePath = getRelativeEngineUri(engineName).toASCIIString();
     SchemaLogRestServiceImpl subResource = new SchemaLogRestServiceImpl(engineName, getObjectMapper());

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/ConfigurationRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/ConfigurationRestService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.impl;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.rest.dto.ProcessEngineConfigurationDto;
+
+@Produces(MediaType.APPLICATION_JSON)
+public class ConfigurationRestService extends AbstractRestProcessEngineAware {
+
+  public static final String PATH = "/configuration";
+
+  public ConfigurationRestService(String engineName, ObjectMapper objectMapper) {
+    super(engineName, objectMapper);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public ProcessEngineConfigurationDto getConfiguration() {
+    ProcessEngineConfiguration configuration = getProcessEngine().getProcessEngineConfiguration();
+    return ProcessEngineConfigurationDto.fromProcessEngineConfiguration(configuration);
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/DefaultProcessEngineRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/DefaultProcessEngineRestServiceImpl.java
@@ -183,6 +183,11 @@ public class DefaultProcessEngineRestServiceImpl extends AbstractProcessEngineRe
     return super.getVersionRestService(null);
   }
 
+  @Path(ConfigurationRestService.PATH)
+  public ConfigurationRestService getConfigurationRestService() {
+    return super.getConfigurationRestService(null);
+  }
+
   @Path(SchemaLogRestService.PATH)
   public SchemaLogRestService getSchemaLogRestService() {
     return super.getSchemaLogRestService(null);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
@@ -228,6 +228,12 @@ public class NamedProcessEngineRestServiceImpl extends AbstractProcessEngineRest
   }
 
   @Override
+  @Path("/{name}" + ConfigurationRestService.PATH)
+  public ConfigurationRestService getConfigurationRestService(@PathParam("name") String engineName) {
+    return super.getConfigurationRestService(engineName);
+  }
+
+  @Override
   @Path("/{name}" + SchemaLogRestService.PATH)
   public SchemaLogRestService getSchemaLogRestService(@PathParam("name") String engineName) {
     return super.getSchemaLogRestService(engineName);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ConfigurationRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ConfigurationRestServiceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest;
+
+import jakarta.ws.rs.core.Response.Status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.rest.impl.ConfigurationRestService;
+import org.operaton.bpm.engine.rest.util.container.TestContainerExtension;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.when;
+
+public class ConfigurationRestServiceTest extends AbstractRestServiceTest {
+
+  @RegisterExtension
+  public static TestContainerExtension rule = new TestContainerExtension();
+
+  protected static final String CONFIGURATION_URL = TEST_RESOURCE_ROOT_PATH + ConfigurationRestService.PATH;
+  protected static final String NAMED_ENGINE_CONFIGURATION_URL = TEST_RESOURCE_ROOT_PATH + "/engine/{name}" + ConfigurationRestService.PATH;
+
+  private ProcessEngineConfiguration processEngineConfigurationMock;
+
+  @BeforeEach
+  void setUpMocks() {
+    processEngineConfigurationMock = processEngine.getProcessEngineConfiguration();
+
+    when(processEngineConfigurationMock.getProcessEngineName()).thenReturn("default");
+    when(processEngineConfigurationMock.getHistory()).thenReturn("full");
+    when(processEngineConfigurationMock.isAuthorizationEnabled()).thenReturn(true);
+    when(processEngineConfigurationMock.isEnablePasswordPolicy()).thenReturn(false);
+  }
+
+  @Test
+  void testGetConfiguration() {
+    given()
+      .header(ACCEPT_JSON_HEADER)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+      .body("engineName", equalTo("default"))
+      .body("historyLevel", equalTo("full"))
+      .body("authorizationEnabled", equalTo(true))
+      .body("enablePasswordPolicy", equalTo(false))
+    .when().get(CONFIGURATION_URL);
+  }
+
+  @Test
+  void testGetConfigurationWithNamedEngine() {
+    given()
+      .header(ACCEPT_JSON_HEADER)
+      .pathParam("name", "default")
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+      .body("engineName", equalTo("default"))
+      .body("historyLevel", equalTo("full"))
+      .body("authorizationEnabled", equalTo(true))
+      .body("enablePasswordPolicy", equalTo(false))
+    .when().get(NAMED_ENGINE_CONFIGURATION_URL);
+  }
+
+  @Test
+  void testGetConfigurationDifferentValues() {
+    when(processEngineConfigurationMock.getProcessEngineName()).thenReturn("custom");
+    when(processEngineConfigurationMock.getHistory()).thenReturn("none");
+    when(processEngineConfigurationMock.isAuthorizationEnabled()).thenReturn(false);
+    when(processEngineConfigurationMock.isEnablePasswordPolicy()).thenReturn(true);
+
+    given()
+      .header(ACCEPT_JSON_HEADER)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+      .body("engineName", equalTo("custom"))
+      .body("historyLevel", equalTo("none"))
+      .body("authorizationEnabled", equalTo(false))
+      .body("enablePasswordPolicy", equalTo(true))
+    .when().get(CONFIGURATION_URL);
+  }
+
+}


### PR DESCRIPTION
## Summary

Backports CIB Seven's small process engine configuration REST endpoint to Operaton.

This adds `GET /configuration` for the default engine and `GET /engine/{name}/configuration` for named engines. The response exposes selected process engine configuration values:

- `engineName`
- `historyLevel`
- `authorizationEnabled`
- `enablePasswordPolicy`

The endpoint is read-only and uses the existing REST sub-resource wiring for default and named process engines.

## Reviewer Notes

The original discussion PR grouped five REST statistics/admin API candidates. This implementation intentionally includes only the small CIB Seven configuration endpoint from change unit `1119`.

The following change units were split out and remain `needs_design` in the backport database because they add broader REST/statistics/history API surface:

- `432` - Fluxnova task attachment/comment count endpoints
- `433` - Fluxnova process-instance incident count API
- `434` - Fluxnova process-instance statistics API
- `1120` - CIB Seven history statistics POST/filter endpoint

Security/API review point: this endpoint exposes configuration metadata. The current response mirrors the CIB Seven source and limits the payload to four selected values, but maintainers should still confirm that exposing `authorizationEnabled`, `enablePasswordPolicy`, and `historyLevel` is acceptable for Operaton's REST API policy.

New files use the Operaton contributor header; source attribution is recorded below and in the commit body.

## Attribution

Source fork: CIB Seven

Backported and adapted from CIB Seven PR:

- https://github.com/cibseven/cibseven/pull/326

Backported commit:

- `e2a20e4034eee144c65d1d396bba1e7f58bcdbda` - `feat(rest): added new endpoint to get process engine config (#326)`

Original author:

- Vladimir Gribko `<156691737+vladgrind@users.noreply.github.com>`

Backport database:

- Change unit `1119` marked `pr_opened` for this PR.
- Change units `432`, `433`, `434`, and `1120` remain `needs_design` and were split out of this PR.

## Verification

- `git diff --check`
- `./mvnw -f engine-rest/engine-rest/pom.xml -Dtest=ConfigurationRestServiceTest test`
  - REST test runs twice by the module's standard/encoding Surefire executions.
  - Each execution: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`
- Backport database: `PRAGMA integrity_check` returned `ok`.
