### PR TITLE
feat(engine): optionally validate task variable task ids

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -570,6 +570,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected boolean standaloneTasksEnabled = true;
 
+  /**
+   * When set to true, the engine validates that the TASK_ID_ referenced by a
+   * variable exists in ACT_RU_TASK before inserting or updating the variable.
+   */
+  protected boolean checkVariableTaskId;
+
   protected boolean enableGracefulDegradationOnContextSwitchFailure = true;
 
   protected BusinessCalendarManager businessCalendarManager;
@@ -4211,6 +4217,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setStandaloneTasksEnabled(boolean standaloneTasksEnabled) {
     this.standaloneTasksEnabled = standaloneTasksEnabled;
+    return this;
+  }
+
+  public boolean isCheckVariableTaskId() {
+    return checkVariableTaskId;
+  }
+
+  public ProcessEngineConfigurationImpl setCheckVariableTaskId(boolean checkVariableTaskId) {
+    this.checkVariableTaskId = checkVariableTaskId;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -21,8 +21,10 @@ import java.util.Map;
 
 import org.operaton.bpm.application.InvocationContext;
 import org.operaton.bpm.application.ProcessApplicationReference;
+import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmmn.entity.runtime.CaseExecutionEntity;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.context.ProcessApplicationContextUtil;
@@ -138,10 +140,29 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
 
   public static void insert(VariableInstanceEntity variableInstance) {
     if (!variableInstance.isTransient()) {
+      validateTaskIdIfEnabled(variableInstance);
       Context
       .getCommandContext()
       .getDbEntityManager()
       .insert(variableInstance);
+    }
+  }
+
+  protected static void validateTaskIdIfEnabled(VariableInstanceEntity variableInstance) {
+    String taskId = variableInstance.getTaskId();
+
+    if (taskId != null) {
+      ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
+
+      if (configuration != null && configuration.isCheckVariableTaskId()) {
+        TaskEntity task = variableInstance.getTask();
+
+        if (task == null || task.isDeleted()) {
+          throw new ProcessEngineException(("Task with id '%s' doesn't exist or it is already completed. "
+              + "Cannot create variable '%s' with a reference to a not existing task.")
+              .formatted(taskId, variableInstance.getName()));
+        }
+      }
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntityPersistenceListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntityPersistenceListener.java
@@ -35,4 +35,9 @@ public class VariableInstanceEntityPersistenceListener implements VariableInstan
     variable.delete();
   }
 
+  @Override
+  public void onUpdate(VariableInstanceEntity variable, AbstractVariableScope sourceScope) {
+    VariableInstanceEntity.validateTaskIdIfEnabled(variable);
+  }
+
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationTest.java
@@ -74,6 +74,16 @@ public class ProcessEngineConfigurationTest {
   }
 
   @Test
+  void shouldDisableVariableTaskIdCheckByDefault() {
+    // when
+    ProcessEngineConfigurationImpl engineCfg = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
+        .createStandaloneProcessEngineConfiguration();
+
+    // then
+    assertThat(engineCfg.isCheckVariableTaskId()).isFalse();
+  }
+
+  @Test
   void validIsolationLevel() {
     // given
     ((PooledDataSource) engineConfiguration.getDataSource()).setDefaultTransactionIsolationLevel(Connection.TRANSACTION_READ_COMMITTED);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInTransactionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInTransactionTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.api.runtime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.operaton.bpm.engine.impl.db.entitymanager.cache.CachedDbEntity;
@@ -30,6 +31,8 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.variable.Variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  *
@@ -62,5 +65,43 @@ class VariableInTransactionTest {
       return null;
     });
 
+  }
+
+  @Test
+  void shouldCreateVariableWithNonExistingTaskIdByDefault() {
+    String nonExistingTaskId = "non-existing-task-id";
+
+    assertThatCode(() -> processEngineConfiguration.getCommandExecutorTxRequired()
+      .execute((Command<Void>) commandContext -> {
+        VariableInstanceEntity variable = VariableInstanceEntity.create("myVar",
+            Variables.stringValue("myValue"), false);
+        variable.setTaskId(nonExistingTaskId);
+        VariableInstanceEntity.insert(variable);
+        variable.delete();
+
+        return null;
+      })).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectVariableWithNonExistingTaskIdWhenCheckEnabled() {
+    String nonExistingTaskId = "non-existing-task-id";
+    processEngineConfiguration.setCheckVariableTaskId(true);
+
+    try {
+      assertThatThrownBy(() -> processEngineConfiguration.getCommandExecutorTxRequired()
+        .execute((Command<Void>) commandContext -> {
+          VariableInstanceEntity variable = VariableInstanceEntity.create("myVar",
+              Variables.stringValue("myValue"), false);
+          variable.setTaskId(nonExistingTaskId);
+          VariableInstanceEntity.insert(variable);
+
+          return null;
+        }))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("Task with id 'non-existing-task-id' doesn't exist or it is already completed");
+    } finally {
+      processEngineConfiguration.setCheckVariableTaskId(false);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Backports an Operaton-adapted version of CIBSeven's optional task-variable integrity check.

This adds the `checkVariableTaskId` engine configuration option. The option is disabled by default. When enabled, runtime variable inserts and updates that carry a `TASK_ID_` reference validate that the referenced runtime task exists and has not been deleted before the variable is persisted.

## What This Fixes

Without this opt-in check, custom engine integrations can create or update runtime variables with a stale or non-existing task id. That leaves `ACT_RU_VARIABLE.TASK_ID_` pointing at no live task, which is hard to diagnose later because the variable row looks task-scoped but cannot be resolved back to a task.

The backport adds the validation at the variable persistence boundary:

- `VariableInstanceEntity.insert(...)` validates before inserting non-transient variables.
- `VariableInstanceEntityPersistenceListener#onUpdate(...)` validates before variable updates.
- Existing installations keep the current permissive behavior unless `checkVariableTaskId` is explicitly enabled.

## Out Of Scope

The earlier discussion PR also grouped a Fluxnova change that stores task ids on historic variable instances. That is a separate history/data-model semantics topic and is intentionally not included here. It remains tracked separately as `needs_design` in the backport database.

## Attribution

Backport adapted from CIBSeven:

- CIBSeven PR: cibseven/cibseven#318
- Source commit: `435a86c52dbd55c9647a4a31b88bf4aa02bc5092`
- Source subject: `new(engine): check for task Id before assigning a variable (#318)`
- Original author: Vladimir Gribko <156691737+vladgrind@users.noreply.github.com>

## Reviewer Notes

This is intentionally modeled as an opt-in guard rather than a default behavior change. Enabling it can expose existing integrations that currently write task-scoped variables after the task has completed or with an invalid task id, so keeping the default at `false` preserves compatibility.

The validation uses the existing task lookup path via `VariableInstanceEntity#getTask()`, which delegates to `TaskManager.findTaskById(...)`, and additionally rejects deleted task entities.

## Verification

```bash
./mvnw -pl engine -Dtest=ProcessEngineConfigurationTest,VariableInTransactionTest test
```

Result: 10 tests, 0 failures, 0 errors.
