### PR TITLE
feat(engine-rest): make task formKey evaluation optional

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
@@ -697,6 +697,13 @@
       location = "query"
       type = "boolean"
       defaultValue = "false"
-      last = last
       desc = "Indicates if all the local variables visible from task should be retrieved. Value may only be `true`, as
              `false` is the default behavior." />
+
+  <@lib.parameter name = "evaluateFormKey"
+      location = "query"
+      type = "boolean"
+      defaultValue = "true"
+      last = last
+      desc = "Indicates whether the form key should be evaluated when returning the task. If set to `false`,
+              the form key is returned as-is without evaluation. Defaults to `true`." />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
@@ -14,8 +14,16 @@
         location = "path"
         type = "string"
         required = true
-        last = true
         desc = "The id of the task to be retrieved."/>
+
+    <@lib.parameter
+        name = "evaluateFormKey"
+        location = "query"
+        type = "boolean"
+        defaultValue = "true"
+        last = true
+        desc = "Indicates whether the form key should be evaluated when returning the task. If set to `false`,
+                the form key is returned as-is without evaluation. Defaults to `true`." />
 
   ],
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TaskRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TaskRestService.java
@@ -39,15 +39,17 @@ public interface TaskRestService {
   TaskResource getTask(@PathParam("id") String id,
                        @QueryParam("withCommentAttachmentInfo") boolean withCommentAttachmentInfo,
                        @QueryParam("withTaskVariablesInReturn") boolean withTaskVariablesInReturn,
-                       @QueryParam("withTaskLocalVariablesInReturn") boolean withTaskLocalVariablesInReturn);
+                       @QueryParam("withTaskLocalVariablesInReturn") boolean withTaskLocalVariablesInReturn,
+                       @QueryParam("evaluateFormKey") @DefaultValue("true") boolean evaluateFormKey);
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
   Object getTasks(@Context Request request, @Context UriInfo uriInfo,
-                  @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults);
+                  @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults,
+                  @QueryParam("evaluateFormKey") @DefaultValue("true") boolean evaluateFormKey);
 
   /**
-   * Expects the same parameters as {@link TaskRestService#getTasks(UriInfo, Integer, Integer)} (as
+   * Expects the same parameters as {@link TaskRestService#getTasks(Request, UriInfo, Integer, Integer, boolean)} (as
    * JSON message body) and allows more than one variable check.
    * @param query
    * @param firstResult

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
@@ -59,33 +59,36 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
   }
 
   @Override
-  public Object getTasks(Request request, UriInfo uriInfo, Integer firstResult, Integer maxResults) {
+  public Object getTasks(Request request, UriInfo uriInfo, Integer firstResult, Integer maxResults,
+                         boolean evaluateFormKey) {
     Variant variant = request.selectVariant(VARIANTS);
     if (variant != null) {
       if (MediaType.APPLICATION_JSON_TYPE.equals(variant.getMediaType())) {
-        return getJsonTasks(uriInfo, firstResult, maxResults);
+        return getJsonTasks(uriInfo, firstResult, maxResults, evaluateFormKey);
       }
       else if (Hal.APPLICATION_HAL_JSON_TYPE.equals(variant.getMediaType())) {
-        return getHalTasks(uriInfo, firstResult, maxResults);
+        return getHalTasks(uriInfo, firstResult, maxResults, evaluateFormKey);
       }
     }
     throw new InvalidRequestException(Response.Status.NOT_ACCEPTABLE, "No acceptable content-type found");
   }
 
-  public List<TaskDto> getJsonTasks(UriInfo uriInfo, Integer firstResult, Integer maxResults) {
+  public List<TaskDto> getJsonTasks(UriInfo uriInfo, Integer firstResult, Integer maxResults,
+                                    boolean evaluateFormKey) {
     // get list of tasks
     TaskQueryDto queryDto = new TaskQueryDto(getObjectMapper(), uriInfo.getQueryParameters());
-    return queryTasks(queryDto, firstResult, maxResults);
+    return queryTasksInternal(queryDto, firstResult, maxResults, evaluateFormKey);
   }
 
-  public HalTaskList getHalTasks(UriInfo uriInfo, Integer firstResult, Integer maxResults) {
+  public HalTaskList getHalTasks(UriInfo uriInfo, Integer firstResult, Integer maxResults,
+                                 boolean evaluateFormKey) {
     TaskQueryDto queryDto = new TaskQueryDto(getObjectMapper(), uriInfo.getQueryParameters());
 
     ProcessEngine engine = getProcessEngine();
     TaskQuery query = queryDto.toQuery(engine);
 
     // get list of tasks
-    List<Task> matchingTasks = executeTaskQuery(firstResult, maxResults, query);
+    List<Task> matchingTasks = executeTaskQuery(firstResult, maxResults, query, evaluateFormKey);
 
     // get total count
     long count = query.count();
@@ -96,11 +99,16 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
   @Override
   public List<TaskDto> queryTasks(TaskQueryDto queryDto, Integer firstResult,
       Integer maxResults) {
+    return queryTasksInternal(queryDto, firstResult, maxResults, true);
+  }
+
+  private List<TaskDto> queryTasksInternal(TaskQueryDto queryDto, Integer firstResult,
+      Integer maxResults, boolean evaluateFormKey) {
     ProcessEngine engine = getProcessEngine();
     queryDto.setObjectMapper(getObjectMapper());
     TaskQuery query = queryDto.toQuery(engine);
 
-    List<Task> matchingTasks = executeTaskQuery(firstResult, maxResults, query);
+    List<Task> matchingTasks = executeTaskQuery(firstResult, maxResults, query, evaluateFormKey);
 
 
     boolean withTaskVariables = Boolean.TRUE.equals(queryDto.getWithTaskVariablesInReturn());
@@ -117,9 +125,14 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
   }
 
   protected List<Task> executeTaskQuery(Integer firstResult, Integer maxResults, TaskQuery query) {
+    return executeTaskQuery(firstResult, maxResults, query, true);
+  }
+
+  protected List<Task> executeTaskQuery(Integer firstResult, Integer maxResults, TaskQuery query,
+                                        boolean evaluateFormKey) {
 
     // enable initialization of form key:
-    query.initializeFormKeys();
+    query.initializeFormKeys(evaluateFormKey);
     return QueryUtil.list(query, firstResult, maxResults);
   }
 
@@ -146,9 +159,10 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
   public TaskResource getTask(String id,
                               boolean withCommentAttachmentInfo,
                               boolean withTaskVariablesInReturn,
-                              boolean withTaskLocalVariablesInReturn) {
+                              boolean withTaskLocalVariablesInReturn,
+                              boolean evaluateFormKey) {
     return new TaskResourceImpl(getProcessEngine(), id, relativeRootResourcePath, getObjectMapper(),
-        withCommentAttachmentInfo, withTaskVariablesInReturn, withTaskLocalVariablesInReturn);
+        withCommentAttachmentInfo, withTaskVariablesInReturn, withTaskLocalVariablesInReturn, evaluateFormKey);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
@@ -74,6 +74,7 @@ public class TaskResourceImpl implements TaskResource {
   protected boolean withCommentAttachmentInfo;
   protected boolean withTaskVariablesInReturn;
   protected boolean withTaskLocalVariablesInReturn;
+  protected boolean evaluateFormKey;
 
   public TaskResourceImpl(ProcessEngine engine,
                           String taskId,
@@ -81,7 +82,8 @@ public class TaskResourceImpl implements TaskResource {
                           ObjectMapper objectMapper,
                           boolean withCommentAttachmentInfo,
                           boolean withTaskVariablesInReturn,
-                          boolean withTaskLocalVariablesInReturn) {
+                          boolean withTaskLocalVariablesInReturn,
+                          boolean evaluateFormKey) {
     this.engine = engine;
     this.taskId = taskId;
     this.rootResourcePath = rootResourcePath;
@@ -89,6 +91,7 @@ public class TaskResourceImpl implements TaskResource {
     this.withCommentAttachmentInfo = withCommentAttachmentInfo;
     this.withTaskVariablesInReturn = withTaskVariablesInReturn;
     this.withTaskLocalVariablesInReturn = withTaskLocalVariablesInReturn;
+    this.evaluateFormKey = evaluateFormKey;
   }
 
   @Override
@@ -457,10 +460,10 @@ public class TaskResourceImpl implements TaskResource {
 
   protected Task getTaskById(String id, boolean withCommentAttachmentInfo) {
     if (withCommentAttachmentInfo) {
-      return engine.getTaskService().createTaskQuery().taskId(id).withCommentAttachmentInfo().initializeFormKeys().singleResult();
+      return engine.getTaskService().createTaskQuery().taskId(id).withCommentAttachmentInfo().initializeFormKeys(evaluateFormKey).singleResult();
     }
     else{
-      return engine.getTaskService().createTaskQuery().taskId(id).initializeFormKeys().singleResult();
+      return engine.getTaskService().createTaskQuery().taskId(id).initializeFormKeys(evaluateFormKey).singleResult();
     }
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -108,6 +108,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -287,6 +288,7 @@ public class ProcessEngineRestServiceTest extends
     TaskQuery mockTaskQuery = mock(TaskQuery.class);
     when(mockTaskQuery.taskId(MockProvider.EXAMPLE_TASK_ID)).thenReturn(mockTaskQuery);
     when(mockTaskQuery.initializeFormKeys()).thenReturn(mockTaskQuery);
+    when(mockTaskQuery.initializeFormKeys(anyBoolean())).thenReturn(mockTaskQuery);
     when(mockTaskQuery.singleResult()).thenReturn(mockTask);
     when(mockTaskService.createTaskQuery()).thenReturn(mockTaskQuery);
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -194,6 +194,7 @@ public class TaskRestServiceInteractionTest extends
     mockTask = MockProvider.createMockTask();
     mockQuery = mock(TaskQuery.class);
     when(mockQuery.initializeFormKeys()).thenReturn(mockQuery);
+    when(mockQuery.initializeFormKeys(anyBoolean())).thenReturn(mockQuery);
     when(mockQuery.taskId(any())).thenReturn(mockQuery);
     when(mockQuery.withCommentAttachmentInfo()).thenReturn(mockQuery);
     when(mockQuery.singleResult()).thenReturn(mockTask);
@@ -748,6 +749,18 @@ public class TaskRestServiceInteractionTest extends
         .body("operatonFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
         .body("key", nullValue())
       .when().get(SINGLE_TASK_URL);
+  }
+
+  @Test
+  void testGetTaskEvaluateFormKeyFalse() {
+    given()
+      .pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+      .queryParam("evaluateFormKey", false)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .expect().statusCode(Status.OK.getStatusCode())
+    .when().get(SINGLE_TASK_URL);
+
+    verify(mockQuery).initializeFormKeys(false);
   }
 
   /**

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -412,7 +412,20 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .expect().statusCode(Status.OK.getStatusCode())
     .when().get(TASK_QUERY_URL);
 
-    verify(mockQuery).initializeFormKeys();
+    verify(mockQuery).initializeFormKeys(true);
+    verify(mockQuery).list();
+    verifyNoMoreInteractions(mockQuery);
+  }
+
+  @Test
+  void testEvaluateFormKeyFalseQueryParameter() {
+    given()
+      .queryParam("evaluateFormKey", false)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .expect().statusCode(Status.OK.getStatusCode())
+    .when().get(TASK_QUERY_URL);
+
+    verify(mockQuery).initializeFormKeys(false);
     verify(mockQuery).list();
     verifyNoMoreInteractions(mockQuery);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
@@ -158,6 +158,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   protected boolean excludeSubtasks;
   protected SuspensionState suspensionState;
   protected boolean initializeFormKeys;
+  protected boolean evaluateFormKey = true;
   protected boolean taskNameCaseInsensitive;
 
   protected Boolean variableNamesIgnoreCase;
@@ -1076,8 +1077,14 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
 
   @Override
   public TaskQuery initializeFormKeys() {
+    return initializeFormKeys(true);
+  }
+
+  @Override
+  public TaskQuery initializeFormKeys(boolean evaluateFormKey) {
     ensureNotInOrQuery("initializeFormKeys()");
     this.initializeFormKeys = true;
+    this.evaluateFormKey = evaluateFormKey;
     return this;
   }
 
@@ -1470,7 +1477,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     if (initializeFormKeys) {
       for (Task task : taskList) {
         // initialize the form keys of the tasks
-        ((TaskEntity) task).initializeFormKey();
+        ((TaskEntity) task).initializeFormKey(evaluateFormKey);
       }
     }
 
@@ -1803,6 +1810,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     return initializeFormKeys;
   }
 
+  public boolean isEvaluateFormKey() {
+    return evaluateFormKey;
+  }
+
   public boolean isTaskNameCaseInsensitive() {
     return taskNameCaseInsensitive;
   }
@@ -2130,7 +2141,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     }
 
     if (extendingQuery.isInitializeFormKeys() || this.isInitializeFormKeys()) {
-      extendedQuery.initializeFormKeys();
+      boolean evaluateFormKey = extendingQuery.isInitializeFormKeys()
+          ? extendingQuery.isEvaluateFormKey()
+          : this.isEvaluateFormKey();
+      extendedQuery.initializeFormKeys(evaluateFormKey);
     }
 
     if (extendingQuery.isTaskNameCaseInsensitive() || this.isTaskNameCaseInsensitive()) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1439,19 +1439,25 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   }
 
   public void initializeFormKey() {
+    initializeFormKey(true);
+  }
+
+  public void initializeFormKey(boolean evaluateFormKey) {
     isFormKeyInitialized = true;
     if (taskDefinitionKey != null) {
       TaskDefinition taskDef = getTaskDefinition();
       if (taskDef != null) {
-        initializeFormKeyFromTaskDefinition(taskDef);
+        initializeFormKeyFromTaskDefinition(taskDef, evaluateFormKey);
       }
     }
   }
 
-  private void initializeFormKeyFromTaskDefinition(TaskDefinition taskDef) {
+  private void initializeFormKeyFromTaskDefinition(TaskDefinition taskDef, boolean evaluateFormKey) {
     Expression taskDefFormKey = taskDef.getFormKey();
     if (taskDefFormKey != null) {
-      this.formKey = (String) taskDefFormKey.getValue(this);
+      this.formKey = evaluateFormKey
+          ? (String) taskDefFormKey.getValue(this)
+          : taskDefFormKey.getExpressionText();
     } else {
       initializeFormRefFromTaskDefinition(taskDef);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
@@ -925,6 +925,21 @@ public interface TaskQuery extends Query<TaskQuery, Task> {
   TaskQuery initializeFormKeys();
 
   /**
+   * If called, the form keys and form references of the fetched tasks are initialized.
+   * When {@code evaluateFormKey} is {@code true}, {@link Task#getFormKey()} and
+   * {@link Task#getOperatonFormRef()} return resolved values. When {@code false},
+   * the form key expression is exposed as stored on the task definition without
+   * evaluating the expression.
+   *
+   * @param evaluateFormKey whether form key expressions should be evaluated
+   * @return the query itself
+   * @throws ProcessEngineException When method has been executed within "or query". Method must be executed on the base query.
+   */
+  default TaskQuery initializeFormKeys(boolean evaluateFormKey) {
+    return initializeFormKeys();
+  }
+
+  /**
    * Only select tasks with one of the given tenant ids.
    *
    * @throws ProcessEngineException <ul>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -4970,6 +4970,34 @@ class TaskQueryTest {
   }
 
   @Test
+  void testInitializeFormKeysWithoutEvaluationReturnsRawExpression() {
+    BpmnModelInstance process = Bpmn.createExecutableProcess("process")
+        .operatonHistoryTimeToLive(180)
+        .startEvent()
+      .userTask()
+        .operatonFormKey("${formKey}")
+      .endEvent()
+      .done();
+    testRule.deploy(process);
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("formKey", "evaluatedFormKey");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variables);
+
+    Task evaluatedTask = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .initializeFormKeys()
+        .singleResult();
+    assertThat(evaluatedTask.getFormKey()).isEqualTo("evaluatedFormKey");
+
+    Task rawTask = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .initializeFormKeys(false)
+        .singleResult();
+    assertThat(rawTask.getFormKey()).isEqualTo("${formKey}");
+  }
+
+  @Test
   @Deployment
   void testInitializeFormKeysOperatonFormRef() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("formRefProcess");


### PR DESCRIPTION
## Summary

Backports Fluxnova's Task REST `evaluateFormKey` support to Operaton.

This adds an `evaluateFormKey` query parameter to:

- `GET /task`
- `GET /task/{id}`

The default is `true`, so existing REST behavior is unchanged: task form key expressions are evaluated before being returned. When callers pass `evaluateFormKey=false`, Operaton initializes the form key field but returns the stored form key expression without evaluating it.

## Reviewer Notes

This PR intentionally contains only the concrete `evaluateFormKey` backport. The deprecated `camundaFormRef` compatibility change from the original discussion PR is not included, because reintroducing Camunda-named REST response fields in Operaton needs a separate API/compatibility decision.

The Operaton adaptation is slightly stricter than the Fluxnova source commit. Fluxnova documented `evaluateFormKey=false` as returning the form key "as-is", but its implementation effectively left `formKey` as `null` for expression-backed form keys. This PR uses `Expression#getExpressionText()` for the false path, so the behavior matches the documented API: for a task configured with `operaton:formKey="${formKey}"`, the REST DTO can expose `${formKey}` without evaluating the EL expression.

The new engine API is additive: `TaskQuery#initializeFormKeys()` keeps its existing behavior, and `TaskQuery#initializeFormKeys(boolean evaluateFormKey)` adds the explicit control used by REST. `POST /task` continues to use the existing default evaluation behavior.

## Attribution

Source fork: Fluxnova

Backported and adapted from Fluxnova commit:

- `d4adc274df4f984f55f710567a9ec42a84df6329` - `Make formKey expression evaluation optional in Task REST APIs`

Original author:

- Mannuru, ReddyKishore `<ReddyKishore.Mannuru@fmr.com>`

Backport database:

- Change unit `502` marked `pr_opened` for this PR.
- Change unit `465` remains `needs_design` and was split out of this PR.

## Verification

- `git diff --check`
- `./mvnw -pl engine -Dtest=TaskQueryTest test`
  - `Tests run: 245, Failures: 0, Errors: 0, Skipped: 0`
- `./mvnw -pl engine -DskipTests install`
- `./mvnw -f engine-rest/engine-rest/pom.xml -Dtest=TaskRestServiceQueryTest,TaskRestServiceInteractionTest,ProcessEngineRestServiceTest test`
  - REST tests run twice by the module's standard/encoding Surefire executions.
  - Each execution: `Tests run: 313, Failures: 0, Errors: 0, Skipped: 1`
