### PR TITLE
feat(engine): add script preprocessing SPI

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -289,6 +289,8 @@ import org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines;
 import org.operaton.bpm.engine.impl.scripting.engine.VariableScopeResolverFactory;
 import org.operaton.bpm.engine.impl.scripting.env.ScriptEnvResolver;
 import org.operaton.bpm.engine.impl.scripting.env.ScriptingEnvironment;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.CompositeScriptPreprocessor;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
 import org.operaton.bpm.engine.impl.telemetry.dto.DatabaseImpl;
 import org.operaton.bpm.engine.impl.telemetry.dto.InternalsImpl;
 import org.operaton.bpm.engine.impl.telemetry.dto.JdkImpl;
@@ -539,6 +541,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected boolean enableScriptEngineNashornCompatibility;
   protected boolean configureScriptEngineHostAccess = true;
   protected boolean skipIsolationLevelCheck;
+  protected volatile boolean enableScriptPreprocessing;
+  protected volatile List<ScriptPreprocessor> scriptPreprocessors;
+  protected volatile ScriptPreprocessor effectiveScriptPreprocessor;
+  protected final Object scriptPreprocessorLock = new Object();
 
   /**
    * When set to false, the following behavior changes:
@@ -4233,6 +4239,81 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public void setScriptFactory(ScriptFactory scriptFactory) {
     this.scriptFactory = scriptFactory;
+  }
+
+  public boolean isEnableScriptPreprocessing() {
+    return enableScriptPreprocessing;
+  }
+
+  public void setEnableScriptPreprocessing(boolean enableScriptPreprocessing) {
+    synchronized (scriptPreprocessorLock) {
+      this.enableScriptPreprocessing = enableScriptPreprocessing;
+      this.effectiveScriptPreprocessor = null;
+    }
+  }
+
+  public List<ScriptPreprocessor> getScriptPreprocessors() {
+    synchronized (scriptPreprocessorLock) {
+      if (scriptPreprocessors == null) {
+        return null;
+      }
+      return new ArrayList<>(scriptPreprocessors);
+    }
+  }
+
+  public void setScriptPreprocessors(List<ScriptPreprocessor> scriptPreprocessors) {
+    synchronized (scriptPreprocessorLock) {
+      if (scriptPreprocessors == null) {
+        this.scriptPreprocessors = null;
+      } else {
+        this.scriptPreprocessors = new ArrayList<>(scriptPreprocessors);
+      }
+      this.effectiveScriptPreprocessor = null;
+    }
+  }
+
+  public void addScriptPreprocessor(ScriptPreprocessor scriptPreprocessor) {
+    if (scriptPreprocessor == null) {
+      return;
+    }
+    synchronized (scriptPreprocessorLock) {
+      List<ScriptPreprocessor> updatedScriptPreprocessors = this.scriptPreprocessors == null
+          ? new ArrayList<>()
+          : new ArrayList<>(this.scriptPreprocessors);
+      updatedScriptPreprocessors.add(scriptPreprocessor);
+      this.scriptPreprocessors = updatedScriptPreprocessors;
+      this.effectiveScriptPreprocessor = null;
+    }
+  }
+
+  public ScriptPreprocessor getEffectiveScriptPreprocessor() {
+    if (!enableScriptPreprocessing) {
+      return null;
+    }
+    ScriptPreprocessor cached = effectiveScriptPreprocessor;
+    if (cached != null) {
+      return cached;
+    }
+
+    synchronized (scriptPreprocessorLock) {
+      if (!enableScriptPreprocessing) {
+        return null;
+      }
+
+      if (effectiveScriptPreprocessor == null) {
+        List<ScriptPreprocessor> configuredScriptPreprocessors = scriptPreprocessors;
+        if (configuredScriptPreprocessors == null || configuredScriptPreprocessors.isEmpty()) {
+          return null;
+        }
+
+        if (configuredScriptPreprocessors.size() == 1) {
+          effectiveScriptPreprocessor = configuredScriptPreprocessors.get(0);
+        } else {
+          effectiveScriptPreprocessor = new CompositeScriptPreprocessor(new ArrayList<>(configuredScriptPreprocessors));
+        }
+      }
+      return effectiveScriptPreprocessor;
+    }
   }
 
   public ScriptEngineResolver getScriptEngineResolver() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/CompiledExecutableScript.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/CompiledExecutableScript.java
@@ -30,7 +30,7 @@ public class CompiledExecutableScript extends ExecutableScript {
 
   private static final ScriptLogger LOG = ProcessEngineLogger.SCRIPT_LOGGER;
 
-  protected CompiledScript compiledScript;
+  protected volatile CompiledScript compiledScript;
 
   protected CompiledExecutableScript(String language) {
     this(language, null);
@@ -51,9 +51,13 @@ public class CompiledExecutableScript extends ExecutableScript {
 
   @Override
   public Object evaluate(ScriptEngine scriptEngine, VariableScope variableScope, Bindings bindings) {
+    return evaluateCompiledScript(getCompiledScript(), variableScope, bindings);
+  }
+
+  protected Object evaluateCompiledScript(CompiledScript compiledScript, VariableScope variableScope, Bindings bindings) {
     try {
       LOG.debugEvaluatingCompiledScript(language);
-      return getCompiledScript().eval(bindings);
+      return compiledScript.eval(bindings);
     } catch (ScriptException e) {
       Throwable cause = e.getCause();
       if (cause instanceof BpmnError bpmnError) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/DynamicExecutableScript.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/DynamicExecutableScript.java
@@ -42,6 +42,7 @@ public abstract class DynamicExecutableScript extends ExecutableScript {
   @Override
   public Object evaluate(ScriptEngine scriptEngine, VariableScope variableScope, Bindings bindings) {
     String source = getScriptSource(variableScope);
+    source = preprocessScript(source, variableScope);
     try {
       return scriptEngine.eval(source, bindings);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ExecutableScript.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ExecutableScript.java
@@ -23,7 +23,12 @@ import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.DelegateCaseExecution;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.VariableScope;
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
 
 /**
  * <p>Represents an executable script.</p>
@@ -33,6 +38,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
  *
  */
 public abstract class ExecutableScript {
+
+  private static final ScriptLogger LOG = ProcessEngineLogger.SCRIPT_LOGGER;
 
   /** The language of the script. Used to resolve the
    * {@link ScriptEngine}. */
@@ -92,5 +99,49 @@ public abstract class ExecutableScript {
   }
 
   protected abstract Object evaluate(ScriptEngine scriptEngine, VariableScope variableScope, Bindings bindings);
+
+  /**
+   * Applies the configured script preprocessor chain before execution.
+   *
+   * <p>If preprocessing is disabled, no preprocessor is configured, a preprocessor returns
+   * {@code null}, or preprocessing fails, the original script is used unchanged.</p>
+   */
+  protected String preprocessScript(String script, VariableScope variableScope) {
+    if (script == null) {
+      return script;
+    }
+
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    if (processEngineConfiguration == null || !processEngineConfiguration.isEnableScriptPreprocessing()) {
+      return script;
+    }
+
+    ScriptPreprocessor scriptPreprocessor = processEngineConfiguration.getEffectiveScriptPreprocessor();
+    if (scriptPreprocessor == null) {
+      return script;
+    }
+
+    String preprocessorName = getPreprocessorName(scriptPreprocessor);
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(script, language, variableScope);
+
+    String processedScript;
+    try {
+      processedScript = scriptPreprocessor.process(request);
+    } catch (Throwable e) {
+      LOG.warnScriptPreprocessingFailed(language, preprocessorName, e);
+      return script;
+    }
+
+    return processedScript != null ? processedScript : script;
+  }
+
+  private String getPreprocessorName(ScriptPreprocessor scriptPreprocessor) {
+    try {
+      String name = scriptPreprocessor.getName();
+      return name != null ? name : "<unknown>";
+    } catch (Exception e) {
+      return "<unknown>";
+    }
+  }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ScriptFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ScriptFactory.java
@@ -19,10 +19,16 @@ package org.operaton.bpm.engine.impl.scripting;
 import org.operaton.bpm.engine.delegate.Expression;
 
 /**
- * <p>A script factory is responsible for creating a {@link ExecutableScript}
- * instance. Users may customize (subclass) this class in order to customize script
- * creation. For instance, some users may choose to pre-process scripts before
- * they are created.</p>
+ * <p>A script factory is responsible for creating {@link ExecutableScript}
+ * instances. Users may customize (subclass) this class in order to customize script
+ * creation.</p>
+ *
+ * <p>The default executable script implementations created by this factory preserve
+ * configured script preprocessing behavior automatically. Custom subclasses that
+ * return their own {@link ExecutableScript} implementations should ensure that
+ * configured script preprocessors are still applied before evaluation if they
+ * want those custom implementations to participate in the script preprocessing
+ * feature.</p>
  *
  * @author Daniel Meyer
  *

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ScriptLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ScriptLogger.java
@@ -44,4 +44,21 @@ public class ScriptLogger extends ProcessEngineLogger {
         "003", "Failed to close script engine: {}", e.getMessage());
   }
 
+  public void warnScriptPreprocessorRequestNull(String preprocessorName) {
+    logWarn(
+        "004",
+        "ScriptPreprocessorRequest is null in preprocessor {}; returning null (no preprocessing will be done).",
+        preprocessorName);
+  }
+
+  public void warnScriptPreprocessingFailed(String language, String preprocessorName, Throwable throwable) {
+    logWarn(
+        "005",
+        "Script preprocessing failed for language {} using preprocessor {}. Error: {}. Falling back to the original script.",
+        language,
+        preprocessorName,
+        throwable.getMessage(),
+        throwable);
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -16,6 +16,12 @@
  */
 package org.operaton.bpm.engine.impl.scripting;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Objects;
+
 import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
@@ -44,7 +50,13 @@ public class SourceExecutableScript extends CompiledExecutableScript {
   protected String scriptSource;
 
   /** Flag to signal if the script should be compiled */
-  protected boolean shouldBeCompiled = true;
+  protected volatile boolean shouldBeCompiled = true;
+
+  /**
+   * Digest of the processed script source used to produce the current {@link #compiledScript}.
+   * A {@code null} value indicates no compiled artifact is present.
+   */
+  protected volatile String compiledScriptSourceDigest;
 
   public SourceExecutableScript(String language, String source) {
     super(language);
@@ -53,16 +65,34 @@ public class SourceExecutableScript extends CompiledExecutableScript {
 
   @Override
   public Object evaluate(ScriptEngine engine, VariableScope variableScope, Bindings bindings) {
-    if (shouldBeCompiled) {
-      compileScript(engine);
+    String processedScript = preprocessScript(scriptSource, variableScope);
+    String processedScriptDigest = null;
+    CompiledScript compiledScriptToEvaluate;
+
+    synchronized (this) {
+      boolean hasCompiledScript = compiledScript != null;
+
+      if (hasCompiledScript || shouldBeCompiled) {
+        processedScriptDigest = computeScriptDigest(processedScript);
+      }
+
+      if (hasCompiledScript && !Objects.equals(compiledScriptSourceDigest, processedScriptDigest)) {
+        invalidateCompiledScript();
+      }
+
+      if (shouldBeCompiled) {
+        compileScript(engine, processedScript);
+      }
+
+      compiledScriptToEvaluate = compiledScript;
     }
 
-    if (getCompiledScript() != null) {
-      return super.evaluate(engine, variableScope, bindings);
+    if (compiledScriptToEvaluate != null) {
+      return evaluateCompiledScript(compiledScriptToEvaluate, variableScope, bindings);
     }
     else {
       try {
-        return evaluateScript(engine, bindings);
+        return evaluateScript(engine, processedScript, bindings);
       } catch (ScriptException e) {
         Throwable cause = e.getCause();
         if (cause instanceof BpmnError bpmnError) {
@@ -74,7 +104,7 @@ public class SourceExecutableScript extends CompiledExecutableScript {
     }
   }
 
-  protected void compileScript(ScriptEngine engine) {
+  protected void compileScript(ScriptEngine engine, String processedScript) {
     ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     if (processEngineConfiguration.isEnableScriptEngineCaching() && processEngineConfiguration.isEnableScriptCompilation()) {
 
@@ -82,7 +112,8 @@ public class SourceExecutableScript extends CompiledExecutableScript {
         synchronized (this) {
           if (getCompiledScript() == null && shouldBeCompiled) {
             // try to compile script
-            compiledScript = compile(engine, language, scriptSource);
+            compiledScript = compile(engine, language, processedScript);
+            compiledScriptSourceDigest = compiledScript != null ? computeScriptDigest(processedScript) : null;
 
             // either the script was successfully compiled or it can't be
             // compiled but we won't try it again
@@ -119,9 +150,9 @@ public class SourceExecutableScript extends CompiledExecutableScript {
 
   }
 
-  protected Object evaluateScript(ScriptEngine engine, Bindings bindings) throws ScriptException {
-    LOG.debugEvaluatingNonCompiledScript(scriptSource);
-    return engine.eval(scriptSource, bindings);
+  protected Object evaluateScript(ScriptEngine engine, String processedScript, Bindings bindings) throws ScriptException {
+    LOG.debugEvaluatingNonCompiledScript(processedScript);
+    return engine.eval(processedScript, bindings);
   }
 
   public String getScriptSource() {
@@ -134,14 +165,31 @@ public class SourceExecutableScript extends CompiledExecutableScript {
    * @param scriptSource
    *          the new script source code
    */
-  public void setScriptSource(String scriptSource) {
-    this.compiledScript = null;
-    shouldBeCompiled = true;
+  public synchronized void setScriptSource(String scriptSource) {
+    invalidateCompiledScript();
     this.scriptSource = scriptSource;
+  }
+
+  protected synchronized void invalidateCompiledScript() {
+    this.compiledScript = null;
+    this.compiledScriptSourceDigest = null;
+    this.shouldBeCompiled = true;
   }
 
   public boolean isShouldBeCompiled() {
     return shouldBeCompiled;
+  }
+
+  private String computeScriptDigest(String scriptText) {
+    if (scriptText == null) {
+      return null;
+    }
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(scriptText.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest);
+    } catch (NoSuchAlgorithmException e) {
+      throw new ScriptCompilationException("Unable to compute script digest", e);
+    }
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.preprocessor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.scripting.ScriptLogger;
+
+/**
+ * Composite {@link ScriptPreprocessor} that applies configured preprocessors sequentially.
+ */
+public class CompositeScriptPreprocessor implements ScriptPreprocessor {
+
+  private static final ScriptLogger LOG = ProcessEngineLogger.SCRIPT_LOGGER;
+
+  private final List<ScriptPreprocessor> preprocessors;
+
+  public CompositeScriptPreprocessor(List<ScriptPreprocessor> preprocessors) {
+    if (preprocessors == null) {
+      this.preprocessors = Collections.emptyList();
+    } else {
+      this.preprocessors = preprocessors.stream()
+          .filter(Objects::nonNull)
+          .toList();
+    }
+  }
+
+  @Override
+  public String process(ScriptPreprocessorRequest request) {
+    if (request == null) {
+      LOG.warnScriptPreprocessorRequestNull(getName());
+      return null;
+    }
+
+    String script = request.getScript();
+    if (script == null) {
+      return null;
+    }
+
+    for (ScriptPreprocessor preprocessor : preprocessors) {
+      ScriptPreprocessorRequest nextRequest = new ScriptPreprocessorRequest(script, request.getLanguage(), request.getVariableScope());
+      String processedScript = preprocessor.process(nextRequest);
+      if (processedScript != null) {
+        script = processedScript;
+      }
+    }
+
+    return script;
+  }
+
+  public List<ScriptPreprocessor> getPreprocessors() {
+    return Collections.unmodifiableList(new ArrayList<>(preprocessors));
+  }
+
+  @Override
+  public String getName() {
+    return "CompositeScriptPreprocessor";
+  }
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.preprocessor;
+
+/**
+ * SPI for preprocessing scripts before they are evaluated by a script engine.
+ */
+public interface ScriptPreprocessor {
+
+  /**
+   * Preprocesses the script before execution.
+   *
+   * @param request encapsulates script text and execution context
+   * @return processed script text; returning {@code null} indicates no replacement and lets
+   *         the caller continue with the original script
+   */
+  String process(ScriptPreprocessorRequest request);
+
+  /**
+   * Returns a stable, human-readable name for this preprocessor implementation.
+   */
+  String getName();
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequest.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.preprocessor;
+
+import org.operaton.bpm.engine.delegate.VariableScope;
+
+/**
+ * Immutable request object passed to a {@link ScriptPreprocessor}.
+ */
+public final class ScriptPreprocessorRequest {
+
+  private final String script;
+  private final String language;
+  private final VariableScope variableScope;
+
+  public ScriptPreprocessorRequest(String script, String language, VariableScope variableScope) {
+    this.script = script;
+    this.language = language;
+    this.variableScope = variableScope;
+  }
+
+  public String getScript() {
+    return script;
+  }
+
+  public String getLanguage() {
+    return language;
+  }
+
+  public VariableScope getVariableScope() {
+    return variableScope;
+  }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationScriptPreprocessorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationScriptPreprocessorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.cfg;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.CompositeScriptPreprocessor;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProcessEngineConfigurationScriptPreprocessorTest {
+
+  private ProcessEngineConfigurationImpl configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
+        .createProcessEngineConfigurationFromResourceDefault();
+  }
+
+  @Test
+  void shouldBeDisabledByDefault() {
+    assertThat(configuration.isEnableScriptPreprocessing()).isFalse();
+  }
+
+  @Test
+  void shouldEnableScriptPreprocessing() {
+    configuration.setEnableScriptPreprocessing(true);
+
+    assertThat(configuration.isEnableScriptPreprocessing()).isTrue();
+  }
+
+  @Test
+  void shouldReturnNullEffectivePreprocessorWhenDisabled() {
+    configuration.setEnableScriptPreprocessing(false);
+    configuration.setScriptPreprocessors(Collections.singletonList(mockPreprocessor("p1")));
+
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isNull();
+  }
+
+  @Test
+  void shouldReturnNullEffectivePreprocessorWhenNoPreprocessorsConfigured() {
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(null);
+
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isNull();
+  }
+
+  @Test
+  void shouldReturnSinglePreprocessorDirectlyWhenOnlyOneConfigured() {
+    ScriptPreprocessor preprocessor = mockPreprocessor("only");
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.singletonList(preprocessor));
+
+    ScriptPreprocessor effective = configuration.getEffectiveScriptPreprocessor();
+
+    assertThat(effective).isSameAs(preprocessor);
+  }
+
+  @Test
+  void shouldReturnCompositePreprocessorWhenMultipleConfigured() {
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Arrays.asList(mockPreprocessor("p1"), mockPreprocessor("p2")));
+
+    ScriptPreprocessor effective = configuration.getEffectiveScriptPreprocessor();
+
+    assertThat(effective).isInstanceOf(CompositeScriptPreprocessor.class);
+  }
+
+  @Test
+  void shouldInvalidateCacheWhenPreprocessorsReplaced() {
+    ScriptPreprocessor first = mockPreprocessor("first");
+    ScriptPreprocessor second = mockPreprocessor("second");
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.singletonList(first));
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isSameAs(first);
+
+    configuration.setScriptPreprocessors(Collections.singletonList(second));
+
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isSameAs(second);
+  }
+
+  @Test
+  void shouldAddScriptPreprocessor() {
+    ScriptPreprocessor preprocessor = mockPreprocessor("p1");
+
+    configuration.addScriptPreprocessor(preprocessor);
+
+    List<ScriptPreprocessor> preprocessors = configuration.getScriptPreprocessors();
+    assertThat(preprocessors).containsExactly(preprocessor);
+  }
+
+  @Test
+  void shouldIgnoreNullOnAddScriptPreprocessor() {
+    configuration.addScriptPreprocessor(null);
+
+    assertThat(configuration.getScriptPreprocessors()).isNullOrEmpty();
+  }
+
+  @Test
+  void shouldReturnDefensiveCopyOfPreprocessors() {
+    configuration.setScriptPreprocessors(Collections.singletonList(mockPreprocessor("p1")));
+
+    List<ScriptPreprocessor> copy = configuration.getScriptPreprocessors();
+    copy.clear();
+
+    assertThat(configuration.getScriptPreprocessors()).hasSize(1);
+  }
+
+  private ScriptPreprocessor mockPreprocessor(String name) {
+    ScriptPreprocessor preprocessor = mock(ScriptPreprocessor.class);
+    when(preprocessor.getName()).thenReturn(name);
+    when(preprocessor.process(any(ScriptPreprocessorRequest.class))).thenReturn(null);
+    return preprocessor;
+  }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.preprocessor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CompositeScriptPreprocessorTest {
+
+  @Test
+  void shouldApplyPreprocessorsInOrder() {
+    ScriptPreprocessor first = scriptPreprocessor("first", request -> request.getScript() + "-first");
+    ScriptPreprocessor second = scriptPreprocessor("second", request -> request.getScript() + "-second");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Arrays.asList(first, second));
+
+    String processed = composite.process(new ScriptPreprocessorRequest("source", "groovy", null));
+
+    assertThat(processed).isEqualTo("source-first-second");
+  }
+
+  @Test
+  void shouldContinueWhenPreprocessorReturnsNull() {
+    ScriptPreprocessor first = scriptPreprocessor("first", request -> null);
+    ScriptPreprocessor second = scriptPreprocessor("second", request -> request.getScript() + "-processed");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Arrays.asList(first, second));
+
+    String processed = composite.process(new ScriptPreprocessorRequest("source", "groovy", null));
+
+    assertThat(processed).isEqualTo("source-processed");
+  }
+
+  @Test
+  void shouldIgnoreNullPreprocessorsInConstructor() {
+    ScriptPreprocessor nonNull = scriptPreprocessor("only", request -> request.getScript() + "-ok");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Arrays.asList(null, nonNull, null));
+
+    String processed = composite.process(new ScriptPreprocessorRequest("source", "groovy", null));
+
+    assertThat(processed).isEqualTo("source-ok");
+    assertThat(composite.getPreprocessors()).containsExactly(nonNull);
+  }
+
+  @Test
+  void shouldReturnNullWhenRequestIsNull() {
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(null);
+
+    assertThat(composite.process(null)).isNull();
+  }
+
+  @Test
+  void shouldReturnNullWhenScriptIsNull() {
+    AtomicBoolean called = new AtomicBoolean(false);
+    ScriptPreprocessor preprocessor = scriptPreprocessor("probe", request -> {
+      called.set(true);
+      return request.getScript() + "-changed";
+    });
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Collections.singletonList(preprocessor));
+
+    String result = composite.process(new ScriptPreprocessorRequest(null, "groovy", null));
+
+    assertThat(result).isNull();
+    assertThat(called).isFalse();
+  }
+
+  @Test
+  void shouldProcessEmptyScript() {
+    ScriptPreprocessor preprocessor = scriptPreprocessor("probe", request -> request.getScript() + "-changed");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Collections.singletonList(preprocessor));
+
+    String result = composite.process(new ScriptPreprocessorRequest("", "groovy", null));
+
+    assertThat(result).isEqualTo("-changed");
+  }
+
+  @Test
+  void shouldExposeCompositeName() {
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(null);
+
+    assertThat(composite.getName()).isEqualTo("CompositeScriptPreprocessor");
+  }
+
+  private ScriptPreprocessor scriptPreprocessor(String name, Function<ScriptPreprocessorRequest, String> behavior) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return behavior.apply(request);
+      }
+
+      @Override
+      public String getName() {
+        return name;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequestTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequestTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.preprocessor;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.delegate.VariableScope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ScriptPreprocessorRequestTest {
+
+  @Test
+  void shouldConstructWithAllParameters() {
+    String script = "var x = 1;";
+    String language = "javascript";
+    VariableScope variableScope = mock(VariableScope.class);
+
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(script, language, variableScope);
+
+    assertThat(request.getScript()).isEqualTo(script);
+    assertThat(request.getLanguage()).isEqualTo(language);
+    assertThat(request.getVariableScope()).isEqualTo(variableScope);
+  }
+
+  @Test
+  void shouldConstructWithAllNullFields() {
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(null, null, null);
+
+    assertThat(request.getScript()).isNull();
+    assertThat(request.getLanguage()).isNull();
+    assertThat(request.getVariableScope()).isNull();
+  }
+
+  @Test
+  void shouldReturnEmptyScriptAsIs() {
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest("", "groovy", null);
+
+    assertThat(request.getScript()).isEmpty();
+    assertThat(request.getLanguage()).isEqualTo("groovy");
+    assertThat(request.getVariableScope()).isNull();
+  }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptCompilationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptCompilationTest.java
@@ -16,6 +16,13 @@
  */
 package org.operaton.bpm.engine.test.standalone.scripting;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +32,8 @@ import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
 import org.operaton.bpm.engine.impl.scripting.ScriptFactory;
 import org.operaton.bpm.engine.impl.scripting.SourceExecutableScript;
 import org.operaton.bpm.engine.impl.scripting.env.ScriptingEnvironment;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -136,6 +145,103 @@ class ScriptCompilationTest {
     // it is compiled again
     assertThat(script.isShouldBeCompiled()).isFalse();
     assertThat(script.getCompiledScript()).isNotNull();
+  }
+
+  @Test
+  void testRecompileWhenPreprocessedScriptChanges() {
+    boolean preprocessingEnabledBefore = processEngineConfiguration.isEnableScriptPreprocessing();
+    List<ScriptPreprocessor> preprocessorsBefore = processEngineConfiguration.getScriptPreprocessors();
+
+    AtomicInteger preprocessorInvocations = new AtomicInteger();
+    ScriptPreprocessor preprocessor = new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return preprocessorInvocations.incrementAndGet() == 1 ? "1 + 1" : "1 + 2";
+      }
+
+      @Override
+      public String getName() {
+        return "changing-preprocessor";
+      }
+    };
+    enablePreprocessingWith(preprocessor);
+
+    AtomicInteger compileInvocations = new AtomicInteger();
+    SourceExecutableScript script = createCountingScript(compileInvocations);
+
+    try {
+      Object firstResult = executeScript(script);
+      CompiledScript compiledForFirstPreprocessedOutput = script.getCompiledScript();
+
+      Object secondResult = executeScript(script);
+      CompiledScript compiledForSecondPreprocessedOutput = script.getCompiledScript();
+
+      assertThat(firstResult).isEqualTo(2);
+      assertThat(secondResult).isEqualTo(3);
+      assertThat(compileInvocations).hasValue(2);
+      assertThat(compiledForFirstPreprocessedOutput).isNotNull();
+      assertThat(compiledForSecondPreprocessedOutput).isNotNull();
+      assertThat(compiledForSecondPreprocessedOutput).isNotSameAs(compiledForFirstPreprocessedOutput);
+    } finally {
+      restorePreprocessingConfig(preprocessingEnabledBefore, preprocessorsBefore);
+    }
+  }
+
+  @Test
+  void testCompiledScriptCacheIsReusedWhenPreprocessedScriptIsStable() {
+    boolean preprocessingEnabledBefore = processEngineConfiguration.isEnableScriptPreprocessing();
+    List<ScriptPreprocessor> preprocessorsBefore = processEngineConfiguration.getScriptPreprocessors();
+
+    ScriptPreprocessor preprocessor = new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return "1 + 1";
+      }
+
+      @Override
+      public String getName() {
+        return "stable-preprocessor";
+      }
+    };
+    enablePreprocessingWith(preprocessor);
+
+    AtomicInteger compileInvocations = new AtomicInteger();
+    SourceExecutableScript script = createCountingScript(compileInvocations);
+
+    try {
+      Object firstResult = executeScript(script);
+      CompiledScript firstCompiledScript = script.getCompiledScript();
+      Object secondResult = executeScript(script);
+      Object thirdResult = executeScript(script);
+
+      assertThat(firstResult).isEqualTo(2);
+      assertThat(secondResult).isEqualTo(2);
+      assertThat(thirdResult).isEqualTo(2);
+      assertThat(script.getCompiledScript()).isSameAs(firstCompiledScript);
+      assertThat(compileInvocations).hasValue(1);
+    } finally {
+      restorePreprocessingConfig(preprocessingEnabledBefore, preprocessorsBefore);
+    }
+  }
+
+  private SourceExecutableScript createCountingScript(AtomicInteger compileInvocations) {
+    return new SourceExecutableScript(SCRIPT_LANGUAGE, "ignored") {
+      @Override
+      public CompiledScript compile(ScriptEngine scriptEngine, String language, String src) {
+        compileInvocations.incrementAndGet();
+        return super.compile(scriptEngine, language, src);
+      }
+    };
+  }
+
+  private void enablePreprocessingWith(ScriptPreprocessor preprocessor) {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setScriptPreprocessors(Collections.singletonList(preprocessor));
+  }
+
+  private void restorePreprocessingConfig(boolean enabledBefore, List<ScriptPreprocessor> preprocessorsBefore) {
+    processEngineConfiguration.setEnableScriptPreprocessing(enabledBefore);
+    processEngineConfiguration.setScriptPreprocessors(preprocessorsBefore);
   }
 
   protected Object executeScript(final ExecutableScript script) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptPreprocessingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptPreprocessingTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.test.standalone.scripting;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
+import org.operaton.bpm.engine.impl.scripting.ScriptFactory;
+import org.operaton.bpm.engine.impl.scripting.SourceExecutableScript;
+import org.operaton.bpm.engine.impl.scripting.env.ScriptingEnvironment;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.operaton.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(ProcessEngineExtension.class)
+class ScriptPreprocessingTest {
+
+  private static final String SCRIPT_LANGUAGE = "groovy";
+  private static final String ORIGINAL_SCRIPT = "1 + 1";
+  private static final String PREPROCESSED_SCRIPT = "1 + 2";
+
+  ProcessEngineConfigurationImpl processEngineConfiguration;
+  private ScriptFactory scriptFactory;
+
+  @BeforeEach
+  void setUp() {
+    scriptFactory = processEngineConfiguration.getScriptFactory();
+    processEngineConfiguration.setEnableScriptPreprocessing(false);
+    processEngineConfiguration.setScriptPreprocessors(null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    processEngineConfiguration.setEnableScriptPreprocessing(false);
+    processEngineConfiguration.setScriptPreprocessors(null);
+  }
+
+  @Test
+  void shouldReturnOriginalScriptWhenPreprocessingDisabled() {
+    AtomicReference<String> capturedScript = new AtomicReference<>();
+    processEngineConfiguration.setEnableScriptPreprocessing(false);
+    processEngineConfiguration.addScriptPreprocessor(capturingPreprocessor(capturedScript, PREPROCESSED_SCRIPT));
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    Object result = executeScript(script);
+
+    assertThat(capturedScript.get()).isNull();
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  void shouldApplyPreprocessorWhenEnabled() {
+    AtomicReference<String> capturedScript = new AtomicReference<>();
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(capturingPreprocessor(capturedScript, PREPROCESSED_SCRIPT));
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    Object result = executeScript(script);
+
+    assertThat(capturedScript.get()).isEqualTo(ORIGINAL_SCRIPT);
+    assertThat(result).isEqualTo(3);
+  }
+
+  @Test
+  void shouldFallBackToOriginalScriptWhenPreprocessorReturnsNull() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(nullReturningPreprocessor());
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    Object result = executeScript(script);
+
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  void shouldFallBackToOriginalScriptWhenPreprocessorThrows() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(throwingPreprocessor());
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    Object result = executeScript(script);
+
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  void shouldApplyPreprocessorsInOrderWhenMultipleConfigured() {
+    AtomicReference<String> inputToSecond = new AtomicReference<>();
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(appendingPreprocessor("-a"));
+    processEngineConfiguration.addScriptPreprocessor(capturingPreprocessor(inputToSecond, PREPROCESSED_SCRIPT));
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    Object result = executeScript(script);
+
+    assertThat(inputToSecond.get()).isEqualTo("1 + 1-a");
+    assertThat(result).isEqualTo(3);
+  }
+
+  private SourceExecutableScript createScript(String source) {
+    return (SourceExecutableScript) scriptFactory.createScriptFromSource(SCRIPT_LANGUAGE, source);
+  }
+
+  private Object executeScript(ExecutableScript script) {
+    ScriptingEnvironment scriptingEnvironment = processEngineConfiguration.getScriptingEnvironment();
+    return processEngineConfiguration.getCommandExecutorTxRequired()
+      .execute(commandContext -> scriptingEnvironment.execute(script, null));
+  }
+
+  private ScriptPreprocessor capturingPreprocessor(AtomicReference<String> capture, String output) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        capture.set(request.getScript());
+        return output;
+      }
+
+      @Override
+      public String getName() {
+        return "capturingPreprocessor";
+      }
+    };
+  }
+
+  private ScriptPreprocessor nullReturningPreprocessor() {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return null;
+      }
+
+      @Override
+      public String getName() {
+        return "nullReturningPreprocessor";
+      }
+    };
+  }
+
+  private ScriptPreprocessor throwingPreprocessor() {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        throw new IllegalStateException("Simulated preprocessing failure");
+      }
+
+      @Override
+      public String getName() {
+        return "throwingPreprocessor";
+      }
+    };
+  }
+
+  private ScriptPreprocessor appendingPreprocessor(String suffix) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return request.getScript() + suffix;
+      }
+
+      @Override
+      public String getName() {
+        return "appendingPreprocessor[" + suffix + "]";
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary

This PR backports the Fluxnova script preprocessing SPI to Operaton as a concrete Draft code change.

It adds a configurable script preprocessor chain to the engine and applies it before script execution for both static source scripts and dynamically resolved script expressions. When script compilation is enabled, the compiled-script cache is tied to the preprocessed source digest so a changed preprocessor result cannot accidentally reuse a compiled artifact from an older source.

## What Changed

- Adds `ScriptPreprocessor`, `ScriptPreprocessorRequest`, and `CompositeScriptPreprocessor` under the engine scripting implementation package.
- Adds `ProcessEngineConfigurationImpl` switches and helpers for enabling preprocessing and configuring one or more preprocessors.
- Applies preprocessing in `SourceExecutableScript` and `DynamicExecutableScript` while falling back to the original script if preprocessing is disabled, absent, returns `null`, or throws.
- Updates compiled script handling so compiled artifacts are invalidated when the preprocessed script output changes.
- Adds focused engine tests for configuration behavior, composite preprocessor behavior, request metadata, runtime script preprocessing, and compile-cache invalidation/reuse.

## Change Unit

- `515` [fluxnova:0ba09fa90b73] feat(engine): script preprocessing feature addition to fluxnova engine

## Attribution

Backported-adapted from Fluxnova commit `0ba09fa90b733043b66c91b520bb9ed703cb0f39`.

Source commit: https://github.com/finos/fluxnova-bpm-platform/commit/0ba09fa90b733043b66c91b520bb9ed703cb0f39

Original author: Palanisamy, Prakash <prakash.palanisamy@fmr.com>

## Reviewer Notes

This remains Draft because it introduces a new engine extension point and changes script evaluation behavior. The important review decision is whether Operaton wants this SPI in `impl.scripting.preprocessor`, and whether the current fail-open fallback is the desired default when a preprocessor throws.

Operaton adaptation notes:

- New SPI files use the Operaton contributors header because they are newly added Operaton files adapted from the Fluxnova feature.
- The Fluxnova commit added `commons-codec` for SHA-256. This PR uses Java 17 `MessageDigest`/`HexFormat` instead, avoiding an extra engine dependency.
- The Fluxnova QA container tests were not copied into this Draft. The PR adds focused engine-module tests that cover the same core runtime behavior: preprocessing is applied, `null`/throwing preprocessors fall back to the original script, chained preprocessors run in order, and compiled-script cache entries are not reused across different preprocessed sources.

## Verification

- `git diff --check origin/main...HEAD`
- `./mvnw -pl engine -Dtest=ProcessEngineConfigurationScriptPreprocessorTest,CompositeScriptPreprocessorTest,ScriptPreprocessorRequestTest,ScriptPreprocessingTest,ScriptCompilationTest test -Dskip.frontend.build=true`
