### PR TITLE
feat(engine): use random UUID v4 for strong IDs

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/StrongUuidGenerator.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/StrongUuidGenerator.java
@@ -16,36 +16,18 @@
  */
 package org.operaton.bpm.engine.impl.persistence;
 
-import com.fasterxml.uuid.EthernetAddress;
-import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedGenerator;
+import java.util.UUID;
 
 import org.operaton.bpm.engine.impl.cfg.IdGenerator;
 
 /**
- * {@link IdGenerator} implementation based on the current time and the ethernet
- * address of the machine it is running on.
- *
- * @author Daniel Meyer
+ * Secure random UUID (v4) based {@link IdGenerator}.
  */
 public class StrongUuidGenerator implements IdGenerator {
 
-  // different ProcessEngines on the same classloader share one generator.
-  protected static TimeBasedGenerator timeBasedGenerator;
-
-  public StrongUuidGenerator() {
-    ensureGeneratorInitialized();
-  }
-
-  protected synchronized void ensureGeneratorInitialized() {
-    if (timeBasedGenerator == null) {
-      timeBasedGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface());
-    }
-  }
-
   @Override
   public String getNextId() {
-    return timeBasedGenerator.generate().toString();
+    return UUID.randomUUID().toString();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/UuidGeneratorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/UuidGeneratorTest.java
@@ -18,12 +18,13 @@ package org.operaton.bpm.engine.test.concurrency;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 
-import com.fasterxml.uuid.EthernetAddress;
-import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedGenerator;
 import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.impl.cfg.IdGenerator;
+import org.operaton.bpm.engine.impl.persistence.StrongUuidGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,18 +41,27 @@ class UuidGeneratorTest {
   void testMultithreaded() throws Exception {
     final List<Thread> threads = new ArrayList<>();
 
-    final TimeBasedGenerator timeBasedGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface());
+    final IdGenerator idGenerator = new StrongUuidGenerator();
     final ConcurrentSkipListSet<String> generatedIds = new ConcurrentSkipListSet<>();
     final ConcurrentSkipListSet<String> duplicatedIds = new ConcurrentSkipListSet<>();
+    final ConcurrentSkipListSet<String> nonUuidV4Ids = new ConcurrentSkipListSet<>();
 
     for (int i = 0; i < THREAD_COUNT; i++) {
       Thread thread = new Thread(() -> {
         for (int j = 0;j < LOOP_COUNT;j++) {
 
-          String id = timeBasedGenerator.generate().toString();
+          String id = idGenerator.getNextId();
           boolean wasAdded = generatedIds.add(id);
           if (!wasAdded) {
             duplicatedIds.add(id);
+          }
+
+          try {
+            if (UUID.fromString(id).version() != 4) {
+              nonUuidV4Ids.add(id);
+            }
+          } catch (IllegalArgumentException e) {
+            nonUuidV4Ids.add(id);
           }
         }
       });
@@ -65,5 +75,6 @@ class UuidGeneratorTest {
 
     assertThat(generatedIds).hasSize(THREAD_COUNT * LOOP_COUNT);
     assertThat(duplicatedIds).isEmpty();
+    assertThat(nonUuidV4Ids).isEmpty();
   }
 }

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
@@ -164,13 +164,13 @@ class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
     );
     // And
     Mocks.register("serviceTask_1", "someService");
-    execute(jobQuery().list().get(0));
+    execute(jobQuery().activityId("ServiceTask_1").singleResult());
     // And
     Mocks.register("serviceTask_2", "someService");
-    execute(jobQuery().list().get(0));
+    execute(jobQuery().activityId("ServiceTask_2").singleResult());
     // And
     Mocks.register("serviceTask_3", "someService");
-    execute(jobQuery().list().get(0));
+    execute(jobQuery().activityId("ServiceTask_3").singleResult());
     // Then
     expect(() -> assertThat(processInstance).job("ServiceTask_4").isNotNull(), ProcessEngineException.class);
   }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceResourceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceResourceTest.java
@@ -119,8 +119,12 @@ class ProcessInstanceResourceTest extends AbstractCockpitPluginTest {
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
     assertThat(result).hasSize(2);
-    assertThat(result.get(0).getBusinessKey()).isEqualTo("firstCall:myBusinessKey");
-    assertThat(result.get(1).getBusinessKey()).isEqualTo("secondCall:myBusinessKey");
+    assertThat(result)
+        .extracting(CalledProcessInstanceDto::getBusinessKey)
+        .containsExactlyInAnyOrder(
+            "firstCall:myBusinessKey",
+            "secondCall:myBusinessKey"
+        );
   }
 
 


### PR DESCRIPTION
## Summary

This PR backports the EximeeBPMS switch from time/MAC-based UUID v1 generation to random UUID v4 generation.

It changes `StrongUuidGenerator` to use `UUID.randomUUID()` and adapts tests that implicitly relied on UUID-v1 ordering by querying jobs/activity results explicitly or order-independently. The existing UUID concurrency test is also updated so it now exercises `StrongUuidGenerator` directly and asserts that generated IDs are UUID v4 values.

## Change unit

- `627` [eximeebpms:751bd7925cae] Replaced the current time-based UUID (v1) generation in StrongUuidGenerator with random UUID v4 (EximeeBPMS/eximeebpms#117)

## Attribution

Backported-adapted from EximeeBPMS commit `751bd7925cae3a4c5efa4598b59d113589810fcc`.

Original PR: https://github.com/EximeeBPMS/eximeebpms/pull/117

Original author: Robert Mastalerek <robert.mastalerek@gmail.com>

## Reviewer notes

This changes runtime ID semantics from time-based UUIDs to random UUIDs. The dependency cleanup for `com.fasterxml.uuid:java-uuid-generator` is intentionally left for explicit review, because the dependency is still referenced in several modules beyond the engine class changed here.

## Verification

- `git diff --check origin/main...HEAD`
- `./mvnw -pl engine -Dtest=UuidGeneratorTest,QueryByIdAfterTest test -Dskip.frontend.build=true`
- `./mvnw -pl test-utils/assert/core -Dtest=ProcessInstanceAssertJobTest test -Dskip.frontend.build=true`
- `./mvnw -pl webapps/assembly -Dtest=ProcessInstanceResourceTest test -Dskip.frontend.build=true`