### PR TITLE
perf(engine): allow skipping auth group prefiltering

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1000,6 +1000,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected boolean legacyJobRetryBehaviorEnabled;
 
   /**
+   * Minimum authenticated group count before authorization checks prefilter the groups against ACT_RU_AUTHORIZATION.
+   */
+  protected int authGroupFilterThreshold;
+
+  /**
    * @return {@code true} if the exception code feature is disabled and vice-versa.
    */
   public boolean isDisableExceptionCode() {
@@ -5278,6 +5283,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   
   public ProcessEngineConfiguration setLegacyJobRetryBehaviorEnabled(boolean legacyJobRetryBehaviorEnabled) {
     this.legacyJobRetryBehaviorEnabled = legacyJobRetryBehaviorEnabled;
+    return this;
+  }
+
+  public int getAuthGroupFilterThreshold() {
+    return authGroupFilterThreshold;
+  }
+
+  public ProcessEngineConfigurationImpl setAuthGroupFilterThreshold(int authGroupFilterThreshold) {
+    this.authGroupFilterThreshold = authGroupFilterThreshold;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -1139,11 +1139,22 @@ public class AuthorizationManager extends AbstractManager {
     if(authenticatedGroupIds == null || authenticatedGroupIds.isEmpty()) {
       return EMPTY_LIST;
     }
+    else if (authenticatedGroupIds.size() < getAuthGroupFilterThreshold()) {
+      return authenticatedGroupIds;
+    }
     else {
       Set<String> groupIntersection = new HashSet<>(getAllGroups());
       groupIntersection.retainAll(authenticatedGroupIds);
       return new ArrayList<>(groupIntersection);
     }
+  }
+
+  protected int getAuthGroupFilterThreshold() {
+    var configuration = Context.getProcessEngineConfiguration();
+    if (configuration != null) {
+      return configuration.getAuthGroupFilterThreshold();
+    }
+    return 0;
   }
 
   protected Set<String> getAllGroups() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
@@ -85,6 +85,24 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
+  void testTaskQueryWithoutGroupAuthorizationsAndSkippedGroupFiltering() {
+    withSkippedGroupPrefiltering(() -> processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
+      AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
+
+      TaskQueryImpl taskQuery = (TaskQueryImpl) spy(processEngine.getTaskService().createTaskQuery());
+      AuthorizationCheck authCheck = spy(new AuthorizationCheck());
+      when(taskQuery.getAuthCheck()).thenReturn(authCheck);
+
+      taskQuery.list();
+
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
+      verify(authCheck, atLeastOnce()).setAuthGroupIds(TEST_GROUP_IDS);
+
+      return null;
+    }));
+  }
+
+  @Test
   void testTaskQueryWithOneGroupAuthorization() {
     createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
 
@@ -102,6 +120,26 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
       return null;
     });
+  }
+
+  @Test
+  void testTaskQueryWithOneGroupAuthorizationAndSkippedGroupFiltering() {
+    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
+
+    withSkippedGroupPrefiltering(() -> processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
+      AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
+
+      TaskQueryImpl taskQuery = (TaskQueryImpl) spy(processEngine.getTaskService().createTaskQuery());
+      AuthorizationCheck authCheck = spy(new AuthorizationCheck());
+      when(taskQuery.getAuthCheck()).thenReturn(authCheck);
+
+      taskQuery.list();
+
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
+      verify(authCheck, atLeastOnce()).setAuthGroupIds(TEST_GROUP_IDS);
+
+      return null;
+    }));
   }
 
   @Test
@@ -185,6 +223,28 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
       return null;
     });
+  }
+
+  @Test
+  void testCheckAuthorizationWithOneGroupAuthorizationAndSkippedGroupFiltering() {
+    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
+
+    withSkippedGroupPrefiltering(() -> processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
+      AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
+      DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
+
+      authorizationService.isUserAuthorized(TEST_USER_ID, TEST_GROUP_IDS, Permissions.READ, Resources.TASK);
+
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
+
+      ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
+      verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
+
+      AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();
+      assertThat(authorizationCheck.getAuthGroupIds()).isEqualTo(TEST_GROUP_IDS);
+
+      return null;
+    }));
   }
 
   @Test
@@ -290,6 +350,16 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   protected void createGroupAndAddUser(String groupId, String userId) {
     createGroup(groupId);
     identityService.createMembership(userId, groupId);
+  }
+
+  protected void withSkippedGroupPrefiltering(Runnable runnable) {
+    int previousThreshold = processEngineConfiguration.getAuthGroupFilterThreshold();
+    processEngineConfiguration.setAuthGroupFilterThreshold(TEST_GROUP_IDS.size() + 1);
+    try {
+      runnable.run();
+    } finally {
+      processEngineConfiguration.setAuthGroupFilterThreshold(previousThreshold);
+    }
   }
 
   protected <T extends Session> T spyOnSession(CommandContext commandContext, Class<T> sessionClass) {


### PR DESCRIPTION
## Summary

Backports an Operaton-adapted version of CIBSeven's `authGroupFilterThreshold` optimization.

This adds a new engine configuration option, `authGroupFilterThreshold`. By default it is `0`, so Operaton keeps the current behavior. When set above the number of authenticated groups, the authorization manager skips the preliminary lookup of authorized groups from `ACT_RU_AUTHORIZATION` and passes the authenticated group list through unchanged.

## What This Optimizes

Today, authorization checks prefilter the authenticated groups by querying all group ids that appear in authorization rows and intersecting that database result with the authenticated groups. That can avoid large `GROUP_ID_ IN (...)` lists, but it also adds an extra authorization-table lookup even for very small group lists.

With this opt-in threshold, installations can skip that prefilter when the authenticated group list is already small enough that the additional lookup is not worth it.

## Scope

This PR intentionally implements only the CIBSeven threshold configuration from commit `2d36d045ba006272f72d7270ec3fb32d307bf7a0`.

The earlier discussion PR also grouped CIBSeven commit `fd12ffc2e422683ec9e41ccb82ff3bafe4d8b19c`, which rewrites task authorization SQL to use an EXISTS-based fast path. That change is security- and dialect-sensitive SQL behavior and is intentionally left out of this PR. It remains tracked separately as `needs_design` in the backport database.

## Attribution

Backport adapted from CIBSeven:

- CIBSeven PR: cibseven/cibseven#221
- Source commit: `2d36d045ba006272f72d7270ec3fb32d307bf7a0`
- Source subject: `chore(engine): add a threshold for a group number to optionally skip filtering requests to the authentication table (#221)`
- Original author: vladgrind <156691737+vladgrind@users.noreply.github.com>

## Reviewer Notes

The default remains `0`, so existing installations continue to prefilter authenticated groups exactly as before.

The test coverage verifies the observable SQL-parameter behavior rather than just the new setter: when the threshold skip is enabled, both task-query authorization and direct authorization checks receive the full authenticated group list instead of the group list prefiltered through existing authorization rows.

## Verification

```bash
./mvnw -pl engine -Dtest=GroupAuthorizationTest test
```

Result: 12 tests, 0 failures, 0 errors.
