### PR TITLE
feat(engine-rest): add case-insensitive LIKE query option

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
@@ -670,6 +670,16 @@
       desc = "Match all variable values in this query case-insensitively. If set
               `variableValue` and `variablevalue` are treated as equal." />
 
+  <@lib.parameter name = "likePatternIgnoreCase"
+      location = "query"
+      type = "boolean"
+      defaultValue = "false"
+      desc = "Makes LIKE comparisons case-insensitive for fields that are case-sensitive by default.
+              This affects: `assigneeLike`, `taskDefinitionKeyLike`, `processInstanceBusinessKeyLike`,
+              `caseInstanceBusinessKeyLike`, `processDefinitionNameLike`, `caseDefinitionNameLike`,
+              and `candidateGroupLike`. Note: `nameLike`, `nameNotLike`, and `descriptionLike`
+              are already case-insensitive by default." />
+
   <@lib.parameter name = "parentTaskId"
       location = "query"
       type = "string"

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/user-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/user-query-params.ftl
@@ -62,5 +62,13 @@
     name = "potentialStarter"
     location = "query"
     type = "string"
-    last = last
     desc = "Only select Users that are potential starter for the given process definition."/>
+
+<@lib.parameter
+    name = "likePatternIgnoreCase"
+    location = "query"
+    type = "boolean"
+    defaultValue = "false"
+    last = last
+    desc = "Makes LIKE comparisons case-insensitive for fields that are case-sensitive by default.
+            This affects: `firstNameLike`, `lastNameLike`, and `emailLike`."/>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
@@ -681,7 +681,17 @@
         defaultValue = "false"
         desc = "Match all variable values in this query case-insensitively. If set
                 `variableValue` and `variablevalue` are treated as equal." />
-  
+
+    <@lib.property
+        name = "likePatternIgnoreCase"
+        type = "boolean"
+        defaultValue = "false"
+        desc = "Makes LIKE comparisons case-insensitive for fields that are case-sensitive by default.
+                This affects: `assigneeLike`, `taskDefinitionKeyLike`, `processInstanceBusinessKeyLike`,
+                `caseInstanceBusinessKeyLike`, `processDefinitionNameLike`, `caseDefinitionNameLike`,
+                and `candidateGroupLike`. Note: `nameLike`, `nameNotLike`, and `descriptionLike`
+                are already case-insensitive by default." />
+
     <@lib.property
         name = "parentTaskId"
         type = "string"

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/identity/UserQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/identity/UserQueryDto.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.identity.UserQuery;
 import org.operaton.bpm.engine.rest.dto.AbstractQueryDto;
 import org.operaton.bpm.engine.rest.dto.OperatonQueryParam;
+import org.operaton.bpm.engine.rest.dto.converter.BooleanConverter;
 import org.operaton.bpm.engine.rest.dto.converter.StringArrayConverter;
 
 /**
@@ -60,6 +61,7 @@ public class UserQueryDto extends AbstractQueryDto<UserQuery> {
   protected String memberOfGroup;
   protected String potentialStarter;
   protected String tenantId;
+  protected Boolean likePatternIgnoreCase;
 
   public UserQueryDto() {
 
@@ -124,6 +126,15 @@ public class UserQueryDto extends AbstractQueryDto<UserQuery> {
     this.tenantId = tenantId;
   }
 
+  @OperatonQueryParam(value = "likePatternIgnoreCase", converter = BooleanConverter.class)
+  public void setLikePatternIgnoreCase(Boolean likePatternIgnoreCase) {
+    this.likePatternIgnoreCase = likePatternIgnoreCase;
+  }
+
+  public Boolean getLikePatternIgnoreCase() {
+    return likePatternIgnoreCase;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -168,6 +179,9 @@ public class UserQueryDto extends AbstractQueryDto<UserQuery> {
     }
     if (tenantId != null) {
       query.memberOfTenant(tenantId);
+    }
+    if (Boolean.TRUE.equals(likePatternIgnoreCase)) {
+      query.likePatternIgnoreCase();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -185,6 +185,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
   protected Boolean variableNamesIgnoreCase;
   protected Boolean variableValuesIgnoreCase;
+  protected Boolean likePatternIgnoreCase;
 
   private List<VariableQueryParameterDto> taskVariables;
   private List<VariableQueryParameterDto> processVariables;
@@ -713,6 +714,11 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     this.variableValuesIgnoreCase = variableValuesCaseInsensitive;
   }
 
+  @OperatonQueryParam(value = "likePatternIgnoreCase", converter = BooleanConverter.class)
+  public void setLikePatternIgnoreCase(Boolean likePatternIgnoreCase) {
+    this.likePatternIgnoreCase = likePatternIgnoreCase;
+  }
+
   @OperatonQueryParam(value = "withCommentAttachmentInfo", converter = BooleanConverter.class)
   public void setWithCommentAttachmentInfo(Boolean withCommentAttachmentInfo) {
     this.withCommentAttachmentInfo = withCommentAttachmentInfo;
@@ -1106,6 +1112,10 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     return variableValuesIgnoreCase;
   }
 
+  public Boolean isLikePatternIgnoreCase() {
+    return likePatternIgnoreCase;
+  }
+
   public Boolean getWithCommentAttachmentInfo() { return withCommentAttachmentInfo;}
 
   public Boolean getWithTaskVariablesInReturn() {
@@ -1404,6 +1414,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     if(variableNamesIgnoreCase != null && variableNamesIgnoreCase) {
       query.matchVariableNamesIgnoreCase();
     }
+    if (Boolean.TRUE.equals(likePatternIgnoreCase)) {
+      query.likePatternIgnoreCase();
+    }
 
     if (taskVariables != null) {
       for (VariableQueryParameterDto variableQueryParam : taskVariables) {
@@ -1665,6 +1678,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
     dto.variableNamesIgnoreCase = taskQuery.isVariableNamesIgnoreCase();
     dto.variableValuesIgnoreCase = taskQuery.isVariableValuesIgnoreCase();
+    dto.likePatternIgnoreCase = taskQuery.isLikePatternIgnoreCase();
 
     if (taskQuery.isFollowUpNullAccepted()) {
       dto.followUpBeforeOrNotExistent = taskQuery.getFollowUpBefore();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -553,6 +553,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     parameters.put("withoutCandidateUsers", true);
     parameters.put("withoutDueDate", true);
     parameters.put("withCommentAttachmentInfo", true);
+    parameters.put("likePatternIgnoreCase", true);
 
     return parameters;
   }
@@ -621,6 +622,22 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).withoutCandidateUsers();
     verify(mockQuery).withoutDueDate();
     verify(mockQuery).withCommentAttachmentInfo();
+    verify(mockQuery).likePatternIgnoreCase();
+  }
+
+  @Test
+  void testQueryWithLikePatternIgnoreCaseGetRequest() {
+    String assigneeLike = "testUser%";
+
+    given()
+      .queryParam("assigneeLike", assigneeLike)
+      .queryParam("likePatternIgnoreCase", true)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .expect().statusCode(Status.OK.getStatusCode())
+    .when().get(TASK_QUERY_URL);
+
+    verify(mockQuery).taskAssigneeLike(assigneeLike);
+    verify(mockQuery).likePatternIgnoreCase();
   }
 
   @Test
@@ -1753,6 +1770,23 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     verify(mockQuery).includeAssignedTasks();
     verify(mockQuery).taskCandidateGroupIn(argThat(new EqualsList(candidateGroups)));
+  }
+
+  @Test
+  void testQueryWithLikePatternIgnoreCasePostRequest() {
+    String assigneeLike = "testUser%";
+    Map<String, Object> queryParameters = new HashMap<>();
+    queryParameters.put("assigneeLike", assigneeLike);
+    queryParameters.put("likePatternIgnoreCase", true);
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(queryParameters)
+    .expect().statusCode(Status.OK.getStatusCode())
+    .when().post(TASK_QUERY_URL);
+
+    verify(mockQuery).taskAssigneeLike(assigneeLike);
+    verify(mockQuery).likePatternIgnoreCase();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceQueryTest.java
@@ -167,6 +167,22 @@ public class UserRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   @Test
+  void testQueryWithLikePatternIgnoreCaseGetRequest() {
+    String firstNameLike = "first%";
+
+    given()
+      .queryParam("firstNameLike", firstNameLike)
+      .queryParam("likePatternIgnoreCase", true)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+    .when()
+      .get(USER_QUERY_URL);
+
+    verify(mockQuery).userFirstNameLike(firstNameLike);
+    verify(mockQuery).likePatternIgnoreCase();
+  }
+
+  @Test
   void testLastNameLikeQuery() {
     String[] testQueries = new String[] {"last%", "%Name", "%stNa%"};
 

--- a/engine/src/main/java/org/operaton/bpm/engine/identity/UserQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/identity/UserQuery.java
@@ -65,6 +65,12 @@ public interface UserQuery extends Query<UserQuery, User> {
   /** Only select {@link User}s that belongs to the given tenant. */
   UserQuery memberOfTenant(String tenantId);
 
+  /**
+   * Makes LIKE comparisons case-insensitive for fields that are case-sensitive by default.
+   * This affects firstNameLike, lastNameLike, and emailLike.
+   */
+  UserQuery likePatternIgnoreCase();
+
   //sorting ////////////////////////////////////////////////////////
 
   /** Order by user id (needs to be followed by {@link #asc()} or {@link #desc()}). */

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
@@ -162,6 +162,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
 
   protected Boolean variableNamesIgnoreCase;
   protected Boolean variableValuesIgnoreCase;
+  protected Boolean likePatternIgnoreCase;
 
   protected String parentTaskId;
   protected boolean isWithoutTenantId;
@@ -1835,6 +1836,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     return variableValuesIgnoreCase;
   }
 
+  public Boolean isLikePatternIgnoreCase() {
+    return likePatternIgnoreCase;
+  }
+
   public List<TaskQueryImpl> getQueries() {
     return queries;
   }
@@ -2137,6 +2142,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
       extendedQuery.taskNameCaseInsensitive();
     }
 
+    if (Boolean.TRUE.equals(extendingQuery.isLikePatternIgnoreCase()) || Boolean.TRUE.equals(this.isLikePatternIgnoreCase())) {
+      extendedQuery.likePatternIgnoreCase();
+    }
+
     if (extendingQuery.getTenantIds() != null) {
       extendedQuery.tenantIdIn(extendingQuery.getTenantIds());
     } else if (this.getTenantIds() != null) {
@@ -2296,6 +2305,12 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     for (TaskQueryVariableValue variable : this.variables) {
       variable.setVariableValueIgnoreCase(true);
     }
+    return this;
+  }
+
+  @Override
+  public TaskQuery likePatternIgnoreCase() {
+    this.likePatternIgnoreCase = true;
     return this;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/UserQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/UserQueryImpl.java
@@ -42,6 +42,7 @@ public abstract class UserQueryImpl extends AbstractQuery<UserQuery, User> imple
   protected String groupId;
   protected String procDefId;
   protected String tenantId;
+  protected Boolean likePatternIgnoreCase;
 
   protected UserQueryImpl() {
   }
@@ -125,6 +126,12 @@ public abstract class UserQueryImpl extends AbstractQuery<UserQuery, User> imple
     return this;
   }
 
+  @Override
+  public UserQuery likePatternIgnoreCase() {
+    this.likePatternIgnoreCase = true;
+    return this;
+  }
+
   //sorting //////////////////////////////////////////////////////////
 
   @Override
@@ -178,5 +185,8 @@ public abstract class UserQueryImpl extends AbstractQuery<UserQuery, User> imple
   }
   public String getTenantId() {
     return tenantId;
+  }
+  public Boolean isLikePatternIgnoreCase() {
+    return likePatternIgnoreCase;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/JsonTaskQueryConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/JsonTaskQueryConverter.java
@@ -120,6 +120,7 @@ public class JsonTaskQueryConverter implements JsonObjectConverter<TaskQuery> {
   public static final String CASE_INSTANCE_VARIABLES = "caseInstanceVariables";
   public static final String TENANT_IDS = "tenantIds";
   public static final String WITHOUT_TENANT_ID = "withoutTenantId";
+  public static final String LIKE_PATTERN_IGNORE_CASE = "likePatternIgnoreCase";
   public static final String ORDERING_PROPERTIES = "orderingProperties";
   public static final String OR_QUERIES = "orQueries";
 
@@ -225,6 +226,7 @@ public class JsonTaskQueryConverter implements JsonObjectConverter<TaskQuery> {
     JsonUtil.addField(json, CASE_INSTANCE_BUSINESS_KEY_LIKE, query.getCaseInstanceBusinessKeyLike());
     JsonUtil.addField(json, CASE_EXECUTION_ID, query.getCaseExecutionId());
     addTenantIdFields(json, query);
+    JsonUtil.addDefaultField(json, LIKE_PATTERN_IGNORE_CASE, false, Boolean.TRUE.equals(query.isLikePatternIgnoreCase()));
 
     if (query.getQueries().size() > 1 && !isOrQueryActive) {
       JsonArray orQueries = JsonUtil.createArray();
@@ -443,6 +445,11 @@ public class JsonTaskQueryConverter implements JsonObjectConverter<TaskQuery> {
       Map.entry(CASE_EXECUTION_ID, (query, json) -> query.caseExecutionId(JsonUtil.getString(json, CASE_EXECUTION_ID))),
       Map.entry(TENANT_IDS, (query, json) -> query.tenantIdIn(getArray(JsonUtil.getArray(json, TENANT_IDS)))),
       Map.entry(WITHOUT_TENANT_ID, (query, json) -> query.withoutTenantId()),
+      Map.entry(LIKE_PATTERN_IGNORE_CASE, (query, json) -> {
+        if (JsonUtil.getBoolean(json, LIKE_PATTERN_IGNORE_CASE)) {
+          query.likePatternIgnoreCase();
+        }
+      }),
       Map.entry(ORDER_BY, (query, json) -> query.setOrderingProperties(LEGACY_QUERY_ORDERING_PROPERTY_CONVERTER.fromOrderByString(JsonUtil.getString(json, ORDER_BY)))),
       Map.entry(ORDERING_PROPERTIES, (query, json) -> query.setOrderingProperties(JsonQueryOrderingPropertyConverter.ARRAY_CONVERTER.toObject(JsonUtil.getArray(json, ORDERING_PROPERTIES))))
   );

--- a/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
@@ -561,6 +561,14 @@ public interface TaskQuery extends Query<TaskQuery, Task> {
   TaskQuery matchVariableValuesIgnoreCase();
 
   /**
+   * Makes LIKE comparisons case-insensitive for fields that are case-sensitive by default.
+   * This affects assigneeLike, processInstanceBusinessKeyLike, caseInstanceBusinessKeyLike,
+   * taskDefinitionKeyLike, processDefinitionNameLike, caseDefinitionNameLike, and candidateGroupLike.
+   * taskNameLike, taskNameNotLike, and taskDescriptionLike are already case-insensitive by default.
+   */
+  TaskQuery likePatternIgnoreCase();
+
+  /**
    * Only select tasks which have a local task variable with the given name
    * set to the given value.
    */

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Task.xml
@@ -388,7 +388,14 @@
               ${queryType} RES.ASSIGNEE_ = #{query.assignee}
             </if>
             <if test="query.assigneeLike != null">
-              ${queryType} RES.ASSIGNEE_ like #{query.assigneeLike} ESCAPE ${escapeChar}
+              <choose>
+                <when test="likePatternIgnoreCase">
+                  ${queryType} UPPER(RES.ASSIGNEE_) like UPPER(#{query.assigneeLike}) ESCAPE ${escapeChar}
+                </when>
+                <otherwise>
+                  ${queryType} RES.ASSIGNEE_ like #{query.assigneeLike} ESCAPE ${escapeChar}
+                </otherwise>
+              </choose>
             </if>
             <if test="query.assigneeIn != null &amp;&amp; query.assigneeIn.size &gt; 0">
               ${queryType} RES.ASSIGNEE_ in
@@ -440,7 +447,14 @@
               </foreach>
             </if>
             <if test="query.processInstanceBusinessKeyLike != null">
-              ${queryType} E.BUSINESS_KEY_ like #{query.processInstanceBusinessKeyLike} ESCAPE ${escapeChar}
+              <choose>
+                <when test="likePatternIgnoreCase">
+                  ${queryType} UPPER(E.BUSINESS_KEY_) like UPPER(#{query.processInstanceBusinessKeyLike}) ESCAPE ${escapeChar}
+                </when>
+                <otherwise>
+                  ${queryType} E.BUSINESS_KEY_ like #{query.processInstanceBusinessKeyLike} ESCAPE ${escapeChar}
+                </otherwise>
+              </choose>
             </if>
             <if test="query.executionId != null">
               ${queryType} RES.EXECUTION_ID_ = #{query.executionId}
@@ -452,7 +466,14 @@
               ${queryType} CE.BUSINESS_KEY_ = #{query.caseInstanceBusinessKey}
             </if>
             <if test="query.caseInstanceBusinessKeyLike != null">
-              ${queryType} CE.BUSINESS_KEY_ like #{query.caseInstanceBusinessKeyLike} ESCAPE ${escapeChar}
+              <choose>
+                <when test="likePatternIgnoreCase">
+                  ${queryType} UPPER(CE.BUSINESS_KEY_) like UPPER(#{query.caseInstanceBusinessKeyLike}) ESCAPE ${escapeChar}
+                </when>
+                <otherwise>
+                  ${queryType} CE.BUSINESS_KEY_ like #{query.caseInstanceBusinessKeyLike} ESCAPE ${escapeChar}
+                </otherwise>
+              </choose>
             </if>
             <if test="query.caseExecutionId != null">
               ${queryType} RES.CASE_EXECUTION_ID_ = #{query.caseExecutionId}
@@ -474,7 +495,14 @@
               ${queryType} RES.TASK_DEF_KEY_ = #{query.key}
             </if>
             <if test="query.keyLike != null">
-              ${queryType} RES.TASK_DEF_KEY_ like #{query.keyLike} ESCAPE ${escapeChar}
+              <choose>
+                <when test="likePatternIgnoreCase">
+                  ${queryType} UPPER(RES.TASK_DEF_KEY_) like UPPER(#{query.keyLike}) ESCAPE ${escapeChar}
+                </when>
+                <otherwise>
+                  ${queryType} RES.TASK_DEF_KEY_ like #{query.keyLike} ESCAPE ${escapeChar}
+                </otherwise>
+              </choose>
             </if>
             <if test="query.parentTaskId != null">
               ${queryType} RES.PARENT_TASK_ID_ = #{query.parentTaskId}
@@ -510,7 +538,14 @@
               ${queryType} D.NAME_ = #{query.processDefinitionName}
             </if>
             <if test="query.processDefinitionNameLike != null">
-              ${queryType} D.NAME_ like #{query.processDefinitionNameLike} ESCAPE ${escapeChar}
+              <choose>
+                <when test="likePatternIgnoreCase">
+                  ${queryType} UPPER(D.NAME_) like UPPER(#{query.processDefinitionNameLike}) ESCAPE ${escapeChar}
+                </when>
+                <otherwise>
+                  ${queryType} D.NAME_ like #{query.processDefinitionNameLike} ESCAPE ${escapeChar}
+                </otherwise>
+              </choose>
             </if>
             <if test="query.caseDefinitionId != null">
               ${queryType} RES.CASE_DEF_ID_ = #{query.caseDefinitionId}
@@ -522,7 +557,14 @@
               ${queryType} CD.NAME_ = #{query.caseDefinitionName}
             </if>
             <if test="query.caseDefinitionNameLike != null">
-              ${queryType} CD.NAME_ like #{query.caseDefinitionNameLike} ESCAPE ${escapeChar}
+              <choose>
+                <when test="likePatternIgnoreCase">
+                  ${queryType} UPPER(CD.NAME_) like UPPER(#{query.caseDefinitionNameLike}) ESCAPE ${escapeChar}
+                </when>
+                <otherwise>
+                  ${queryType} CD.NAME_ like #{query.caseDefinitionNameLike} ESCAPE ${escapeChar}
+                </otherwise>
+              </choose>
             </if>
             <if test="query.dueDate != null || query.dueBefore != null || query.dueAfter != null">
               ${queryType}
@@ -613,7 +655,14 @@
                     or
                   </if>
                   <if test="query.candidateGroupLike != null">
-                    I.GROUP_ID_ LIKE #{query.candidateGroupLike}
+                    <choose>
+                      <when test="likePatternIgnoreCase">
+                        UPPER(I.GROUP_ID_) LIKE UPPER(#{query.candidateGroupLike})
+                      </when>
+                      <otherwise>
+                        I.GROUP_ID_ LIKE #{query.candidateGroupLike}
+                      </otherwise>
+                    </choose>
                   </if>
                   )
                 </if>

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/User.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/User.xml
@@ -129,19 +129,40 @@
         and RES.FIRST_ = #{firstName}
       </if>
       <if test="firstNameLike != null">
-        and RES.FIRST_ like #{firstNameLike} ESCAPE ${escapeChar}
+        <choose>
+          <when test="likePatternIgnoreCase">
+            and UPPER(RES.FIRST_) like UPPER(#{firstNameLike}) ESCAPE ${escapeChar}
+          </when>
+          <otherwise>
+            and RES.FIRST_ like #{firstNameLike} ESCAPE ${escapeChar}
+          </otherwise>
+        </choose>
       </if>
       <if test="lastName != null">
         and RES.LAST_ = #{lastName}
       </if>
       <if test="lastNameLike != null">
-        and RES.LAST_ like #{lastNameLike} ESCAPE ${escapeChar}
+        <choose>
+          <when test="likePatternIgnoreCase">
+            and UPPER(RES.LAST_) like UPPER(#{lastNameLike}) ESCAPE ${escapeChar}
+          </when>
+          <otherwise>
+            and RES.LAST_ like #{lastNameLike} ESCAPE ${escapeChar}
+          </otherwise>
+        </choose>
       </if>
       <if test="email != null">
         and RES.EMAIL_ = #{email}
       </if>
       <if test="emailLike != null">
-        and RES.EMAIL_ like #{emailLike} ESCAPE ${escapeChar}
+        <choose>
+          <when test="likePatternIgnoreCase">
+            and UPPER(RES.EMAIL_) like UPPER(#{emailLike}) ESCAPE ${escapeChar}
+          </when>
+          <otherwise>
+            and RES.EMAIL_ like #{emailLike} ESCAPE ${escapeChar}
+          </otherwise>
+        </choose>
       </if>
       <if test="groupId != null">
         and G.ID_ = #{groupId}

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -178,6 +178,7 @@ class FilterTaskQueryTest {
   void testTaskQuery() {
     // create query
     TaskQueryImpl query = new TaskQueryImpl();
+    query.likePatternIgnoreCase();
     query.taskId(testString);
     query.taskName(testString);
     query.taskNameNotEqual(testString);
@@ -285,6 +286,7 @@ class FilterTaskQueryTest {
 
     // test query
     query = testFilter.getQuery();
+    assertThat(query.isLikePatternIgnoreCase()).isTrue();
     assertThat(query.getTaskId()).isEqualTo(testString);
     assertThat(query.getName()).isEqualTo(testString);
     assertThat(query.getNameNotEqual()).isEqualTo(testString);
@@ -1254,6 +1256,35 @@ class FilterTaskQueryTest {
     assertThat(tasks)
             .isNotNull()
             .hasSize(3);
+  }
+
+  @Test
+  void testFilterListWithLikePatternIgnoreCaseInStoredQuery() {
+    TaskQuery query = taskService.createTaskQuery()
+      .likePatternIgnoreCase()
+      .taskAssigneeLike("KERMIT%");
+    saveQuery(query);
+
+    List<Task> tasks = filterService.list(testFilter.getId());
+
+    assertThat(tasks).hasSize(1);
+    assertThat(tasks.get(0).getId()).isEqualTo("task2");
+    assertThat(tasks.get(0).getAssignee()).isEqualTo("kermit");
+  }
+
+  @Test
+  void testFilterListWithLikePatternIgnoreCaseInExtendingQuery() {
+    TaskQuery query = taskService.createTaskQuery().taskAssigneeLike("KERMIT%");
+    saveQuery(query);
+
+    assertThat(filterService.list(testFilter.getId())).isEmpty();
+
+    TaskQuery extendingQuery = taskService.createTaskQuery().likePatternIgnoreCase();
+    List<Task> tasks = filterService.list(testFilter.getId(), extendingQuery);
+
+    assertThat(tasks).hasSize(1);
+    assertThat(tasks.get(0).getId()).isEqualTo("task2");
+    assertThat(tasks.get(0).getAssignee()).isEqualTo("kermit");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
@@ -142,6 +142,16 @@ class UserQueryTest {
   }
 
   @Test
+  void testQueryByFirstNameLikeIgnoreCase() {
+    UserQuery query = identityService.createUserQuery().userFirstNameLike("ker%");
+    verifyQueryResults(query, 0);
+
+    query = identityService.createUserQuery().likePatternIgnoreCase().userFirstNameLike("ker%");
+    verifyQueryResults(query, 1);
+    assertThat(query.singleResult().getId()).isEqualTo("kermit");
+  }
+
+  @Test
   void testQueryByInvalidFirstNameLike() {
     UserQuery query = identityService.createUserQuery().userFirstNameLike("%mispiggy%");
     verifyQueryResults(query, 0);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -388,6 +388,19 @@ class TaskQueryTest {
   }
 
   @Test
+  void testQueryByAssigneeLikeIgnoreCase() {
+    TaskQuery query = taskService.createTaskQuery().taskAssigneeLike("GONZO%");
+    assertThat(query.count()).isZero();
+
+    query = taskService.createTaskQuery().likePatternIgnoreCase().taskAssigneeLike("GONZO%");
+    assertThat(query.count()).isOne();
+    assertThat(query.singleResult().getAssignee()).isEqualTo("gonzo_");
+
+    query = taskService.createTaskQuery().likePatternIgnoreCase().taskAssigneeLike("GoNzO%");
+    assertThat(query.count()).isOne();
+  }
+
+  @Test
   void testQueryByNullAssignee() {
     var taskQuery = taskService.createTaskQuery();
     assertThatThrownBy(() -> taskQuery.taskAssignee(null)).isInstanceOf(ProcessEngineException.class);


### PR DESCRIPTION
## Summary

Backports CIB Seven's opt-in `likePatternIgnoreCase` support to Operaton's Task and User query APIs.

This adds the new boolean option to:

- `GET /task`
- `POST /task`
- `GET /user`
- `TaskQuery` and `UserQuery`
- stored Task filter query JSON serialization
- REST OpenAPI templates

The default is `false`, so existing query behavior is unchanged. When callers enable `likePatternIgnoreCase`, the SQL mappings use `UPPER(column) LIKE UPPER(pattern)` for LIKE fields that are case-sensitive by default.

## Reviewer Notes

This PR intentionally groups the Task and User changes because both CIB Seven commits introduce the same explicit API concept and the same opt-in SQL behavior.

Affected Task LIKE fields:

- `assigneeLike`
- `taskDefinitionKeyLike`
- `processInstanceBusinessKeyLike`
- `caseInstanceBusinessKeyLike`
- `processDefinitionNameLike`
- `caseDefinitionNameLike`
- `candidateGroupLike`

Affected User LIKE fields:

- `firstNameLike`
- `lastNameLike`
- `emailLike`

Task `nameLike`, `nameNotLike`, and `descriptionLike` are intentionally not changed here because Operaton already routes those through the existing case-insensitive task name/description handling. The new flag is additive and opt-in for the remaining LIKE comparisons.

The stored Task filter query path is covered as well: `JsonTaskQueryConverter` persists `likePatternIgnoreCase` only when enabled and restores it when filters are loaded or extended. This prevents saved filters from silently losing the new matching behavior.

Because this introduces `UPPER(...)` around selected columns, reviewers may want to consider DB/index implications for large installations. The behavior is only applied when the new option is explicitly set.

This PR does not include the separate CIB Seven case-insensitive identity/user-id query changes. Those change user-id semantics more broadly and remain a design topic outside this backport.

## Attribution

Source fork: CIB Seven

Backported and adapted from CIB Seven PRs:

- https://github.com/cibseven/cibseven/pull/266
- https://github.com/cibseven/cibseven/pull/274

Backported commits:

- `1daabccb83e597203f0eb38e819046f256379a6a` - `chore(rest): new option likePatternIgnoreCase for the TASK query to make LIKE operators case insensitive (#266)`
- `59f76b18d64e299a21937240ceaa66c7383c6e96` - `new(rest): add likePatternIgnoreCase parameter to User query (#274)`

Original authors:

- vladgrind `<156691737+vladgrind@users.noreply.github.com>`
- Vladimir Gribko `<156691737+vladgrind@users.noreply.github.com>`

Backport database:

- Change unit `1078` marked `pr_opened` for this PR.
- Change unit `1081` marked `pr_opened` for this PR.

## Verification

- `git diff --check`
- `./mvnw -pl engine -Dtest=TaskQueryTest,UserQueryTest,FilterTaskQueryTest test`
  - `Tests run: 353, Failures: 0, Errors: 0, Skipped: 4`
- `./mvnw -pl engine -DskipTests install`
- `./mvnw -f engine-rest/engine-rest/pom.xml -Dtest=TaskRestServiceQueryTest,UserRestServiceQueryTest test`
  - REST tests run twice by the module's standard/encoding Surefire executions.
  - Each execution: `Tests run: 98, Failures: 0, Errors: 0, Skipped: 0`
- Backport database: `PRAGMA integrity_check` returned `ok`.
