### PR TITLE
feat(examples): add invoice demo authorization read seed

### DIFF
--- a/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/DemoDataGenerator.java
+++ b/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/DemoDataGenerator.java
@@ -149,6 +149,13 @@ public class DemoDataGenerator {
         }
       }
 
+      // create GLOBAL READ permission to be able to read OWN authorizations
+      Authorization globalAuthorizationRead = authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GLOBAL);
+      globalAuthorizationRead.setResource(Resources.AUTHORIZATION);
+      globalAuthorizationRead.setResourceId(ANY);
+      globalAuthorizationRead.addPermission(READ);
+      authorizationService.saveAuthorization(globalAuthorizationRead);
+
       identityService.createMembership(RESOURCE_ID_DEMO, GROUP_SALES);
       identityService.createMembership(RESOURCE_ID_DEMO, GROUP_ACCOUNTING);
       identityService.createMembership(RESOURCE_ID_DEMO, GROUP_MANAGEMENT);


### PR DESCRIPTION
## Summary

This PR backports the CIBSeven invoice demo authorization seed change to Operaton.

It adds a global `READ` authorization for `AUTHORIZATION/*` while generating the invoice demo users. This allows users in the demo setup to read their own authorization data, matching the behavior proposed in CIBSeven.

## Change unit

- `1073` [cibseven:f3d92d571a80] Create global read authorization for resources (cibseven/cibseven#262)

## Attribution

Backported-adapted from CIBSeven commit `f3d92d571a8010cc0d40a3e8e63bccb0af27ad5d`.

Original PR: https://github.com/cibseven/cibseven/pull/262

Original author: Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>

## Reviewer notes

This intentionally changes only the invoice example data generator. The main review question is whether the demo should grant global `READ` on authorizations, or whether a narrower demo-specific authorization would be preferable.

## Verification

- `git diff --check origin/main...HEAD`
- `./mvnw -pl examples/invoice -DskipTests install -Dskip.frontend.build=true`