### PR TITLE
docs(rest): remove obsolete telemetry license example

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/data/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/data/get.ftl
@@ -24,7 +24,6 @@
                            "product": {
                              "name": "Operaton BPM Runtime",
                              "version": "7.14.0",
-                             "edition": "enterprise",
                              "internals": {
                                "database": {  
                                  "vendor": "h2",
@@ -53,16 +52,6 @@
                                  "spring-boot-starter",
                                  "operaton-bpm-run"
                                ],
-                               "license-key": {
-                                 "customer": "customer name",
-                                 "type": "UNIFIED",
-                                 "valid-until": "2022-09-30",
-                                 "unlimited": false,
-                                 "features": {
-                                   "operatonBPM": "true"
-                                 },
-                                 "raw": "customer=customer name;expiryDate=2022-09-30;operatonBPM=true;optimize=false;cawemo=false"
-                               },
                                "webapps": [
                                  "cockpit",
                                  "admin"


### PR DESCRIPTION
## Summary

Backports the only still-relevant Operaton part of Fluxnova change unit 279: the deprecated telemetry OpenAPI example still contained Enterprise/licensing sample fields even though telemetry sending is removed and Operaton does not expose a license-key concept.

The larger Fluxnova commit mostly changes Fluxnova branding, documentation URLs and generated OpenAPI template details. Operaton already has its own Operaton-specific OpenAPI branding and package layout, so those parts are intentionally not ported.

## Source attribution

- Backport source: Fluxnova commit `03960cabcc4f24303dbf92aabd3ac46fd741bcda`
- Source PR: https://github.com/finos/fluxnova-bpm-platform/pull/235
- Backport tracker change unit: `279`

## Reviewer notes

- This patch removes `edition: enterprise` and the nested `license-key` object from the deprecated `GET /telemetry/data` OpenAPI response example.
- The endpoint description already says telemetry sending was removed and the endpoint is deprecated.
- I checked `origin/main`: OpenAPI `main.ftl` already uses `docs.operaton.org`, `Operaton REST API`, and `org/operaton` template paths, so the broad Fluxnova branding/template portion is not relevant to Operaton.

## Verification

- Manual diff review against Fluxnova `03960cabcc4f`
- Local grep against `origin/main` for `Camunda Platform REST API`, `docs.camunda.org`, `TelemetryLicenseKey`, `license-key`
