### PR TITLE
perf(engine): use EXISTS for task authorization queries

### DIFF
--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Authorization.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Authorization.xml
@@ -844,13 +844,26 @@
     <bind name="atomicChecks" value="authCheck.permissionChecks.atomicChecks" />
     <bind name="disjunctive" value="authCheck.permissionChecks.disjunctive" />
     <bind name="useLeftJoin" value="authCheck.useLeftJoin" />
+    <bind name="useNoJoin" value="false" />
     <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding${authCheckMethodSuffix}" />
     <!-- The suffix above is added to handle mssql differently (with UNION instead of OR for groups) -->
+  </sql>
+
+  <sql id="authCheckForTaskQueryWithExistsClause">
+    <bind name="authGroupIds" value="authCheck.authGroupIds" />
+    <bind name="atomicChecks" value="authCheck.permissionChecks.atomicChecks" />
+    <bind name="disjunctive" value="authCheck.permissionChecks.disjunctive" />
+    <bind name="useLeftJoin" value="false" />
+    <bind name="useNoJoin" value="true" />
+    EXISTS (SELECT 1 FROM
+    <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding${authCheckMethodSuffix}" />
+    AUTH WHERE AUTH.RESOURCE_ID_ IN (RES.ID_, D.KEY_, '*'))
   </sql>
 
   <sql id="authCheckJoinWithoutOnClauseWithBinding">
     <choose>
       <when test="useLeftJoin != null &amp;&amp; useLeftJoin == true">left join</when>
+      <when test="useNoJoin != null &amp;&amp; useNoJoin == true"></when>
       <otherwise>inner join</otherwise>
     </choose>
     (
@@ -869,6 +882,7 @@
   <sql id="authCheckJoinWithoutOnClauseWithBinding_mssql">
     <choose>
       <when test="useLeftJoin != null &amp;&amp; useLeftJoin == true">left join</when>
+      <when test="useNoJoin != null &amp;&amp; useNoJoin == true"></when>
       <otherwise>inner join</otherwise>
     </choose>
     (
@@ -1048,7 +1062,14 @@
             (RES.CASE_EXECUTION_ID_ IS NOT NULL)
             OR
           </if>
-            (AUTH.RESOURCE_ID_ IS NOT NULL)
+            <choose>
+              <when test="applyAuthorizationCheckForTaskQueryFast">
+                <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckForTaskQueryWithExistsClause" />
+              </when>
+              <otherwise>
+                (AUTH.RESOURCE_ID_ IS NOT NULL)
+              </otherwise>
+            </choose>
             <if test="authCheck.permissionChecks.compositeChecks != null &amp;&amp; authCheck.permissionChecks.compositeChecks.size > 0">
               AND
               <foreach item="permCheck" index="index" collection="authCheck.permissionChecks.compositeChecks" separator="AND">

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Statistics.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Statistics.xml
@@ -418,6 +418,7 @@
     <bind name="authUserId" value="authCheck.authUserId" />
     <bind name="authGroupIds" value="authCheck.authGroupIds" />
     <bind name="useLeftJoin" value="authCheck.useLeftJoin" />
+    <bind name="useNoJoin" value="false" />
     <bind name="disjunctive" value="#{true}" />
     <bind name="revokeAuthorizationCheckEnabled" value="authCheck.revokeAuthorizationCheckEnabled" />
 
@@ -463,6 +464,7 @@
     <bind name="authUserId" value="authCheck.authUserId" />
     <bind name="authGroupIds" value="authCheck.authGroupIds" />
     <bind name="useLeftJoin" value="authCheck.useLeftJoin" />
+    <bind name="useNoJoin" value="false" />
     <bind name="disjunctive" value="#{true}" />
     <bind name="revokeAuthorizationCheckEnabled" value="authCheck.revokeAuthorizationCheckEnabled" />
 

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Task.xml
@@ -313,13 +313,6 @@
       left join ${prefix}ACT_RU_EXECUTION E1 on RES.EXECUTION_ID_ = E1.ID_
     </if>
 
-    <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; authCheck.authUserId != null">
-      <if test="!authCheck.revokeAuthorizationCheckEnabled">
-        <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} D.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
-      </if>
-    </if>
-
     <foreach collection="orderingProperties" item="orderingProperty" index="i">
       <if test="orderingProperty.relation != null">
         <bind name="tableAlias" value="@org.operaton.bpm.engine.impl.db.sql.MybatisJoinHelper@tableAlias(orderingProperty.relation, i)"/>
@@ -720,6 +713,7 @@
 
       <!-- Task query does not use left join if cmmn is disabled,
         so we don't need to account for case tasks in this case. -->
+      <bind name="applyAuthorizationCheckForTaskQueryFast" value="true" />
       <bind name="applyAuthorizationCheckForCaseInstances" value="authCheck.useLeftJoin" />
       <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.contextualAuthorizationCheck" />
       <include refid="org.operaton.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheck" />

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -463,6 +463,7 @@
             </foreach>
 
             <bind name="applyAuthorizationCheckForCaseInstances" value="true" />
+            <bind name="applyAuthorizationCheckForTaskQueryFast" value="false" />
             <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.contextualAuthorizationCheck" />
             <include refid="org.operaton.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheck" />
 


### PR DESCRIPTION
## Summary

Backports the CIBSeven task-query authorization SQL optimization to Operaton.

The old task query joins `ACT_RU_AUTHORIZATION` into the main task result set and then checks `AUTH.RESOURCE_ID_ IS NOT NULL` in the contextual authorization block. This patch keeps the existing contextual authorization semantics but evaluates task-query authorizations through an `EXISTS` subquery instead of the main join. The goal is to avoid inflating the task result set during task list and task count queries.

## What changes

- Adds `AuthorizationEntity.authCheckForTaskQueryWithExistsClause`.
- Allows `authCheckJoinWithoutOnClauseWithBinding` to be reused without emitting `inner join` / `left join` when it is embedded in the `EXISTS` subquery.
- Removes the main `AUTH` join from `Task.xml` for non-revoke task queries.
- Enables the new EXISTS path only for task queries via `applyAuthorizationCheckForTaskQueryFast`.
- Explicitly keeps variable-instance and statistics mappings on the old join behavior.

## Source attribution

Backported from CIBSeven:

- Source commit: `fd12ffc2e422683ec9e41ccb82ff3bafe4d8b19c`
- Source PR: https://github.com/cibseven/cibseven/pull/151
- Source title: `improve(engine): use fast authentication check with EXISTS clause in the task-count and task-selection queries`
- Original author: vladgrind `<156691737+vladgrind@users.noreply.github.com>`

Operaton adaptation:

- Mapper references adapted from `org.cibseven` to `org.operaton`.
- Kept the PR as Draft because this is security-sensitive authorization SQL and should get maintainer review before merge.

## Reviewer notes

This PR intentionally changes SQL shape, not authorization rules. The acceptance question is whether the generated SQL is equivalent across Operaton's supported databases while improving task-list/count performance.

Important review points:

- Non-revoke task authorization now uses `EXISTS (...)` over `ACT_RU_AUTHORIZATION` instead of a main `AUTH` join.
- Revoke authorization mode still uses the existing `authorizationCheck` CASE path.
- Case-instance handling remains tied to `applyAuthorizationCheckForCaseInstances`.
- The MSSQL-specific authorization include remains in use through `authCheckMethodSuffix`.

## Verification

- `./mvnw -pl engine -Dtest=TaskAuthorizationTest,TaskCountByCandidateGroupAuthorizationTest,VariableInstanceAuthorizationTest,ActivityStatisticsAuthorizationTest test -Dskip.frontend.build=true`
- Result: 344 tests, 0 failures, 0 errors
