### PR TITLE
feat(engine-rest): add bulk job operations

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobActivateSuspendDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobActivateSuspendDto.ftl
@@ -1,0 +1,19 @@
+<#macro dto_macro docsUrl="">
+  <@lib.dto desc = "List of job ids and the requested suspension state.">
+
+    <@lib.property
+        name = "jobIds"
+        type = "array"
+        itemType = "string"
+        desc = "List of job ids."
+    />
+
+    <@lib.property
+        name = "suspended"
+        type = "boolean"
+        last = true
+        desc = "Supply `true` to suspend the jobs and `false` to activate them."
+    />
+
+  </@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobDeletionDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobDeletionDto.ftl
@@ -1,0 +1,13 @@
+<#macro dto_macro docsUrl="">
+  <@lib.dto desc = "List of job ids to delete.">
+
+    <@lib.property
+        name = "jobIds"
+        type = "array"
+        itemType = "string"
+        last = true
+        desc = "List of job ids for deletion."
+    />
+
+  </@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobDeletionResponse.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobDeletionResponse.ftl
@@ -1,0 +1,24 @@
+<#macro dto_macro docsUrl="">
+  <@lib.dto desc = "Result of a bulk job deletion for a single job.">
+
+    <@lib.property
+        name = "jobId"
+        type = "string"
+        desc = "The id of the job."
+    />
+
+    <@lib.property
+        name = "status"
+        type = "string"
+        desc = "The status of the deletion operation."
+    />
+
+    <@lib.property
+        name = "errorMessage"
+        type = "string"
+        last = true
+        desc = "The error details related to a deletion operation failure."
+    />
+
+  </@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobSuspensionResponse.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/JobSuspensionResponse.ftl
@@ -1,0 +1,24 @@
+<#macro dto_macro docsUrl="">
+  <@lib.dto desc = "Result of a bulk job suspension state update for a single job.">
+
+    <@lib.property
+        name = "jobId"
+        type = "string"
+        desc = "The id of the job."
+    />
+
+    <@lib.property
+        name = "status"
+        type = "string"
+        desc = "The status of the update operation."
+    />
+
+    <@lib.property
+        name = "errorMessage"
+        type = "string"
+        last = true
+        desc = "The error details related to an update operation failure."
+    />
+
+  </@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/job/delete/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/job/delete/post.ftl
@@ -1,0 +1,82 @@
+<#macro endpoint_macro docsUrl="">
+  {
+    <@lib.endpointInfo
+        id = "deleteByJobIds"
+        tag = "Job"
+        summary = "Delete Jobs by List of Job Ids"
+        desc = "Deletes jobs by the supplied list of job ids."
+    />
+
+    <@lib.requestBody
+        mediaType = "application/json"
+        dto = "JobDeletionDto"
+        examples = [
+        '"example-1": {
+                       "summary": "Delete jobs with the given job ids. POST `/job/delete`",
+                       "value": {
+                         "jobIds": [
+                           "aJobId",
+                           "anotherJobId"
+                         ]
+                       }
+                     }'
+        ]
+    />
+
+    "responses": {
+
+      <@lib.response
+          code = "200"
+          desc = "Request successful."
+          dto = "JobDeletionResponse"
+          array = true
+          examples = ['"example-1": {
+                         "summary": "Status 200 response",
+                         "value": [
+                           {
+                             "status": "SUCCESS",
+                             "errorMessage": null,
+                             "jobId": "aJobId"
+                           },
+                           {
+                             "status": "SUCCESS",
+                             "errorMessage": null,
+                             "jobId": "anotherJobId"
+                           }
+                         ]
+                       }']
+      />
+
+      <@lib.response
+          code = "207"
+          desc = "Multi-Status: Indicates that at least one requested deletion has failed."
+          dto = "JobDeletionResponse"
+          array = true
+          examples = ['"example-1": {
+                         "summary": "Status 207 response",
+                         "value": [
+                           {
+                             "status": "FAILURE",
+                             "errorMessage": "Cannot find job with id aJobId",
+                             "jobId": "aJobId"
+                           },
+                           {
+                             "status": "SUCCESS",
+                             "errorMessage": null,
+                             "jobId": "anotherJobId"
+                           }
+                         ]
+                       }']
+      />
+
+      <@lib.response
+          code = "400"
+          dto = "ExceptionDto"
+          desc = "Returned if the request parameters are invalid, for example if an empty list is provided as input."
+          last = true
+      />
+
+    }
+
+  }
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/job/suspended/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/job/suspended/post.ftl
@@ -1,0 +1,83 @@
+<#macro endpoint_macro docsUrl="">
+  {
+    <@lib.endpointInfo
+        id = "updateSuspensionStateByJobIds"
+        tag = "Job"
+        summary = "Activate/Suspend Jobs by List of Job Ids"
+        desc = "Activates or suspends jobs by the supplied list of job ids and a boolean `suspended` flag."
+    />
+
+    <@lib.requestBody
+        mediaType = "application/json"
+        dto = "JobActivateSuspendDto"
+        examples = [
+        '"example-1": {
+                       "summary": "Activates or suspends jobs with the given job ids. POST `/job/suspended`",
+                       "value": {
+                         "jobIds": [
+                           "aJobId",
+                           "anotherJobId"
+                         ],
+                         "suspended": true
+                       }
+                     }'
+        ]
+    />
+
+    "responses": {
+
+      <@lib.response
+          code = "200"
+          desc = "Request successful."
+          dto = "JobSuspensionResponse"
+          array = true
+          examples = ['"example-1": {
+                         "summary": "Status 200 response",
+                         "value": [
+                           {
+                             "status": "SUCCESS",
+                             "errorMessage": null,
+                             "jobId": "aJobId"
+                           },
+                           {
+                             "status": "SUCCESS",
+                             "errorMessage": null,
+                             "jobId": "anotherJobId"
+                           }
+                         ]
+                       }']
+      />
+
+      <@lib.response
+          code = "207"
+          desc = "Multi-Status: Indicates that at least one requested update has failed."
+          dto = "JobSuspensionResponse"
+          array = true
+          examples = ['"example-1": {
+                         "summary": "Status 207 response",
+                         "value": [
+                           {
+                             "status": "FAILURE",
+                             "errorMessage": "Cannot find job with id aJobId",
+                             "jobId": "aJobId"
+                           },
+                           {
+                             "status": "SUCCESS",
+                             "errorMessage": null,
+                             "jobId": "anotherJobId"
+                           }
+                         ]
+                       }']
+      />
+
+      <@lib.response
+          code = "400"
+          dto = "ExceptionDto"
+          desc = "Returned if the request parameters are invalid, for example if an empty list is provided as input."
+          last = true
+      />
+
+    }
+
+  }
+</#macro>

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/JobRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/JobRestService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
@@ -28,6 +29,8 @@ import org.operaton.bpm.engine.rest.dto.runtime.JobDto;
 import org.operaton.bpm.engine.rest.dto.runtime.JobQueryDto;
 import org.operaton.bpm.engine.rest.dto.runtime.JobSuspensionStateDto;
 import org.operaton.bpm.engine.rest.dto.runtime.SetJobRetriesDto;
+import org.operaton.bpm.engine.rest.dto.runtime.modification.JobActivateSuspendDto;
+import org.operaton.bpm.engine.rest.dto.runtime.modification.JobDeletionDto;
 import org.operaton.bpm.engine.rest.sub.runtime.JobResource;
 
 @Produces(MediaType.APPLICATION_JSON)
@@ -74,4 +77,16 @@ public interface JobRestService {
   @Path("/suspended")
   @Consumes(MediaType.APPLICATION_JSON)
   void updateSuspensionState(JobSuspensionStateDto dto);
+
+  @POST
+  @Path("/suspended")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  Response updateSuspensionStateForJobs(JobActivateSuspendDto dto);
+
+  @POST
+  @Path("/delete")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  Response deleteJobs(JobDeletionDto dto);
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobDeletionResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobDeletionResponse.java
@@ -10,42 +10,12 @@
  */
 package org.operaton.bpm.engine.rest.dto;
 
-public class JobDeletionResponse {
-
-  private String jobId;
-  private ResponseStatus status;
-  private String errorMessage;
+public class JobDeletionResponse extends JobOperationResponse {
 
   public JobDeletionResponse() {
   }
 
   public JobDeletionResponse(String jobId, ResponseStatus status, String errorMessage) {
-    this.jobId = jobId;
-    this.status = status;
-    this.errorMessage = errorMessage;
-  }
-
-  public String getJobId() {
-    return jobId;
-  }
-
-  public void setJobId(String jobId) {
-    this.jobId = jobId;
-  }
-
-  public ResponseStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(ResponseStatus status) {
-    this.status = status;
-  }
-
-  public String getErrorMessage() {
-    return errorMessage;
-  }
-
-  public void setErrorMessage(String errorMessage) {
-    this.errorMessage = errorMessage;
+    super(jobId, status, errorMessage);
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobDeletionResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobDeletionResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+public class JobDeletionResponse {
+
+  private String jobId;
+  private ResponseStatus status;
+  private String errorMessage;
+
+  public JobDeletionResponse() {
+  }
+
+  public JobDeletionResponse(String jobId, ResponseStatus status, String errorMessage) {
+    this.jobId = jobId;
+    this.status = status;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public ResponseStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(ResponseStatus status) {
+    this.status = status;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobDeletionResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobDeletionResponse.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright 2025 FINOS
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * The source files in this repository are made available under the Apache License Version 2.0.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
  */
 package org.operaton.bpm.engine.rest.dto;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobOperationResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobOperationResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+public abstract class JobOperationResponse {
+
+  private String jobId;
+  private ResponseStatus status;
+  private String errorMessage;
+
+  protected JobOperationResponse() {
+  }
+
+  protected JobOperationResponse(String jobId, ResponseStatus status, String errorMessage) {
+    this.jobId = jobId;
+    this.status = status;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public ResponseStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(ResponseStatus status) {
+    this.status = status;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobSuspensionResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobSuspensionResponse.java
@@ -10,42 +10,12 @@
  */
 package org.operaton.bpm.engine.rest.dto;
 
-public class JobSuspensionResponse {
-
-  private String jobId;
-  private ResponseStatus status;
-  private String errorMessage;
+public class JobSuspensionResponse extends JobOperationResponse {
 
   public JobSuspensionResponse() {
   }
 
   public JobSuspensionResponse(String jobId, ResponseStatus status, String errorMessage) {
-    this.jobId = jobId;
-    this.status = status;
-    this.errorMessage = errorMessage;
-  }
-
-  public String getJobId() {
-    return jobId;
-  }
-
-  public void setJobId(String jobId) {
-    this.jobId = jobId;
-  }
-
-  public ResponseStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(ResponseStatus status) {
-    this.status = status;
-  }
-
-  public String getErrorMessage() {
-    return errorMessage;
-  }
-
-  public void setErrorMessage(String errorMessage) {
-    this.errorMessage = errorMessage;
+    super(jobId, status, errorMessage);
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobSuspensionResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobSuspensionResponse.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright 2025 FINOS
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * The source files in this repository are made available under the Apache License Version 2.0.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
  */
 package org.operaton.bpm.engine.rest.dto;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobSuspensionResponse.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/JobSuspensionResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+public class JobSuspensionResponse {
+
+  private String jobId;
+  private ResponseStatus status;
+  private String errorMessage;
+
+  public JobSuspensionResponse() {
+  }
+
+  public JobSuspensionResponse(String jobId, ResponseStatus status, String errorMessage) {
+    this.jobId = jobId;
+    this.status = status;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public ResponseStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(ResponseStatus status) {
+    this.status = status;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/MultiStatusResponseCode.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/MultiStatusResponseCode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+public final class MultiStatusResponseCode {
+
+  public static final int MULTI_STATUS_CODE = 207;
+
+  private MultiStatusResponseCode() {
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/MultiStatusResponseCode.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/MultiStatusResponseCode.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright 2025 FINOS
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * The source files in this repository are made available under the Apache License Version 2.0.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
  */
 package org.operaton.bpm.engine.rest.dto;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ResponseStatus.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ResponseStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+public enum ResponseStatus {
+
+  SUCCESS("success"),
+  FAILURE("failure");
+
+  private final String value;
+
+  ResponseStatus(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ResponseStatus.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ResponseStatus.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright 2025 FINOS
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * The source files in this repository are made available under the Apache License Version 2.0.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
  */
 package org.operaton.bpm.engine.rest.dto;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobActivateSuspendDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobActivateSuspendDto.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright 2025 FINOS
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * The source files in this repository are made available under the Apache License Version 2.0.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
  */
 package org.operaton.bpm.engine.rest.dto.runtime.modification;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobActivateSuspendDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobActivateSuspendDto.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto.runtime.modification;
+
+import java.util.List;
+
+public class JobActivateSuspendDto {
+
+  private List<String> jobIds;
+  private boolean suspended;
+
+  public List<String> getJobIds() {
+    return jobIds;
+  }
+
+  public void setJobIds(List<String> jobIds) {
+    this.jobIds = jobIds;
+  }
+
+  public boolean isSuspended() {
+    return suspended;
+  }
+
+  public void setSuspended(boolean suspended) {
+    this.suspended = suspended;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobDeletionDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobDeletionDto.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto.runtime.modification;
+
+import java.util.List;
+
+public class JobDeletionDto {
+
+  private List<String> jobIds;
+
+  public List<String> getJobIds() {
+    return jobIds;
+  }
+
+  public void setJobIds(List<String> jobIds) {
+    this.jobIds = jobIds;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobDeletionDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/JobDeletionDto.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright 2025 FINOS
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * The source files in this repository are made available under the Apache License Version 2.0.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
  */
 package org.operaton.bpm.engine.rest.dto.runtime.modification;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/JobRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/JobRestServiceImpl.java
@@ -36,6 +36,7 @@ import org.operaton.bpm.engine.management.SetJobRetriesByJobsAsyncBuilder;
 import org.operaton.bpm.engine.rest.JobRestService;
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
 import org.operaton.bpm.engine.rest.dto.JobDeletionResponse;
+import org.operaton.bpm.engine.rest.dto.JobOperationResponse;
 import org.operaton.bpm.engine.rest.dto.JobSuspensionResponse;
 import org.operaton.bpm.engine.rest.dto.ResponseStatus;
 import org.operaton.bpm.engine.rest.dto.batch.BatchDto;
@@ -221,11 +222,7 @@ public class JobRestServiceImpl extends AbstractRestProcessEngineAware
     return Response.status(Status.OK).entity(responseEntity).build();
   }
 
-  private boolean hasFailure(JobSuspensionResponse response) {
-    return ResponseStatus.FAILURE.equals(response.getStatus());
-  }
-
-  private boolean hasFailure(JobDeletionResponse response) {
+  private boolean hasFailure(JobOperationResponse response) {
     return ResponseStatus.FAILURE.equals(response.getStatus());
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/JobRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/JobRestServiceImpl.java
@@ -17,7 +17,11 @@
 package org.operaton.bpm.engine.rest.impl;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriInfo;
 
@@ -31,20 +35,33 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.management.SetJobRetriesByJobsAsyncBuilder;
 import org.operaton.bpm.engine.rest.JobRestService;
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
+import org.operaton.bpm.engine.rest.dto.JobDeletionResponse;
+import org.operaton.bpm.engine.rest.dto.JobSuspensionResponse;
+import org.operaton.bpm.engine.rest.dto.ResponseStatus;
 import org.operaton.bpm.engine.rest.dto.batch.BatchDto;
 import org.operaton.bpm.engine.rest.dto.runtime.JobDto;
 import org.operaton.bpm.engine.rest.dto.runtime.JobQueryDto;
 import org.operaton.bpm.engine.rest.dto.runtime.JobSuspensionStateDto;
 import org.operaton.bpm.engine.rest.dto.runtime.SetJobRetriesDto;
+import org.operaton.bpm.engine.rest.dto.runtime.modification.JobActivateSuspendDto;
+import org.operaton.bpm.engine.rest.dto.runtime.modification.JobDeletionDto;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.rest.sub.runtime.JobResource;
 import org.operaton.bpm.engine.rest.sub.runtime.impl.JobResourceImpl;
 import org.operaton.bpm.engine.rest.util.QueryUtil;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.JobQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.operaton.bpm.engine.rest.dto.MultiStatusResponseCode.MULTI_STATUS_CODE;
 
 public class JobRestServiceImpl extends AbstractRestProcessEngineAware
   implements JobRestService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JobRestServiceImpl.class);
+  private static final int MAX_JOBS_ALLOWED_FOR_BULK_DELETE = 200;
+  private static final int MAX_JOBS_ALLOWED_FOR_BULK_SUSPEND_RESUME = 200;
 
   public JobRestServiceImpl(String engineName, ObjectMapper objectMapper) {
     super(engineName, objectMapper);
@@ -136,6 +153,80 @@ public class JobRestServiceImpl extends AbstractRestProcessEngineAware
     }
 
     dto.updateSuspensionState(getProcessEngine());
+  }
+
+  @Override
+  public Response updateSuspensionStateForJobs(JobActivateSuspendDto dto) {
+    Set<String> jobIds = validateAndDeduplicateJobIds(dto == null ? null : dto.getJobIds(), MAX_JOBS_ALLOWED_FOR_BULK_SUSPEND_RESUME);
+    boolean suspended = dto.isSuspended();
+
+    List<JobSuspensionResponse> suspensionResponses = jobIds.stream()
+        .map(jobId -> updateJobSuspensionState(jobId, suspended))
+        .collect(Collectors.toList());
+
+    return createBulkResponse(suspensionResponses.stream().anyMatch(this::hasFailure), suspensionResponses);
+  }
+
+  @Override
+  public Response deleteJobs(JobDeletionDto dto) {
+    Set<String> jobIds = validateAndDeduplicateJobIds(dto == null ? null : dto.getJobIds(), MAX_JOBS_ALLOWED_FOR_BULK_DELETE);
+
+    List<JobDeletionResponse> deleteResponses = jobIds.stream()
+        .map(this::deleteJob)
+        .collect(Collectors.toList());
+
+    return createBulkResponse(deleteResponses.stream().anyMatch(this::hasFailure), deleteResponses);
+  }
+
+  private JobSuspensionResponse updateJobSuspensionState(String jobId, boolean suspended) {
+    try {
+      JobResource currentJob = getJob(jobId);
+      JobSuspensionStateDto dto = new JobSuspensionStateDto();
+      dto.setJobId(currentJob.getJob().getId());
+      dto.setSuspended(suspended);
+      dto.updateSuspensionState(getProcessEngine());
+      return new JobSuspensionResponse(jobId, ResponseStatus.SUCCESS, null);
+    } catch (Exception e) {
+      LOG.error("Unable to update suspension state for job id: {}", jobId, e);
+      return new JobSuspensionResponse(jobId, ResponseStatus.FAILURE, e.getMessage());
+    }
+  }
+
+  private JobDeletionResponse deleteJob(String jobId) {
+    try {
+      getJob(jobId).deleteJob();
+      return new JobDeletionResponse(jobId, ResponseStatus.SUCCESS, null);
+    } catch (Exception e) {
+      LOG.error("Unable to delete job id: {}", jobId, e);
+      return new JobDeletionResponse(jobId, ResponseStatus.FAILURE, e.getMessage());
+    }
+  }
+
+  private Set<String> validateAndDeduplicateJobIds(List<String> jobIds, int limit) {
+    boolean invalidInput = jobIds == null || jobIds.isEmpty()
+        || jobIds.stream().anyMatch(jobId -> jobId == null || jobId.isBlank());
+    if (invalidInput) {
+      throw new InvalidRequestException(Status.BAD_REQUEST, "Please supply valid job ids as input.");
+    }
+    if (jobIds.size() > limit) {
+      throw new InvalidRequestException(Status.BAD_REQUEST, "Input request exceeds the limit of %s.".formatted(limit));
+    }
+    return new HashSet<>(jobIds);
+  }
+
+  private <T> Response createBulkResponse(boolean hasFailures, List<T> responseEntity) {
+    if (hasFailures) {
+      return Response.status(MULTI_STATUS_CODE).entity(responseEntity).build();
+    }
+    return Response.status(Status.OK).entity(responseEntity).build();
+  }
+
+  private boolean hasFailure(JobSuspensionResponse response) {
+    return ResponseStatus.FAILURE.equals(response.getStatus());
+  }
+
+  private boolean hasFailure(JobDeletionResponse response) {
+    return ResponseStatus.FAILURE.equals(response.getStatus());
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceInteractionTest.java
@@ -57,6 +57,7 @@ import org.operaton.bpm.engine.runtime.JobQuery;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -88,6 +89,7 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
   protected static final String JOB_RESOURCE_RECALC_DUEDATE_URL = JOB_RESOURCE_SET_DUEDATE_URL + "/recalculate";
   protected static final String SINGLE_JOB_SUSPENDED_URL = SINGLE_JOB_RESOURCE_URL + "/suspended";
   protected static final String JOB_SUSPENDED_URL = JOB_RESOURCE_URL + "/suspended";
+  protected static final String JOB_DELETION_URL = JOB_RESOURCE_URL + "/delete";
 
   private ProcessEngine namedProcessEngine;
   private ManagementService mockManagementService;
@@ -1801,6 +1803,92 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
 
     verify(mockManagementService).recalculateJobDuedate(jobId, true);
     verifyNoMoreInteractions(mockManagementService);
+  }
+
+  @Test
+  void testBulkSuspendJobs() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("jobIds", List.of(MockProvider.EXAMPLE_JOB_ID));
+    params.put("suspended", true);
+
+    given()
+      .contentType(ContentType.JSON)
+      .body(params)
+    .then()
+      .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .body("[0].jobId", is(MockProvider.EXAMPLE_JOB_ID))
+        .body("[0].status", is("SUCCESS"))
+        .body("[0].errorMessage", equalTo(null))
+    .when()
+      .post(JOB_SUSPENDED_URL);
+
+    verify(mockSuspensionStateSelectBuilder).byJobId(MockProvider.EXAMPLE_JOB_ID);
+    verify(mockSuspensionStateBuilder).suspend();
+  }
+
+  @Test
+  void testBulkDeleteJobs() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("jobIds", List.of(MockProvider.EXAMPLE_JOB_ID));
+
+    given()
+      .contentType(ContentType.JSON)
+      .body(params)
+    .then()
+      .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .body("[0].jobId", is(MockProvider.EXAMPLE_JOB_ID))
+        .body("[0].status", is("SUCCESS"))
+        .body("[0].errorMessage", equalTo(null))
+    .when()
+      .post(JOB_DELETION_URL);
+
+    verify(mockManagementService).deleteJob(MockProvider.EXAMPLE_JOB_ID);
+  }
+
+  @Test
+  void testBulkDeleteJobsReturnsMultiStatusForPartialFailure() {
+    String expectedMessage = "expected delete failure";
+    doThrow(new ProcessEngineException(expectedMessage))
+        .when(mockManagementService).deleteJob(MockProvider.NON_EXISTING_JOB_ID);
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("jobIds", List.of(MockProvider.EXAMPLE_JOB_ID, MockProvider.NON_EXISTING_JOB_ID));
+
+    given()
+      .contentType(ContentType.JSON)
+      .body(params)
+    .then()
+      .expect()
+        .statusCode(207)
+        .body("jobId", hasItem(MockProvider.EXAMPLE_JOB_ID))
+        .body("jobId", hasItem(MockProvider.NON_EXISTING_JOB_ID))
+        .body("status", hasItem("SUCCESS"))
+        .body("status", hasItem("FAILURE"))
+        .body("errorMessage", hasItem(expectedMessage))
+    .when()
+      .post(JOB_DELETION_URL);
+
+    verify(mockManagementService).deleteJob(MockProvider.EXAMPLE_JOB_ID);
+    verify(mockManagementService).deleteJob(MockProvider.NON_EXISTING_JOB_ID);
+  }
+
+  @Test
+  void testBulkDeleteJobsRejectsEmptyInput() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("jobIds", List.of());
+
+    given()
+      .contentType(ContentType.JSON)
+      .body(params)
+    .then()
+      .expect()
+        .statusCode(Status.BAD_REQUEST.getStatusCode())
+        .body("type", is(InvalidRequestException.class.getSimpleName()))
+        .body("message", is("Please supply valid job ids as input."))
+    .when()
+      .post(JOB_DELETION_URL);
   }
 
   protected void verifyBatchJson(String batchJson) {


### PR DESCRIPTION
## Summary

This draft PR backports the Fluxnova bulk job REST API and adapts it to Operaton's current REST stack.

It adds two job-level bulk endpoints:

- `POST /job/delete` deletes up to 200 jobs by id.
- `POST /job/suspended` activates or suspends up to 200 jobs by id.

Each endpoint processes the submitted job ids independently. If all operations succeed, the endpoint returns `200 OK` with a per-job result list. If at least one operation fails, the endpoint returns `207 Multi-Status` and includes success/failure details for each processed job. Empty, null, blank, or oversized input is rejected with `400 Bad Request`.

The OpenAPI templates are included for the new request and response DTOs. I also added the response schema for the delete endpoint in the Operaton adaptation, so both new endpoints document their per-job result payloads.

## Scope

This PR intentionally implements only the Bulk Job API from change unit 357.

The related Fluxnova Bulk Task API work is intentionally not included here. That part is much larger, introduces several task endpoints and partial-success semantics, and should stay as a separate API/product design review before code is proposed.

## Attribution

Backport of Fluxnova commit:

- `29cc3ec42dbf6a04ff97443ec10a149373b5356b` - `Bulk job api - delete, suspend & activate`

Original author:

- `jyotisahu9 <30759880+jyotisahu9@users.noreply.github.com>`

Operaton adaptation notes:

- Migrated package names to `org.operaton`.
- Used Jakarta REST imports and current Operaton REST test style.
- Added Operaton headers for newly created DTO/template files where the source files did not carry original copyright headers.
- Kept the implementation as a thin REST layer over existing single-job operations.
- Corrected the suspend/activate error log message so it describes suspension-state updates instead of deletion.
- Added OpenAPI response schemas for both new bulk result DTOs.

## Reviewer Notes

The implementation deduplicates job ids before processing, matching the set-based behavior in the source backport. This means duplicate ids in one request do not produce duplicate response entries.

The per-item failure handling deliberately catches exceptions around each individual job operation and continues processing the remaining ids. This is what makes the `207 Multi-Status` response meaningful for partial failures.

## Verification

- `./mvnw -pl engine-rest/engine-rest -Dtest=JobRestServiceInteractionTest test -Dskip.frontend.build=true`
- `./mvnw -pl engine-rest/engine-rest-openapi test -Dskip.frontend.build=true`
