### PR TITLE
fix(engine): persist task ids for historic task variables

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
@@ -61,6 +61,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricJobLogEventEntity;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.IncidentEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
@@ -401,6 +402,7 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
     String scopeActivityInstanceId = getScopeActivityInstanceId(variableInstance);
     String sourceActivityInstanceId = getSourceActivityInstanceId(sourceVariableScope);
     ExecutionEntity sourceExecution = getSourceExecution(sourceVariableScope);
+    String taskId = getSourceTaskId(sourceVariableScope, sourceExecution);
 
     // create event
     HistoricVariableUpdateEventEntity evt = newVariableUpdateEventEntity(sourceExecution);
@@ -414,6 +416,10 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
 
     // set source activity instance id
     evt.setActivityInstanceId(sourceActivityInstanceId);
+
+    if (evt.getTaskId() == null) {
+      evt.setTaskId(taskId);
+    }
 
     // mark initial variables on process start
     if (sourceExecution != null && sourceExecution.isProcessInstanceStarting()
@@ -483,6 +489,39 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
       sourceExecution = taskEntity.getExecution();
     }
     return sourceExecution;
+  }
+
+  private static String getSourceTaskId(VariableScope sourceVariableScope, ExecutionEntity sourceExecution) {
+    if (sourceVariableScope instanceof TaskEntity taskEntity) {
+      if (taskEntity.getId() != null) {
+        return taskEntity.getId();
+      }
+      if (sourceExecution != null
+          && sourceExecution.getTasks() != null
+          && !sourceExecution.getTasks().isEmpty()) {
+        return sourceExecution.getTasks().get(0).getId();
+      }
+    }
+    return null;
+  }
+
+  private void updateCachedHistoricVariableTaskIds(ExecutionEntity executionEntity, String taskId) {
+    String activityInstanceId = executionEntity.getActivityInstanceId();
+    if (activityInstanceId == null || taskId == null) {
+      return;
+    }
+
+    List<HistoricVariableInstanceEntity> cachedHistoricVariableInstances = Context
+      .getCommandContext()
+      .getDbEntityManager()
+      .getCachedEntitiesByType(HistoricVariableInstanceEntity.class);
+
+    for (HistoricVariableInstanceEntity historicVariableInstance : cachedHistoricVariableInstances) {
+      if (historicVariableInstance.getTaskId() == null
+          && activityInstanceId.equals(historicVariableInstance.getActivityInstanceId())) {
+        historicVariableInstance.setTaskId(taskId);
+      }
+    }
   }
 
   // event instance factory ////////////////////////
@@ -731,6 +770,7 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
     if(task != null) {
       evt.setTaskId(task.getId());
       evt.setTaskAssignee(task.getAssignee());
+      updateCachedHistoricVariableTaskIds(executionEntity, task.getId());
     }
 
     return evt;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceScopeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceScopeTest.java
@@ -79,6 +79,7 @@ class HistoricVariableInstanceScopeTest {
 
     // the variable is in the process instance scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(pi.getId());
+    assertThat(variable.getTaskId()).isNull();
 
     taskService.complete(taskService.createTaskQuery().singleResult().getId());
     testRule.assertProcessEnded(pi.getId());
@@ -106,6 +107,7 @@ class HistoricVariableInstanceScopeTest {
 
     // the variable is in the task scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(taskExecution.getActivityInstanceId());
+    assertThat(variable.getTaskId()).isEqualTo(task.getId());
 
     taskService.complete(task.getId());
     testRule.assertProcessEnded(pi.getId());
@@ -136,12 +138,14 @@ class HistoricVariableInstanceScopeTest {
     assertThat(firstVar.getValue()).isEqualTo("testValue");
     // the variable is in the process instance scope
     assertThat(firstVar.getActivityInstanceId()).isEqualTo(pi.getId());
+    assertThat(firstVar.getTaskId()).isNull();
 
     HistoricVariableInstance secondVar = result.get(1);
     assertThat(secondVar.getVariableName()).isEqualTo("testVar");
     assertThat(secondVar.getValue()).isEqualTo("anotherTestValue");
     // the variable is in the task scope
     assertThat(secondVar.getActivityInstanceId()).isEqualTo(taskExecution.getActivityInstanceId());
+    assertThat(secondVar.getTaskId()).isEqualTo(task.getId());
 
     taskService.complete(task.getId());
     testRule.assertProcessEnded(pi.getId());
@@ -163,6 +167,7 @@ class HistoricVariableInstanceScopeTest {
     HistoricVariableInstance variable = query.singleResult();
     // the variable is in the process instance scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(pi.getId());
+    assertThat(variable.getTaskId()).isEqualTo(task.getId());
 
     taskService.complete(task.getId());
     testRule.assertProcessEnded(pi.getId());
@@ -179,6 +184,7 @@ class HistoricVariableInstanceScopeTest {
     HistoricVariableInstance variable = query.singleResult();
     // the variable is in the process instance scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(pi.getId());
+    assertThat(variable.getTaskId()).isNull();
 
     testRule.assertProcessEnded(pi.getId());
   }
@@ -223,6 +229,7 @@ class HistoricVariableInstanceScopeTest {
     HistoricVariableInstance variable = query.singleResult();
     // the variable is in the user task scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(taskExecution.getActivityInstanceId());
+    assertThat(variable.getTaskId()).isEqualTo(task.getId());
 
     taskService.complete(task.getId());
 
@@ -245,6 +252,7 @@ class HistoricVariableInstanceScopeTest {
     HistoricVariableInstance variable = query.singleResult();
     // the variable is in the process instance scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(pi.getId());
+    assertThat(variable.getTaskId()).isEqualTo(task.getId());
 
     taskService.complete(task.getId());
 
@@ -262,6 +270,7 @@ class HistoricVariableInstanceScopeTest {
     HistoricVariableInstance variable = query.singleResult();
     // the variable is in the process instance scope
     assertThat(variable.getActivityInstanceId()).isEqualTo(pi.getId());
+    assertThat(variable.getTaskId()).isNull();
 
     testRule.assertProcessEnded(pi.getId());
   }
@@ -333,6 +342,8 @@ class HistoricVariableInstanceScopeTest {
     String theService1Id = activityInstanceQuery.activityId("theService1").singleResult().getId();
     String theService2Id = activityInstanceQuery.activityId("theService2").singleResult().getId();
     String theTaskId = activityInstanceQuery.activityId("theTask").singleResult().getId();
+    Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
+    assertThat(task).isNotNull();
 
     // when (1)
     HistoricVariableInstance firstVariable = historyService
@@ -342,6 +353,7 @@ class HistoricVariableInstanceScopeTest {
 
     // then (1)
     assertThat(firstVariable.getActivityInstanceId()).isEqualTo(theService1Id);
+    assertThat(firstVariable.getTaskId()).isNull();
 
     if(processEngineConfiguration.getHistoryLevel().getId() > ProcessEngineConfigurationImpl.HISTORYLEVEL_AUDIT) {
       HistoricDetail firstVariableDetail = historyService
@@ -360,6 +372,7 @@ class HistoricVariableInstanceScopeTest {
 
     // then (2)
     assertThat(secondVariable.getActivityInstanceId()).isEqualTo(theService2Id);
+    assertThat(secondVariable.getTaskId()).isNull();
 
     if(processEngineConfiguration.getHistoryLevel().getId() > ProcessEngineConfigurationImpl.HISTORYLEVEL_AUDIT) {
       HistoricDetail secondVariableDetail = historyService
@@ -378,6 +391,7 @@ class HistoricVariableInstanceScopeTest {
 
     // then (3)
     assertThat(thirdVariable.getActivityInstanceId()).isEqualTo(theTaskId);
+    assertThat(thirdVariable.getTaskId()).isEqualTo(task.getId());
 
     if(processEngineConfiguration.getHistoryLevel().getId() > ProcessEngineConfigurationImpl.HISTORYLEVEL_AUDIT) {
       HistoricDetail thirdVariableDetail = historyService


### PR DESCRIPTION
## Summary

Backports the concrete Fluxnova fix for historic variable `taskId` persistence.

- Populates `TASK_ID_` on historic variable events created from a task scope.
- Updates cached historic variable instances for user-task input mappings once the user task id is known.
- Adds behavior-focused assertions to `HistoricVariableInstanceScopeTest`.

## Why this matters

Operaton already has the `TASK_ID_` column and the public `HistoricVariableInstance#getTaskId()` API. The missing part was event production: variables created through `TaskService` and user-task input mappings could be written to `ACT_HI_VARINST` without the task id even though the variable came from task context.

That makes later history queries by `taskIdIn(...)` incomplete and loses useful audit context.

## Reviewer notes

- This PR does not introduce a schema change. It only populates an existing field.
- Process-start variables and service-task input variables remain without a task id.
- Variables written via `TaskService` receive the current task id even when the variable scope is ultimately the process instance, matching the source backport intent.
- User-task input variables are created before the task entity has been fully connected to history; the patch updates matching cached historic variable instances by activity instance id after the task id is available.
- The PR intentionally stays Draft because the source item came from the `needs_design` bucket and maintainers should confirm the history semantics.

## Attribution

Backported from Fluxnova:

- `08c6c6d349defe5561a0a59f805a3eb1763c7ead`
- `f2e8077e554c51f37b00f98360ec09e1bc18f6d0`

Original author: `jyotisahu9 <30759880+jyotisahu9@users.noreply.github.com>`

Tracked change unit: `335`.

## Verification

```bash
./mvnw -pl engine -Dtest=HistoricVariableInstanceScopeTest test -Dskip.frontend.build=true
```

Result: `Tests run: 15, Failures: 0, Errors: 0, Skipped: 0`.
