### PR TITLE
feat(history): expose root cause incident messages

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/history/HistoricIncidentDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/history/HistoricIncidentDto.ftl
@@ -149,6 +149,12 @@
         name = "annotation"
         type = "string"
         desc = "The annotation set to the incident."
+    />
+
+    <@lib.property
+        name = "rootCauseIncidentMessage"
+        type = "string"
+        desc = "The incident message of the root cause incident."
         last = true
     />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/incident/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/incident/get.ftl
@@ -58,7 +58,8 @@
                            "resolved": false,
                            "removalTime": null,
                            "rootProcessInstanceId": "aRootProcessInstanceId",
-                           "annotation": "an annotation"
+                           "annotation": "an annotation",
+                           "rootCauseIncidentMessage": "aRootCauseIncidentMessage"
                          },
                          {
                            "id": "anIncidentId",
@@ -81,7 +82,8 @@
                            "resolved": true,
                            "removalTime": "2018-02-10T14:33:19.000+0200",
                            "rootProcessInstanceId": "aRootProcessInstanceId",
-                           "annotation": "another annotation"
+                           "annotation": "another annotation",
+                           "rootCauseIncidentMessage": "anotherRootCauseIncidentMessage"
                          }
                        ]
                      }']

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/HistoricIncidentDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/HistoricIncidentDto.java
@@ -49,6 +49,7 @@ public class HistoricIncidentDto {
   protected Boolean deleted;
   protected Boolean resolved;
   protected String annotation;
+  protected String rootCauseIncidentMessage;
 
   public String getId() {
     return id;
@@ -142,6 +143,10 @@ public class HistoricIncidentDto {
     return annotation;
   }
 
+  public String getRootCauseIncidentMessage() {
+    return rootCauseIncidentMessage;
+  }
+
   public static HistoricIncidentDto fromHistoricIncident(HistoricIncident historicIncident) {
     HistoricIncidentDto dto = new HistoricIncidentDto();
 
@@ -168,6 +173,7 @@ public class HistoricIncidentDto {
     dto.removalTime = historicIncident.getRemovalTime();
     dto.rootProcessInstanceId = historicIncident.getRootProcessInstanceId();
     dto.annotation = historicIncident.getAnnotation();
+    dto.rootCauseIncidentMessage = historicIncident.getRootCauseIncidentMessage();
 
     return dto;
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
@@ -751,6 +751,7 @@ public abstract class MockProvider {
   public static final String EXAMPLE_HIST_INCIDENT_ROOT_PROC_INST_ID = "aRootProcInstId";
   public static final String EXAMPLE_HIST_INCIDENT_CAUSE_INCIDENT_ID = "aCauseIncidentId";
   public static final String EXAMPLE_HIST_INCIDENT_ROOT_CAUSE_INCIDENT_ID = "aRootCauseIncidentId";
+  public static final String EXAMPLE_HIST_ROOT_CAUSE_INCIDENT_MESSAGE = "aRootCauseIncidentMessage";
   public static final String EXAMPLE_HIST_INCIDENT_CONFIGURATION = "aConfiguration";
   public static final String EXAMPLE_HIST_INCIDENT_HISTORY_CONFIGURATION = "aHistoryConfiguration";
   public static final String EXAMPLE_HIST_INCIDENT_MESSAGE = "anIncidentMessage";
@@ -2669,6 +2670,7 @@ public abstract class MockProvider {
     when(incident.getRemovalTime()).thenReturn(DateTimeUtil.parseDate(EXAMPLE_HIST_INCIDENT_REMOVAL_TIME));
     when(incident.getRootProcessInstanceId()).thenReturn(EXAMPLE_HIST_INCIDENT_ROOT_PROC_INST_ID);
     when(incident.getAnnotation()).thenReturn(EXAMPLE_USER_OPERATION_ANNOTATION);
+    when(incident.getRootCauseIncidentMessage()).thenReturn(EXAMPLE_HIST_ROOT_CAUSE_INCIDENT_MESSAGE);
 
     return incident;
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
@@ -388,6 +388,7 @@ public class HistoricIncidentRestServiceQueryTest extends AbstractRestServiceTes
     Date returnedRemovalTime = DateTimeUtil.parseDate(from(content).getString("[0].removalTime"));
     String returnedRootProcessInstanceId = from(content).getString("[0].rootProcessInstanceId");
     String returnedAnnotation = from(content).getString("[0].annotation");
+    String returnedRootCauseIncidentMessage = from(content).getString("[0].rootCauseIncidentMessage");
 
     assertThat(returnedId).isEqualTo(MockProvider.EXAMPLE_HIST_INCIDENT_ID);
     assertThat(returnedProcessInstanceId).isEqualTo(MockProvider.EXAMPLE_HIST_INCIDENT_PROC_INST_ID);
@@ -411,6 +412,7 @@ public class HistoricIncidentRestServiceQueryTest extends AbstractRestServiceTes
     assertThat(returnedRemovalTime).isEqualTo(DateTimeUtil.parseDate(MockProvider.EXAMPLE_HIST_INCIDENT_REMOVAL_TIME));
     assertThat(returnedRootProcessInstanceId).isEqualTo(MockProvider.EXAMPLE_HIST_INCIDENT_ROOT_PROC_INST_ID);
     assertThat(returnedAnnotation).isEqualTo(MockProvider.EXAMPLE_USER_OPERATION_ANNOTATION);
+    assertThat(returnedRootCauseIncidentMessage).isEqualTo(MockProvider.EXAMPLE_HIST_ROOT_CAUSE_INCIDENT_MESSAGE);
 
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/history/HistoricIncident.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/history/HistoricIncident.java
@@ -160,4 +160,9 @@ public interface HistoricIncident {
    * Returns the annotation of this incident
    */
   String getAnnotation();
+
+  /**
+   * Returns the incident message of the root cause incident.
+   */
+  String getRootCauseIncidentMessage();
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoricIncidentEventEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoricIncidentEventEntity.java
@@ -43,6 +43,7 @@ public class HistoricIncidentEventEntity extends HistoryEvent {
   protected String historyConfiguration;
   protected String failedActivityId;
   protected String annotation;
+  protected String rootCauseIncidentMessage;
 
   public Date getCreateTime() {
     return createTime;
@@ -172,6 +173,14 @@ public class HistoricIncidentEventEntity extends HistoryEvent {
 
   public void setAnnotation(String annotation) {
     this.annotation = annotation;
+  }
+
+  public String getRootCauseIncidentMessage() {
+    return rootCauseIncidentMessage;
+  }
+
+  public void setRootCauseIncidentMessage(String rootCauseIncidentMessage) {
+    this.rootCauseIncidentMessage = rootCauseIncidentMessage;
   }
 
 }

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricIncident.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricIncident.xml
@@ -388,16 +388,21 @@
     <result property="removalTime" column="REMOVAL_TIME_" jdbcType="TIMESTAMP"/>
   </resultMap>
 
+  <resultMap id="historicIncidentResultWithRootCauseIncidentMessageMap" type="org.operaton.bpm.engine.impl.persistence.entity.HistoricIncidentEntity" extends="historicIncidentResultMap">
+    <result property="rootCauseIncidentMessage" column="ROOT_CAUSE_INCIDENT_MSG_" jdbcType="VARCHAR" />
+  </resultMap>
+
   <!-- HISTORIC INCIDENT SELECT -->
 
   <select id="selectHistoricIncidentById" resultMap="historicIncidentResultMap">
     select RES.* from ${prefix}ACT_HI_INCIDENT RES where RES.ID_ = #{id}
   </select>
 
-  <select id="selectHistoricIncidentByQueryCriteria" parameterType="org.operaton.bpm.engine.impl.HistoricIncidentQueryImpl" resultMap="historicIncidentResultMap">
+  <select id="selectHistoricIncidentByQueryCriteria" parameterType="org.operaton.bpm.engine.impl.HistoricIncidentQueryImpl" resultMap="historicIncidentResultWithRootCauseIncidentMessageMap">
+    <bind name="includeRootCauseIncidentMessage" value="'Y'" />
     <include refid="org.operaton.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
     ${limitBefore}
-    select ${distinct} RES.*
+    select ${distinct} RES.*, ROOT_INCIDENT.INCIDENT_MSG_ as ROOT_CAUSE_INCIDENT_MSG_
     ${limitBetween}
     <include refid="selectHistoricIncidentByQueryCriteriaSql"/>
     ${orderBy}
@@ -405,6 +410,7 @@
   </select>
 
   <select id="selectHistoricIncidentCountByQueryCriteria" parameterType="org.operaton.bpm.engine.impl.HistoricIncidentQueryImpl" resultType="long">
+    <bind name="includeRootCauseIncidentMessage" value="'N'" />
     ${countDistinctBeforeStart} RES.ID_ ${countDistinctBeforeEnd}
     <include refid="selectHistoricIncidentByQueryCriteriaSql"/>
     ${countDistinctAfterEnd}
@@ -427,6 +433,11 @@
         </if>
         ${authJoinEnd}
       )
+    </if>
+
+    <if test="includeRootCauseIncidentMessage == 'Y'">
+      left join ${prefix}ACT_HI_INCIDENT ROOT_INCIDENT
+      on ROOT_INCIDENT.ID_ = RES.ROOT_CAUSE_INCIDENT_ID_
     </if>
 
     <where>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentTest.java
@@ -257,6 +257,10 @@ class HistoricIncidentTest {
         .singleResult();
     assertThat(pi2).isNotNull();
 
+    Incident rootCauseIncident = runtimeService.createIncidentQuery()
+        .processInstanceId(pi2.getId())
+        .singleResult();
+
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
 
     HistoricIncident rootCauseHistoricIncident = query.processInstanceId(pi2.getId()).singleResult();
@@ -265,6 +269,7 @@ class HistoricIncidentTest {
     // cause and root cause id is equal to the id of the root incident
     assertThat(rootCauseHistoricIncident.getCauseIncidentId()).isEqualTo(rootCauseHistoricIncident.getId());
     assertThat(rootCauseHistoricIncident.getRootCauseIncidentId()).isEqualTo(rootCauseHistoricIncident.getId());
+    assertThat(rootCauseHistoricIncident.getRootCauseIncidentMessage()).isEqualTo(rootCauseIncident.getIncidentMessage());
 
     HistoricIncident historicIncident = query.processInstanceId(pi1.getId()).singleResult();
     assertThat(historicIncident).isNotNull();
@@ -272,6 +277,8 @@ class HistoricIncidentTest {
     // cause and root cause id is equal to the id of the root incident
     assertThat(historicIncident.getCauseIncidentId()).isEqualTo(rootCauseHistoricIncident.getId());
     assertThat(historicIncident.getRootCauseIncidentId()).isEqualTo(rootCauseHistoricIncident.getId());
+    assertThat(historicIncident.getRootCauseIncidentMessage()).isEqualTo(rootCauseIncident.getIncidentMessage());
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(pi1.getId()).count()).isOne();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.testQueryByCauseIncidentId.bpmn20.xml",


### PR DESCRIPTION
## Summary

Backports the Fluxnova `HistoricIncident.rootCauseIncidentMessage` extension to Operaton.

The change exposes the incident message of the root-cause incident together with historic incident query results. This lets REST consumers display the original failure reason for derived incidents without issuing a second query for the root incident.

## What changes

- Adds `HistoricIncident#getRootCauseIncidentMessage()` to the engine history API.
- Populates the field on historic incident query results through a left join from `ACT_HI_INCIDENT.RES.ROOT_CAUSE_INCIDENT_ID_` to the root incident row.
- Keeps count queries free of the extra join.
- Adds the field to `HistoricIncidentDto` and the REST/OpenAPI history incident response model.
- Adds REST DTO coverage and an Engine test that verifies the real DB-backed query returns the root incident message for a recursive incident chain.

## Source attribution

Backported from Fluxnova:

- Source commit: `b7eb6b8d5d878173f90095e6a3e5298a886e708a`
- Source title: `feat(historic-incident): add rootCauseIncidentMessage field`
- Original author: Reddy Kishore Mannuru `<kishoremannuru@gmail.com>`
- Source co-author: Copilot `<223556219+Copilot@users.noreply.github.com>`

Operaton adaptation:

- Package names and OpenAPI templates adapted to `org.operaton`.
- Added an Engine-level regression test in addition to the source REST mock coverage.
- The surrounding history/statistics endpoint candidates from the original design draft are intentionally not included in this PR.

## Reviewer notes

This is not a schema migration. The new response field is derived from existing historic incident data by joining the queried historic incident row to its root-cause incident row.

The important behavior to review is the SQL mapping in `HistoricIncident.xml`: list queries use the join and map `ROOT_INCIDENT.INCIDENT_MSG_`, while count queries bind the include flag to avoid the join entirely.

## Verification

- `./mvnw -pl engine -Dtest=HistoricIncidentTest#testCreateRecursiveHistoricIncidents test -Dskip.frontend.build=true`
- `./mvnw -pl engine-rest/engine-rest -Dtest=HistoricIncidentRestServiceQueryTest test -Dskip.frontend.build=true`
