### PR TITLE
feat(engine-rest): expose deprecated camundaFormRef alias

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/CamundaFormRef.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/CamundaFormRef.ftl
@@ -1,0 +1,25 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto>
+
+    <@lib.property
+        name = "key"
+        type = "string"
+        deprecated = true
+        desc = "The key of the Camunda Form. Deprecated compatibility alias for `operatonFormRef.key`." />
+
+    <@lib.property
+        name = "binding"
+        type = "string"
+        deprecated = true
+        desc = "The binding of the Camunda Form. Deprecated compatibility alias for `operatonFormRef.binding`." />
+
+    <@lib.property
+        name = "version"
+        type = "integer"
+        format = "int32"
+        deprecated = true
+        last = true
+        desc = "The specific version of a Camunda Form. Deprecated compatibility alias for `operatonFormRef.version`." />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/FormDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/FormDto.ftl
@@ -16,6 +16,13 @@
         desc = "A reference to a specific version of a Operaton Form." />
 
     <@lib.property
+        name = "camundaFormRef"
+        type = "ref"
+        dto = "CamundaFormRef"
+        deprecated = true
+        desc = "Deprecated compatibility alias for `operatonFormRef`. Use `operatonFormRef` instead." />
+
+    <@lib.property
         name = "contextPath"
         type = "string"
         last = true

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
@@ -130,6 +130,13 @@
         desc = "A reference to a specific version of a Operaton Form."/>
 
     <@lib.property
+        name = "camundaFormRef"
+        type = "ref"
+        dto = "CamundaFormRef"
+        deprecated = true
+        desc = "Deprecated compatibility alias for `operatonFormRef`. Use `operatonFormRef` instead." />
+
+    <@lib.property
         name = "tenantId"
         type = "string"
         desc = "If not `null`, the tenant id of the task." />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/get.ftl
@@ -68,6 +68,11 @@
                              "binding": "version",
                              "version": 2
                            },
+                           "camundaFormRef":{
+                             "key": "aOperatonFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
                            "tenantId": "aTenantId",
                            "taskState": "aTaskState"
                          }
@@ -100,6 +105,11 @@
                            "suspended": false,
                            "formKey":"aFormKey",
                            "operatonFormRef":{
+                             "key": "aOperatonFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
+                           "camundaFormRef":{
                              "key": "aOperatonFormKey",
                              "binding": "version",
                              "version": 2
@@ -138,6 +148,11 @@
                            "suspended": false,
                            "formKey":"aFormKey",
                            "operatonFormRef":{
+                             "key": "aOperatonFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
+                           "camundaFormRef":{
                              "key": "aOperatonFormKey",
                              "binding": "version",
                              "version": 2
@@ -188,6 +203,11 @@
                            "suspended": false,
                            "formKey":"aFormKey",
                            "operatonFormRef":{
+                             "key": "aOperatonFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
+                           "camundaFormRef":{
                              "key": "aOperatonFormKey",
                              "binding": "version",
                              "version": 2

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/post.ftl
@@ -158,6 +158,11 @@
                              "binding": "version",
                              "version": 2
                            },
+                           "camundaFormRef":{
+                             "key": "aOperatonFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
                            "tenantId":"aTenantId",
                            "taskState": "aTaskState"
                          }

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
@@ -53,6 +53,11 @@
                            "binding": "version",
                            "version": 2
                          },
+                         "camundaFormRef":{
+                           "key": "aOperatonFormKey",
+                           "binding": "version",
+                           "version": 2
+                         },
                          "tenantId":"aTenantId",
 			 "taskState": "aTaskState"
                        }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/CamundaFormRefDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/CamundaFormRefDto.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto;
+
+import org.operaton.bpm.engine.form.OperatonFormRef;
+
+/** @deprecated Use {@link OperatonFormRef} through the {@code operatonFormRef} REST field instead. */
+@Deprecated
+public class CamundaFormRefDto {
+
+  protected String key;
+  protected String binding;
+  protected Integer version;
+
+  public CamundaFormRefDto() {
+  }
+
+  public CamundaFormRefDto(String key, String binding, Integer version) {
+    this.key = key;
+    this.binding = binding;
+    this.version = version;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getBinding() {
+    return binding;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  public static CamundaFormRefDto from(OperatonFormRef operatonFormRef) {
+    if (operatonFormRef == null) {
+      return null;
+    }
+    return new CamundaFormRefDto(operatonFormRef.getKey(), operatonFormRef.getBinding(), operatonFormRef.getVersion());
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/FormDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/FormDto.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest.dto.task;
 
 import org.operaton.bpm.engine.form.FormData;
 import org.operaton.bpm.engine.form.OperatonFormRef;
+import org.operaton.bpm.engine.rest.dto.CamundaFormRefDto;
 
 /**
  *
@@ -27,6 +28,9 @@ public class FormDto {
 
   private String key;
   private OperatonFormRef operatonFormRef;
+  /** @deprecated Use {@link #operatonFormRef} instead. */
+  @Deprecated
+  private CamundaFormRefDto camundaFormRef;
   private String contextPath;
 
   public void setKey(String form) {
@@ -43,6 +47,13 @@ public class FormDto {
 
   public void setOperatonFormRef(OperatonFormRef operatonFormRef) {
     this.operatonFormRef = operatonFormRef;
+    this.camundaFormRef = CamundaFormRefDto.from(operatonFormRef);
+  }
+
+  /** @deprecated Use {@link #getOperatonFormRef()} instead. */
+  @Deprecated
+  public CamundaFormRefDto getCamundaFormRef() {
+    return camundaFormRef;
   }
 
   public void setContextPath(String contextPath) {
@@ -58,7 +69,7 @@ public class FormDto {
 
     if (formData != null) {
       dto.key = formData.getFormKey();
-      dto.operatonFormRef = formData.getOperatonFormRef();
+      dto.setOperatonFormRef(formData.getOperatonFormRef());
     }
 
     return dto;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskDto.java
@@ -20,6 +20,7 @@ import java.util.Date;
 
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.OperatonFormRef;
+import org.operaton.bpm.engine.rest.dto.CamundaFormRefDto;
 import org.operaton.bpm.engine.rest.dto.converter.DelegationStateConverter;
 import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
@@ -48,6 +49,9 @@ public class TaskDto {
   private boolean suspended;
   private String formKey;
   private OperatonFormRef operatonFormRef;
+  /** @deprecated Use {@link #operatonFormRef} instead. */
+  @Deprecated
+  private CamundaFormRefDto camundaFormRef;
   private String tenantId;
   /**
    * Returns task State of task
@@ -87,6 +91,7 @@ public class TaskDto {
     try {
       this.formKey = task.getFormKey();
       this.operatonFormRef = task.getOperatonFormRef();
+      this.camundaFormRef = CamundaFormRefDto.from(this.operatonFormRef);
     }
     catch (BadUserRequestException e) {
       // ignore (initializeFormKeys was not called)
@@ -228,6 +233,12 @@ public class TaskDto {
     return operatonFormRef;
   }
 
+  /** @deprecated Use {@link #getOperatonFormRef()} instead. */
+  @Deprecated
+  public CamundaFormRefDto getCamundaFormRef() {
+    return camundaFormRef;
+  }
+
   public String getTenantId() {
     return tenantId;
   }
@@ -275,6 +286,7 @@ public class TaskDto {
     try {
       dto.formKey = task.getFormKey();
       dto.operatonFormRef = task.getOperatonFormRef();
+      dto.camundaFormRef = CamundaFormRefDto.from(dto.operatonFormRef);
     }
     catch (BadUserRequestException e) {
       // ignore (initializeFormKeys was not called)

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/task/HalTask.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/task/HalTask.java
@@ -31,6 +31,7 @@ import org.operaton.bpm.engine.rest.ProcessDefinitionRestService;
 import org.operaton.bpm.engine.rest.ProcessInstanceRestService;
 import org.operaton.bpm.engine.rest.TaskRestService;
 import org.operaton.bpm.engine.rest.UserRestService;
+import org.operaton.bpm.engine.rest.dto.CamundaFormRefDto;
 import org.operaton.bpm.engine.rest.hal.HalRelation;
 import org.operaton.bpm.engine.rest.hal.HalResource;
 import org.operaton.bpm.engine.rest.hal.identitylink.HalIdentityLink;
@@ -87,6 +88,9 @@ public class HalTask extends HalResource<HalTask> {
   private boolean suspended;
   private String formKey;
   private OperatonFormRef operatonFormRef;
+  /** @deprecated Use {@link #operatonFormRef} instead. */
+  @Deprecated
+  private CamundaFormRefDto camundaFormRef;
   private String tenantId;
 
   public static HalTask generate(Task task, ProcessEngine engine) {
@@ -125,6 +129,7 @@ public class HalTask extends HalResource<HalTask> {
     try {
       dto.formKey = task.getFormKey();
       dto.operatonFormRef = task.getOperatonFormRef();
+      dto.camundaFormRef = CamundaFormRefDto.from(dto.operatonFormRef);
     }
     catch (BadUserRequestException e) {
       // ignore (initializeFormKeys was not called)
@@ -229,6 +234,12 @@ public class HalTask extends HalResource<HalTask> {
 
   public OperatonFormRef getOperatonFormRef() {
     return operatonFormRef;
+  }
+
+  /** @deprecated Use {@link #getOperatonFormRef()} instead. */
+  @Deprecated
+  public CamundaFormRefDto getCamundaFormRef() {
+    return camundaFormRef;
   }
 
   public String getTenantId() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -449,6 +449,9 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .body("operatonFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
       .body("operatonFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
       .body("operatonFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
+      .body("camundaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
+      .body("camundaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
+      .body("camundaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
     .when().get(START_FORM_URL);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -733,6 +733,7 @@ public class TaskRestServiceInteractionTest extends
       .then().expect().statusCode(Status.OK.getStatusCode())
       .body("key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
       .body("operatonFormRef", nullValue())
+      .body("camundaFormRef", nullValue())
       .body("contextPath", equalTo(MockProvider.EXAMPLE_PROCESS_APPLICATION_CONTEXT_PATH))
       .when().get(TASK_FORM_URL);
   }
@@ -746,6 +747,9 @@ public class TaskRestServiceInteractionTest extends
         .body("operatonFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
         .body("operatonFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
         .body("operatonFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
+        .body("camundaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
+        .body("camundaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
+        .body("camundaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
         .body("key", nullValue())
       .when().get(SINGLE_TASK_URL);
   }
@@ -777,6 +781,9 @@ public class TaskRestServiceInteractionTest extends
        .body("operatonFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
        .body("operatonFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
        .body("operatonFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
+       .body("camundaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
+       .body("camundaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
+       .body("camundaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
        .body("key", nullValue())
        .body("contextPath", equalTo(MockProvider.EXAMPLE_PROCESS_APPLICATION_CONTEXT_PATH))
      .when().get(TASK_FORM_URL);


### PR DESCRIPTION
## Summary

Backports the Fluxnova compatibility behavior for deprecated `camundaFormRef` response fields.

- Adds `camundaFormRef` as a deprecated alias for `operatonFormRef` in task/form REST DTOs.
- Includes the alias in HAL task output.
- Documents the deprecated alias in the OpenAPI templates and examples.
- Adds interaction-test assertions for start-form, task GET and task-form responses.

## Operaton adaptation

The source fork added a new Camunda-named Engine API type. This PR keeps the compatibility surface narrower for Operaton:

- No new `org.operaton.bpm.engine.form.CamundaFormRef` core API is introduced.
- The legacy object is represented as REST-local `CamundaFormRefDto`.
- `operatonFormRef` remains the canonical field and `camundaFormRef` is output-only/deprecated compatibility.

## Reviewer notes

- This intentionally reintroduces a Camunda-named REST response field for migration/client compatibility.
- The PR remains Draft because the source item came from the `needs_design` bucket and maintainers should explicitly confirm whether Operaton wants this compatibility contract.
- The legacy field mirrors `key`, `binding` and `version` from `operatonFormRef`; it is `null` whenever `operatonFormRef` is `null`.

## Attribution

Backported from Fluxnova commit `7311b89100e23c6bc4d0e90c7b8663341b693e29`.

Original author: `Mannuru, ReddyKishore <ReddyKishore.Mannuru@fmr.com>`

Tracked change unit: `465`.

## Verification

```bash
./mvnw -pl engine-rest/engine-rest -Dtest=TaskRestServiceInteractionTest,ProcessDefinitionRestServiceInteractionTest test -Dskip.frontend.build=true
```

Result: both Surefire executions passed, `Tests run: 387, Failures: 0, Errors: 0, Skipped: 0` per execution.
