### PR TITLE
feat(connect): make encoding for HTTP connector configurable

### DIFF
--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpConnector.java
@@ -54,8 +54,10 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
 
   protected static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
+  public static final String PROPERTY_CHARSET = "org.operaton.connect.http-client.charset";
+
   protected CloseableHttpClient httpClient;
-  protected final Charset charset;
+  protected Charset charset;
   private Map<String, Object> connectionConfigOptions;
   private final HttpClientConnectionManager connectionManager;
 
@@ -63,7 +65,8 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     super(connectorId);
     connectionManager = new PoolingHttpClientConnectionManager();
     httpClient = createClient();
-    charset = StandardCharsets.UTF_8;
+    String charsetProperty = System.getProperty(PROPERTY_CHARSET);
+    charset = charsetProperty != null ? Charset.forName(charsetProperty) : StandardCharsets.UTF_8;
   }
 
   protected CloseableHttpClient createClient() {
@@ -79,6 +82,29 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
 
   public void setHttpClient(CloseableHttpClient httpClient) {
     this.httpClient = httpClient;
+  }
+
+  /**
+   * Returns the charset used to encode request payloads. Defaults to UTF-8.
+   *
+   * @return the charset
+   * @since 1.1
+   */
+  public Charset getCharset() {
+    return charset;
+  }
+
+  /**
+   * Sets the charset used to encode request payloads.
+   *
+   * @param charset the charset to use; must not be {@code null}
+   * @since 1.1
+   */
+  public void setCharset(Charset charset) {
+    if (charset == null) {
+      throw new IllegalArgumentException("charset must not be null");
+    }
+    this.charset = charset;
   }
 
   @Override

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpConnector.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
@@ -54,7 +55,7 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
 
   protected static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
-  public static final String PROPERTY_CHARSET = "org.operaton.connect.http-client.charset";
+  public static final String PROPERTY_CHARSET = "org.operaton.bpm.connect.httpclient.charset";
 
   protected CloseableHttpClient httpClient;
   protected Charset charset;
@@ -84,13 +85,7 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     this.httpClient = httpClient;
   }
 
-  /**
-   * Returns the charset used to encode request payloads. Defaults to UTF-8.
-   *
-   * @return the charset
-   * @since 1.1
-   */
-  public Charset getCharset() {
+  Charset getCharset() {
     return charset;
   }
 
@@ -98,13 +93,10 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
    * Sets the charset used to encode request payloads.
    *
    * @param charset the charset to use; must not be {@code null}
-   * @since 1.1
+   * @since 2.2
    */
   public void setCharset(Charset charset) {
-    if (charset == null) {
-      throw new IllegalArgumentException("charset must not be null");
-    }
-    this.charset = charset;
+    this.charset = Objects.requireNonNull(charset, "charset must not be null");
   }
 
   @Override

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorSystemPropertiesTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorSystemPropertiesTest.java
@@ -16,13 +16,19 @@
  */
 package org.operaton.connect.httpclient;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,8 +38,11 @@ import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
@@ -91,23 +100,50 @@ class HttpConnectorSystemPropertiesTest {
   }
 
   @Test
-  void shouldSetCharsetFromSystemProperty() {
+  void shouldApplyPayloadUsingCharsetFromSystemProperty(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
     // given
-    setSystemProperty(AbstractHttpConnector.PROPERTY_CHARSET, "ISO-8859-1");
+    setSystemProperty(AbstractHttpConnector.PROPERTY_CHARSET, "UTF-16");
+    stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+    String payload = "café";
 
     // when
     HttpConnectorImpl connector = new HttpConnectorImpl();
+    connector.createRequest()
+        .url("http://localhost:" + wmRuntimeInfo.getHttpPort())
+        .contentType("text/plain")
+        .payload(payload)
+        .post()
+        .execute();
 
     // then
-    assertThat(connector.getCharset()).isEqualTo(Charset.forName("ISO-8859-1"));
+    assertThat(readRequestPayload(StandardCharsets.UTF_16)).isEqualTo(payload);
   }
 
   @Test
-  void shouldDefaultToUtf8WhenNoSystemPropertySet() {
+  void shouldApplyPayloadUsingUtf8ByDefault(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    // given
+    stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+    String payload = "café";
+
     // when
     HttpConnectorImpl connector = new HttpConnectorImpl();
+    connector.createRequest()
+        .url("http://localhost:" + wmRuntimeInfo.getHttpPort())
+        .contentType("text/plain")
+        .payload(payload)
+        .post()
+        .execute();
 
     // then
-    assertThat(connector.getCharset()).isEqualTo(StandardCharsets.UTF_8);
+    assertThat(readRequestPayload(StandardCharsets.UTF_8)).isEqualTo(payload);
+  }
+
+  protected String readRequestPayload(Charset charset) throws CharacterCodingException {
+    List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo("/")));
+    assertThat(requests).hasSize(1);
+    CharsetDecoder decoder = charset.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT);
+    return decoder.decode(ByteBuffer.wrap(requests.get(0).getBody())).toString();
   }
 }

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorSystemPropertiesTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorSystemPropertiesTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.connect.httpclient;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.operaton.connect.httpclient.impl.AbstractHttpConnector;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -35,6 +38,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.apache.hc.core5.http.HttpHeaders.USER_AGENT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -84,5 +88,26 @@ class HttpConnectorSystemPropertiesTest {
     // then
     verify(getRequestedFor(urlEqualTo("/")).withHeader(USER_AGENT, equalTo("foo")));
 
+  }
+
+  @Test
+  void shouldSetCharsetFromSystemProperty() {
+    // given
+    setSystemProperty(AbstractHttpConnector.PROPERTY_CHARSET, "ISO-8859-1");
+
+    // when
+    HttpConnectorImpl connector = new HttpConnectorImpl();
+
+    // then
+    assertThat(connector.getCharset()).isEqualTo(Charset.forName("ISO-8859-1"));
+  }
+
+  @Test
+  void shouldDefaultToUtf8WhenNoSystemPropertySet() {
+    // when
+    HttpConnectorImpl connector = new HttpConnectorImpl();
+
+    // then
+    assertThat(connector.getCharset()).isEqualTo(StandardCharsets.UTF_8);
   }
 }

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.connect.httpclient;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpHead;
@@ -32,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.operaton.commons.utils.IoUtil;
 import org.operaton.connect.ConnectorRequestException;
 import org.operaton.connect.Connectors;
+import org.operaton.connect.httpclient.impl.AbstractHttpConnector;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
 import org.operaton.connect.spi.Connector;
@@ -163,6 +167,41 @@ public class HttpConnectorTest {
     long contentLength = request.getEntity().getContentLength();
 
     assertThat(contentLength).isEqualTo(EXAMPLE_PAYLOAD.length());
+  }
+
+  @Test
+  void shouldGetDefaultCharset() {
+    // when/then
+    assertThat(((AbstractHttpConnector<?, ?>) connector).getCharset()).isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void shouldSetCharset() {
+    // given
+    Charset iso = Charset.forName("ISO-8859-1");
+    AbstractHttpConnector<?, ?> abstractConnector = (AbstractHttpConnector<?, ?>) connector;
+
+    // when
+    abstractConnector.setCharset(iso);
+
+    // then
+    assertThat(abstractConnector.getCharset()).isEqualTo(iso);
+  }
+
+  @Test
+  void shouldUseSetCharsetForPayloadEncoding() throws Exception {
+    // given
+    Charset iso = Charset.forName("ISO-8859-1");
+    ((AbstractHttpConnector<?, ?>) connector).setCharset(iso);
+    String payload = "café"; // contains a non-ASCII character
+
+    // when
+    connector.createRequest().url(EXAMPLE_URL).payload(payload).post().execute();
+
+    // then - payload was encoded using ISO-8859-1
+    HttpPost request = interceptor.getTarget();
+    byte[] bytes = request.getEntity().getContent().readAllBytes();
+    assertThat(bytes).isEqualTo(payload.getBytes(iso));
   }
 
   protected void verifyHttpRequest(Class<? extends BasicClassicHttpRequest> requestClass) {

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
@@ -170,22 +170,14 @@ public class HttpConnectorTest {
   }
 
   @Test
-  void shouldGetDefaultCharset() {
-    // when/then
-    assertThat(((AbstractHttpConnector<?, ?>) connector).getCharset()).isEqualTo(StandardCharsets.UTF_8);
-  }
+  void shouldUseDefaultCharsetForPayloadEncoding() throws Exception {
+    String payload = "café";
 
-  @Test
-  void shouldSetCharset() {
-    // given
-    Charset iso = Charset.forName("ISO-8859-1");
-    AbstractHttpConnector<?, ?> abstractConnector = (AbstractHttpConnector<?, ?>) connector;
+    connector.createRequest().url(EXAMPLE_URL).payload(payload).post().execute();
 
-    // when
-    abstractConnector.setCharset(iso);
-
-    // then
-    assertThat(abstractConnector.getCharset()).isEqualTo(iso);
+    HttpPost request = interceptor.getTarget();
+    byte[] bytes = request.getEntity().getContent().readAllBytes();
+    assertThat(bytes).isEqualTo(payload.getBytes(StandardCharsets.UTF_8));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `getCharset()` and `setCharset(Charset)` to `AbstractHttpConnector` so callers can override the UTF-8 default at runtime
- Read system property `org.operaton.connect.http-client.charset` at construction time so operators can configure encoding without code changes (mirrors the existing `http.agent` system-property pattern)
- Default behavior (UTF-8) is unchanged when neither setter nor system property is used

## Why this matters

This closes #2613, which was filed by kthoms directly from javahippie's review comment on #2608 ("might be sensible to make this customizable in the future"). The encoding was hardcoded as `StandardCharsets.UTF_8` in `AbstractHttpConnector`'s constructor with no override path, affecting both `HttpConnectorImpl` and `SoapHttpConnectorImpl` (which extends `AbstractHttpConnector`).

## Changes

- **`AbstractHttpConnector`**: `charset` field made non-final; system property `org.operaton.connect.http-client.charset` read in constructor; `getCharset()` / `setCharset(Charset)` added with Javadoc
- **`HttpConnectorSystemPropertiesTest`**: two new tests - system property overrides charset, and UTF-8 default when no property is set
- **`HttpConnectorTest`**: three new tests - default charset is UTF-8, setter changes charset, and payload is encoded using the configured charset

Fixes #2613
