### PR TITLE
test(qa): add task authorization benchmark

### DIFF
--- a/qa/performance-tests-engine/README.md
+++ b/qa/performance-tests-engine/README.md
@@ -5,6 +5,7 @@ This testsuite allows running different kinds of performance tests against the p
 **Table of Contents:**
 
 * [The Benchmark](#benchmark)
+* [Task Authorization EXISTS Benchmark](#task-authorization-exists-benchmark)
 * [The Sql Statement Log](#sql-statement-log)
 * [The Activity Log](#activity-log)
 * [Configuration](#configuration)
@@ -75,6 +76,61 @@ The results file may look like this:
 ![LongTermBenchmarkResult Screenshot][3]
 
 This feature works only in the benchmark profile.  
+
+<a id="task-authorization-exists-benchmark"></a>
+## Task Authorization EXISTS Benchmark
+
+The task authorization benchmark is a standalone entry point for comparing task query authorization SQL changes. It creates a simple user-task process,
+starts a configurable number of process instances, creates user and group `TASK/READ` authorizations, enables authorization, and measures:
+
+* `TaskQuery#listPage(0, pageSize)`
+* `TaskQuery#orderByTaskCreateTime().desc().listPage(0, pageSize)`
+* `TaskQuery#count()`
+
+Run it with the `task-auth-benchmark` profile and one database profile. The benchmark writes a CSV file and prints the measured average, p50, p95,
+and max values.
+
+```Shell
+mvn -f qa/performance-tests-engine/pom.xml \
+    -Ptask-auth-benchmark,h2 \
+    -Dbenchmark.branch="$(git rev-parse --abbrev-ref HEAD)" \
+    -Dbenchmark.commit="$(git rev-parse --short HEAD)" \
+    -Dbenchmark.database=h2 \
+    -Dbenchmark.tasks=5000 \
+    -Dbenchmark.groups=10 \
+    -Dbenchmark.pageSize=15 \
+    -Dbenchmark.warmup=50 \
+    -Dbenchmark.iterations=300 \
+    -Dbenchmark.outputFile=target/task-authorization-exists-benchmark.csv \
+    process-test-classes
+```
+
+For a managed PostgreSQL test database container, start the database and use the `mt-postgres` database profile:
+
+```Shell
+docker compose -f qa/test-database-container/docker-compose.yaml up -d postgres
+
+MT_POSTGRES_USERNAME=root \
+MT_POSTGRES_PASSWORD=123456 \
+MT_POSTGRES_HOST_PORT=54320 \
+MT_POSTGRES_DATABASE=operaton \
+mvn -f qa/performance-tests-engine/pom.xml \
+    -Ptask-auth-benchmark,mt-postgres \
+    -Dbenchmark.branch="$(git rev-parse --abbrev-ref HEAD)" \
+    -Dbenchmark.commit="$(git rev-parse --short HEAD)" \
+    -Dbenchmark.database=postgres \
+    -Dbenchmark.tasks=5000 \
+    -Dbenchmark.groups=10 \
+    -Dbenchmark.pageSize=15 \
+    -Dbenchmark.warmup=50 \
+    -Dbenchmark.iterations=300 \
+    -Dbenchmark.outputFile=target/task-authorization-exists-benchmark-postgres.csv \
+    process-test-classes
+```
+
+Use `mt-mysql` or `mt-mariadb` with the corresponding `MT_MYSQL_*` or `MT_MARIADB_*` environment variables for MySQL and MariaDB.
+The benchmark expects an otherwise empty task table; use a fresh database or remove unrelated task data for comparable results.
+By default, benchmark data created by the run is removed afterwards. Set `-Dbenchmark.cleanup=false` if the generated data should stay in the database for inspection.
 
 <a name="sql-statement-log"></a>
 ## The Sql Statement Log

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -322,6 +322,78 @@
       </build>
     </profile>
     <profile>
+      <id>task-auth-benchmark</id>
+      <properties>
+        <numberOfThreads>1</numberOfThreads>
+        <numberOfRuns>1</numberOfRuns>
+        <loadGenerator.numberOfIterations>0</loadGenerator.numberOfIterations>
+        <loadGenerator.colorOutput>false</loadGenerator.colorOutput>
+        <testWatchers/>
+        <processEnginePlugins/>
+        <watchActivities/>
+        <skip.tests>true</skip.tests>
+        <benchmark.branch>unknown</benchmark.branch>
+        <benchmark.commit>unknown</benchmark.commit>
+        <benchmark.database>unknown</benchmark.database>
+        <benchmark.tasks>5000</benchmark.tasks>
+        <benchmark.groups>10</benchmark.groups>
+        <benchmark.pageSize>15</benchmark.pageSize>
+        <benchmark.warmup>30</benchmark.warmup>
+        <benchmark.iterations>200</benchmark.iterations>
+        <benchmark.outputFile>${project.build.directory}/task-authorization-exists-benchmark.csv</benchmark.outputFile>
+        <benchmark.cleanup>true</benchmark.cleanup>
+      </properties>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/test/resources</directory>
+            <filtering>true</filtering>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>task-auth-benchmark</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo message="Running task authorization EXISTS benchmark"/>
+                    <java classname="org.operaton.bpm.qa.performance.engine.query.TaskAuthorizationExistsBenchmark"
+                          classpathref="maven.test.classpath"
+                          fork="true"
+                          failonerror="true">
+                      <sysproperty key="benchmark.branch" value="${benchmark.branch}"/>
+                      <sysproperty key="benchmark.commit" value="${benchmark.commit}"/>
+                      <sysproperty key="benchmark.database" value="${benchmark.database}"/>
+                      <sysproperty key="benchmark.tasks" value="${benchmark.tasks}"/>
+                      <sysproperty key="benchmark.groups" value="${benchmark.groups}"/>
+                      <sysproperty key="benchmark.pageSize" value="${benchmark.pageSize}"/>
+                      <sysproperty key="benchmark.warmup" value="${benchmark.warmup}"/>
+                      <sysproperty key="benchmark.iterations" value="${benchmark.iterations}"/>
+                      <sysproperty key="benchmark.outputFile" value="${benchmark.outputFile}"/>
+                      <sysproperty key="benchmark.cleanup" value="${benchmark.cleanup}"/>
+                    </java>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>${skip.tests}</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>query-perf-test</id>
       <properties>
         <numberOfThreads>1</numberOfThreads>

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/query/TaskAuthorizationExistsBenchmark.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/query/TaskAuthorizationExistsBenchmark.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.qa.performance.engine.query;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.LongSupplier;
+
+import org.operaton.bpm.engine.AuthorizationService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.authorization.Authorization;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.identity.Authentication;
+import org.operaton.bpm.engine.repository.Deployment;
+import org.operaton.bpm.model.bpmn.Bpmn;
+import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+import org.operaton.bpm.qa.performance.engine.junit.PerfTestProcessEngine;
+
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Resources.TASK;
+
+public class TaskAuthorizationExistsBenchmark {
+
+  protected static final String DEPLOYMENT_NAME = "task-authorization-exists-benchmark";
+  protected static final String PROCESS_KEY = "taskAuthorizationExistsBenchmark";
+  protected static final String USER_ID = "task-auth-benchmark-user";
+  protected static final String CSV_HEADER = String.join(",",
+      "timestamp",
+      "branch",
+      "commit",
+      "database",
+      "tasks",
+      "groups",
+      "matchingAuthorizations",
+      "pageSize",
+      "warmupIterations",
+      "iterations",
+      "visibleTasks",
+      "operation",
+      "totalMs",
+      "avgMs",
+      "minMs",
+      "p50Ms",
+      "p95Ms",
+      "maxMs",
+      "observedSum");
+
+  public static void main(String[] args) throws Exception {
+    new TaskAuthorizationExistsBenchmark().run(BenchmarkOptions.fromSystemProperties());
+  }
+
+  public void run(BenchmarkOptions options) throws Exception {
+    ProcessEngine engine = PerfTestProcessEngine.getInstance();
+
+    try {
+      ProcessEngineConfigurationImpl configuration =
+          (ProcessEngineConfigurationImpl) engine.getProcessEngineConfiguration();
+      configuration.setAuthorizationEnabled(false);
+
+      cleanupBenchmarkData(engine, options);
+      assertNoExistingTasks(engine);
+
+      String deploymentId = setupData(engine, options);
+      List<String> authorizationIds = createAuthorizations(engine.getAuthorizationService(), options);
+
+      try {
+        configuration.setAuthorizationEnabled(true);
+        List<String> groupIds = groupIds(options.groupCount);
+        engine.getIdentityService().setAuthentication(new Authentication(USER_ID, groupIds));
+
+        try {
+          long visibleTasks = engine.getTaskService().createTaskQuery().count();
+          if (visibleTasks != options.taskCount) {
+            throw new IllegalStateException("Expected " + options.taskCount
+                + " visible tasks but got " + visibleTasks);
+          }
+
+          warmup(engine.getTaskService(), options);
+
+          List<Measurement> measurements = List.of(
+              measure("listPage", options.iterations, () -> engine.getTaskService().createTaskQuery().listPage(0, options.pageSize).size()),
+              measure("listPageOrderedByCreateTimeDesc", options.iterations, () -> engine.getTaskService().createTaskQuery()
+                  .orderByTaskCreateTime()
+                  .desc()
+                  .listPage(0, options.pageSize)
+                  .size()),
+              measure("count", options.iterations, () -> engine.getTaskService().createTaskQuery().count())
+          );
+
+          writeMeasurements(options, measurements, visibleTasks);
+        } finally {
+          engine.getIdentityService().clearAuthentication();
+        }
+      } finally {
+        if (options.cleanupAfterRun) {
+          configuration.setAuthorizationEnabled(false);
+          cleanupAuthorizations(engine.getAuthorizationService(), authorizationIds);
+          engine.getRepositoryService().deleteDeployment(deploymentId, true);
+        }
+      }
+    } finally {
+      engine.close();
+    }
+  }
+
+  protected static String setupData(ProcessEngine engine, BenchmarkOptions options) {
+    RepositoryService repositoryService = engine.getRepositoryService();
+    RuntimeService runtimeService = engine.getRuntimeService();
+
+    BpmnModelInstance process = Bpmn.createExecutableProcess(PROCESS_KEY)
+        .operatonHistoryTimeToLive(180)
+        .startEvent()
+        .userTask("wait")
+        .name("Benchmark task")
+        .endEvent()
+        .done();
+
+    String deploymentId = repositoryService.createDeployment()
+        .name(DEPLOYMENT_NAME)
+        .addModelInstance("task-authorization-exists-benchmark.bpmn", process)
+        .deploy()
+        .getId();
+
+    for (int i = 0; i < options.taskCount; i++) {
+      runtimeService.startProcessInstanceByKey(PROCESS_KEY);
+    }
+
+    return deploymentId;
+  }
+
+  protected static List<String> createAuthorizations(AuthorizationService authorizationService, BenchmarkOptions options) {
+    List<String> authorizationIds = new ArrayList<>();
+    authorizationIds.add(grantUser(authorizationService, USER_ID, ANY));
+    authorizationIds.add(grantUser(authorizationService, ANY, ANY));
+
+    for (String groupId : groupIds(options.groupCount)) {
+      authorizationIds.add(grantGroup(authorizationService, groupId, ANY));
+      authorizationIds.add(grantGroup(authorizationService, groupId, PROCESS_KEY));
+    }
+    return authorizationIds;
+  }
+
+  protected static void cleanupBenchmarkData(ProcessEngine engine, BenchmarkOptions options) {
+    RepositoryService repositoryService = engine.getRepositoryService();
+    List<Deployment> deployments = repositoryService.createDeploymentQuery().deploymentName(DEPLOYMENT_NAME).list();
+    for (Deployment deployment : deployments) {
+      repositoryService.deleteDeployment(deployment.getId(), true);
+    }
+
+    AuthorizationService authorizationService = engine.getAuthorizationService();
+    for (Authorization authorization : authorizationService.createAuthorizationQuery().userIdIn(USER_ID).list()) {
+      authorizationService.deleteAuthorization(authorization.getId());
+    }
+
+    String[] groupIds = groupIds(options.groupCount).toArray(String[]::new);
+    for (Authorization authorization : authorizationService.createAuthorizationQuery().groupIdIn(groupIds).list()) {
+      authorizationService.deleteAuthorization(authorization.getId());
+    }
+  }
+
+  protected static void cleanupAuthorizations(AuthorizationService authorizationService, List<String> authorizationIds) {
+    for (String authorizationId : authorizationIds) {
+      authorizationService.deleteAuthorization(authorizationId);
+    }
+  }
+
+  protected static void assertNoExistingTasks(ProcessEngine engine) {
+    long existingTasks = engine.getTaskService().createTaskQuery().count();
+    if (existingTasks > 0) {
+      throw new IllegalStateException("Task authorization benchmark expects an empty task table, but found "
+          + existingTasks + " existing tasks. Use a fresh database or remove unrelated task data before running it.");
+    }
+  }
+
+  protected static List<String> groupIds(int groupCount) {
+    List<String> groupIds = new ArrayList<>(groupCount);
+    for (int i = 0; i < groupCount; i++) {
+      groupIds.add("task-auth-benchmark-group-" + i);
+    }
+    return groupIds;
+  }
+
+  protected static String grantUser(AuthorizationService authorizationService, String userId, String resourceId) {
+    Authorization authorization = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    authorization.setResource(TASK);
+    authorization.setResourceId(resourceId);
+    authorization.addPermission(READ);
+    authorization.setUserId(userId);
+    authorizationService.saveAuthorization(authorization);
+    return authorization.getId();
+  }
+
+  protected static String grantGroup(AuthorizationService authorizationService, String groupId, String resourceId) {
+    Authorization authorization = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    authorization.setResource(TASK);
+    authorization.setResourceId(resourceId);
+    authorization.addPermission(READ);
+    authorization.setGroupId(groupId);
+    authorizationService.saveAuthorization(authorization);
+    return authorization.getId();
+  }
+
+  protected static void warmup(TaskService taskService, BenchmarkOptions options) {
+    for (int i = 0; i < options.warmupIterations; i++) {
+      taskService.createTaskQuery().listPage(0, options.pageSize);
+      taskService.createTaskQuery().orderByTaskCreateTime().desc().listPage(0, options.pageSize);
+      taskService.createTaskQuery().count();
+    }
+  }
+
+  protected static Measurement measure(String operation, int iterations, LongSupplier supplier) {
+    long[] durations = new long[iterations];
+    long observed = 0;
+    for (int i = 0; i < iterations; i++) {
+      long start = System.nanoTime();
+      observed += supplier.getAsLong();
+      durations[i] = System.nanoTime() - start;
+    }
+    return new Measurement(operation, durations, observed);
+  }
+
+  protected static void writeMeasurements(BenchmarkOptions options, List<Measurement> measurements, long visibleTasks)
+      throws IOException {
+    Path outputFile = Path.of(options.outputFile);
+    Path parent = outputFile.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+
+    boolean writeHeader = !Files.exists(outputFile);
+    List<String> lines = new ArrayList<>();
+    if (writeHeader) {
+      lines.add(CSV_HEADER);
+    }
+
+    for (Measurement measurement : measurements) {
+      lines.add(measurement.toCsv(options, visibleTasks));
+      System.out.println(measurement.toConsoleLine(options));
+    }
+
+    if (Files.exists(outputFile)) {
+      Files.write(outputFile, lines, StandardCharsets.UTF_8,
+          java.nio.file.StandardOpenOption.WRITE,
+          java.nio.file.StandardOpenOption.APPEND);
+    } else {
+      Files.write(outputFile, lines, StandardCharsets.UTF_8,
+          java.nio.file.StandardOpenOption.WRITE,
+          java.nio.file.StandardOpenOption.CREATE_NEW);
+    }
+  }
+
+  protected record BenchmarkOptions(String branch, String commit, String database, int taskCount, int groupCount,
+                                    int pageSize, int warmupIterations, int iterations, String outputFile,
+                                    boolean cleanupAfterRun) {
+
+    static BenchmarkOptions fromSystemProperties() {
+      return new BenchmarkOptions(
+          property("benchmark.branch", "unknown"),
+          property("benchmark.commit", "unknown"),
+          property("benchmark.database", "unknown"),
+          intProperty("benchmark.tasks", 5000),
+          intProperty("benchmark.groups", 10),
+          intProperty("benchmark.pageSize", 15),
+          intProperty("benchmark.warmup", 30),
+          intProperty("benchmark.iterations", 200),
+          property("benchmark.outputFile", "target/task-authorization-exists-benchmark.csv"),
+          booleanProperty("benchmark.cleanup", true));
+    }
+
+    int matchingAuthorizations() {
+      return 2 + groupCount * 2;
+    }
+
+    static String property(String name, String defaultValue) {
+      String value = System.getProperty(name);
+      return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    static int intProperty(String name, int defaultValue) {
+      String value = System.getProperty(name);
+      return value == null || value.isBlank() ? defaultValue : Integer.parseInt(value);
+    }
+
+    static boolean booleanProperty(String name, boolean defaultValue) {
+      String value = System.getProperty(name);
+      return value == null || value.isBlank() ? defaultValue : Boolean.parseBoolean(value);
+    }
+  }
+
+  protected record Measurement(String operation, long[] durationsNanos, long observedSum) {
+
+    String toCsv(BenchmarkOptions options, long visibleTasks) {
+      long[] sorted = sortedDurations();
+      return String.join(",",
+          Instant.now().toString(),
+          options.branch,
+          options.commit,
+          options.database,
+          Integer.toString(options.taskCount),
+          Integer.toString(options.groupCount),
+          Integer.toString(options.matchingAuthorizations()),
+          Integer.toString(options.pageSize),
+          Integer.toString(options.warmupIterations),
+          Integer.toString(options.iterations),
+          Long.toString(visibleTasks),
+          operation,
+          formatMs(totalNanos()),
+          formatMs(totalNanos() / (double) durationsNanos.length),
+          formatMs(sorted[0]),
+          formatMs(percentile(sorted, 0.50)),
+          formatMs(percentile(sorted, 0.95)),
+          formatMs(sorted[sorted.length - 1]),
+          Long.toString(observedSum));
+    }
+
+    String toConsoleLine(BenchmarkOptions options) {
+      long[] sorted = sortedDurations();
+      return "%s %s %s: avg=%sms p50=%sms p95=%sms max=%sms".formatted(
+          options.branch,
+          options.database,
+          operation,
+          formatMs(totalNanos() / (double) durationsNanos.length),
+          formatMs(percentile(sorted, 0.50)),
+          formatMs(percentile(sorted, 0.95)),
+          formatMs(sorted[sorted.length - 1]));
+    }
+
+    long totalNanos() {
+      long total = 0;
+      for (long duration : durationsNanos) {
+        total += duration;
+      }
+      return total;
+    }
+
+    long[] sortedDurations() {
+      long[] sorted = Arrays.copyOf(durationsNanos, durationsNanos.length);
+      Arrays.sort(sorted);
+      return sorted;
+    }
+
+    static long percentile(long[] sorted, double percentile) {
+      int index = (int) Math.ceil(percentile * sorted.length) - 1;
+      return sorted[Math.max(0, Math.min(index, sorted.length - 1))];
+    }
+
+    static String formatMs(long nanos) {
+      return formatMs((double) nanos);
+    }
+
+    static String formatMs(double nanos) {
+      return String.format(Locale.ROOT, "%.3f", nanos / 1_000_000D);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone `TaskAuthorizationExistsBenchmark` entry point for task authorization query timings
- add a `task-auth-benchmark` Maven profile to run it without JUnit
- document H2/PostgreSQL usage and benchmark properties in the performance test README

## Verification
- `./mvnw -f qa/performance-tests-engine/pom.xml -Ptask-auth-benchmark,h2 -Dskip.frontend.build=true -Dbenchmark.tasks=20 -Dbenchmark.groups=2 -Dbenchmark.warmup=2 -Dbenchmark.iterations=3 -Dbenchmark.branch=standalone-smoke -Dbenchmark.database=h2 process-test-classes`
- `git diff --check`