### PR TITLE
fix(engine): Suppress java:S5738 for still-required deprecated-API usage

### DIFF
--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/CdiResolver.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/CdiResolver.java
@@ -47,11 +47,13 @@ public class CdiResolver extends ELResolver {
     }
   }
 
+  @SuppressWarnings("removal")
   protected ELResolver getWrappedResolver() {
     BeanManager beanManager = getBeanManager();
     if (beanManager == null) {
       return null;
     }
+    // Removal in favor of ELAwareBeanManager, which does not yet exist in the released cdi-api.
     return beanManager.getELResolver();
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/execution/CmmnExecution.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/execution/CmmnExecution.java
@@ -331,6 +331,7 @@ public abstract class CmmnExecution extends CoreExecution implements CmmnCaseIns
 
   }
 
+  @SuppressWarnings("removal")
   protected List<String> collectAffectedSentries(CmmnExecution child, String transition) {
     List<? extends CmmnSentryPart> sentryParts = getCaseSentryParts();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/CommentEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/CommentEntity.java
@@ -38,7 +38,7 @@ import org.operaton.bpm.engine.task.Event;
  * {@code TaskService#getTaskEvents} (backed by {@code GetTaskEventsCmd}), for as long
  * as that deprecated API still exists.
  */
-@SuppressWarnings("java:S5738")
+@SuppressWarnings("removal")
 public class CommentEntity implements Comment, Event, HasDbRevision, DbEntity, HistoricEntity {
 
   public static final String TYPE_EVENT = "event";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/CommentEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/CommentEntity.java
@@ -33,7 +33,12 @@ import org.operaton.bpm.engine.task.Event;
 
 /**
  * @author Tom Baeyens
+ *
+ * Implements the deprecated {@link Event} interface only to remain compatible with
+ * {@code TaskService#getTaskEvents} (backed by {@code GetTaskEventsCmd}), for as long
+ * as that deprecated API still exists.
  */
+@SuppressWarnings("java:S5738")
 public class CommentEntity implements Comment, Event, HasDbRevision, DbEntity, HistoricEntity {
 
   public static final String TYPE_EVENT = "event";


### PR DESCRIPTION
Hi,

My first contribution. Please let me know if I'm doing anything wrong.

Three call sites use APIs that have been deprecated with forRemoval=true but are not replaceable yet, therefore the Sonar finding is suppressed instead of being worked around:

- CdiResolver#getWrappedResolver uses BeanManager#getELResolver which is not replaceable at the moment because ELAwareBeanManager from the CDI specification itself is not included in any version of jakarta.enterprise.cdi-api.
- CmmnExecution#collectAffectedSentries uses the deprecated CmmnSentryPart#getSourceCaseExecutionId because the field may actually contain information about sentry parts that were persisted prior to removing this API from the model.
- CommentEntity uses the deprecated Event interface just to remain compatible with TaskService#getTaskEvents (GetTaskEventsCmd).