### PR TITLE
fix(sonar): merge multiple @AfterEach methods into one

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionAuthorizationTest.java
@@ -137,10 +137,7 @@ public class BatchHistoricDecisionInstanceDeletionAuthorizationTest {
   @AfterEach
   void tearDown() {
     authRule.deleteUsersAndGroups();
-  }
 
-  @AfterEach
-  void removeBatches() {
     for (Batch batch : managementService.createBatchQuery().list()) {
       managementService.deleteBatch(batch.getId(), true);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionUserOperationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionUserOperationTest.java
@@ -96,10 +96,7 @@ public class BatchHistoricDecisionInstanceDeletionUserOperationTest {
     for (HistoricBatch historicBatch : historyService.createHistoricBatchQuery().list()) {
       historyService.deleteHistoricBatch(historicBatch.getId());
     }
-  }
 
-  @AfterEach
-  void clearAuthentication() {
     identityService.clearAuthentication();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationAuthorizationTest.java
@@ -104,10 +104,7 @@ public class BatchModificationAuthorizationTest {
   @AfterEach
   void tearDown() {
     authRule.deleteUsersAndGroups();
-  }
 
-  @AfterEach
-  void cleanBatch() {
     Batch batch = engineRule.getManagementService().createBatchQuery().singleResult();
     if (batch != null) {
       engineRule.getManagementService().deleteBatch(
@@ -119,10 +116,7 @@ public class BatchModificationAuthorizationTest {
       engineRule.getHistoryService().deleteHistoricBatch(
           historicBatch.getId());
     }
-  }
 
-  @AfterEach
-  void removeBatches() {
     helper.removeAllRunningAndHistoricBatches();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchRestartAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchRestartAuthorizationTest.java
@@ -111,10 +111,7 @@ public class BatchRestartAuthorizationTest {
   @AfterEach
   void tearDown() {
     authRule.deleteUsersAndGroups();
-  }
 
-  @AfterEach
-  void cleanBatch() {
     Batch batch = engineRule.getManagementService().createBatchQuery().singleResult();
     if (batch != null) {
       engineRule.getManagementService().deleteBatch(
@@ -126,10 +123,7 @@ public class BatchRestartAuthorizationTest {
       engineRule.getHistoryService().deleteHistoricBatch(
           historicBatch.getId());
     }
-  }
 
-  @AfterEach
-  void removeBatches() {
     helper.removeAllRunningAndHistoricBatches();
   }
 


### PR DESCRIPTION
Hi! 

I have found that Sonar rule java:S8745 complains about classes having multiple @AfterEach annotations. All cleanup actions should be merged in a single @AfterEach annotation while keeping the initial order of execution.
