### PR TITLE
[DRAFT] Parallelize engine tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
       checks: write

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -11,12 +11,14 @@
   <name>Operaton - Engine - Spring</name>
   <description>${project.name}</description>
   <properties>
-    <!-- Run tests across multiple concurrent JVM forks (0.7 * available CPU cores).
+    <!-- Run tests across multiple concurrent JVM forks (0.5 * available CPU cores).
          Safe here because every test's Spring context XML now has its own unique H2
          in-memory database name (previously many shared "jdbc:h2:mem:activiti" /
          "jdbc:h2:mem:operaton", a latent collision risk once tests run close together
-         in wall-clock time under forking). -->
-    <surefire.forkCount>0.7C</surefire.forkCount>
+         in wall-clock time under forking). 0.5C chosen empirically - see engine/pom.xml
+         for the fork-count tuning data (0.5C measured faster than 0.7C/1C/1.5C there;
+         the same pattern held here: 0.5C measurably faster than 0.7C). -->
+    <surefire.forkCount>0.5C</surefire.forkCount>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -10,6 +10,14 @@
   <artifactId>operaton-engine-spring</artifactId>
   <name>Operaton - Engine - Spring</name>
   <description>${project.name}</description>
+  <properties>
+    <!-- Run tests across multiple concurrent JVM forks (0.7 * available CPU cores).
+         Safe here because every test's Spring context XML now has its own unique H2
+         in-memory database name (previously many shared "jdbc:h2:mem:activiti" /
+         "jdbc:h2:mem:operaton", a latent collision risk once tests run close together
+         in wall-clock time under forking). -->
+    <surefire.forkCount>0.7C</surefire.forkCount>
+  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/engine-spring/src/test/resources/activiti-context.xml
+++ b/engine-spring/src/test/resources/activiti-context.xml
@@ -7,7 +7,7 @@
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration"
         init-method="init">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=-1" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:activitiContextProcessName;DB_CLOSE_DELAY=-1" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine-spring/src/test/resources/operaton.cfg.xml
+++ b/engine-spring/src/test/resources/operaton.cfg.xml
@@ -8,7 +8,7 @@
   
     <property name="processEngineName" value="operatonDefault" />
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=-1" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:operatonDefault;DB_CLOSE_DELAY=-1" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/application/PostDeployRegistrationPaTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/application/PostDeployRegistrationPaTest-context.xml
@@ -8,7 +8,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:PostDeployRegistrationPaTest;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/application/PostDeployWithNestedContext-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/application/PostDeployWithNestedContext-context.xml
@@ -8,7 +8,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:PostDeployWithNestedContext;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/application/SpringProcessArchiveDeploymentTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/application/SpringProcessArchiveDeploymentTest-context.xml
@@ -9,7 +9,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:SpringProcessArchiveDeploymentTest;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployCmmnBpmnTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployCmmnBpmnTest-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployCmmnBpmnTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployCmmnTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployCmmnTest-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployCmmnTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployCustomNameTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployCustomNameTest-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployCustomNameTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployDeployChangeOnlyTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployDeployChangeOnlyTest-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployDeployChangeOnlyTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployTenantIdTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployTenantIdTest-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployTenantIdTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployTest-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployTestDefault;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployTest-dynamic-deployment-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/autodeployment/SpringAutoDeployTest-dynamic-deployment-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringAutoDeployTestdynamicdeployment;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/ProcessStartingBeanPostProcessorTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/ProcessStartingBeanPostProcessorTest-context.xml
@@ -15,7 +15,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:ProcessStartingBeanPostProcessorTest;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/ScopingTests-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/ScopingTests-context.xml
@@ -25,7 +25,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:ScopingTests;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/SpringjobExecutorTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/SpringjobExecutorTest-context.xml
@@ -13,7 +13,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:SpringjobExecutorTest;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/StateHandlerTests-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/components/StateHandlerTests-context.xml
@@ -14,7 +14,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:StateHandlerTests;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/container/ManagedProcessEngineFactoryBean-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/container/ManagedProcessEngineFactoryBean-context.xml
@@ -9,7 +9,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1"/>
+                <property name="url" value="jdbc:h2:mem:ManagedProcessEngineFactoryBean;DB_CLOSE_DELAY=-1"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/dmn/DmnJuelTest-applicationContext.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/dmn/DmnJuelTest-applicationContext.xml
@@ -12,7 +12,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:DmnJuelTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/expression/callactivity/testCallActivityByExpression-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/expression/callactivity/testCallActivityByExpression-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:testCallActivityByExpression;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/expression/expressionLimitedBeans-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/expression/expressionLimitedBeans-context.xml
@@ -10,7 +10,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:expressionLimitedBeans;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/junit5/springTypicalUsageTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/junit5/springTypicalUsageTest-context.xml
@@ -8,7 +8,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:springTypicalUsageTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/scripttask/ScriptTaskLimitedBeansTest-applicationContext.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/scripttask/ScriptTaskLimitedBeansTest-applicationContext.xml
@@ -13,7 +13,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:ScriptTaskLimitedBeansTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/scripttask/ScriptTaskNoBeansTest-applicationContext.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/scripttask/ScriptTaskNoBeansTest-applicationContext.xml
@@ -12,7 +12,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:ScriptTaskNoBeansTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/scripttask/ScriptTaskTest-applicationContext.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/scripttask/ScriptTaskTest-applicationContext.xml
@@ -12,7 +12,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:ScriptTaskTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/servicetask/servicetaskSpringTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/servicetask/servicetaskSpringTest-context.xml
@@ -24,7 +24,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:servicetaskSpringTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/servicetask/servicetaskSpringTestCatchError-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/servicetask/servicetaskSpringTestCatchError-context.xml
@@ -6,7 +6,7 @@
 	<bean id="dataSource"
 		class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
 		<property name="driverClass" value="org.h2.Driver" />
-		<property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+		<property name="url" value="jdbc:h2:mem:servicetaskSpringTestCatchError;DB_CLOSE_DELAY=-1" />
 		<property name="username" value="sa" />
 		<property name="password" value="" />
 	</bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/taskListener/TaskListenerDelegateExpressionTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/taskListener/TaskListenerDelegateExpressionTest-context.xml
@@ -12,7 +12,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:TaskListenerDelegateExpressionTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/taskassignment/taskassignment-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/taskassignment/taskassignment-context.xml
@@ -12,7 +12,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:taskassignment;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest-applicationContext.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest-applicationContext.xml
@@ -12,7 +12,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringInnerTransactionRollbackTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationDeleteDeploymentFailTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationDeleteDeploymentFailTest-context.xml
@@ -6,7 +6,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringTransactionIntegrationDeleteDeploymentFailTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationDeploymentFailTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationDeploymentFailTest-context.xml
@@ -6,7 +6,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringTransactionIntegrationDeploymentFailTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest-context.xml
+++ b/engine-spring/src/test/resources/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest-context.xml
@@ -8,7 +8,7 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver" />
-    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="url" value="jdbc:h2:mem:SpringTransactionIntegrationTest;DB_CLOSE_DELAY=-1" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -18,6 +18,11 @@
     <!-- without a special test profile we don't want to exclude anything, this expressions should never match -->
     <test.excludes>$.</test.excludes>
     <skipTests.operaton-engine>false</skipTests.operaton-engine>
+    <!-- Run tests across multiple concurrent JVM forks (0.7 * available CPU cores).
+         Each fork stays single-threaded internally (execution order is unaffected);
+         only fork count changes. Safe because the h2-in-memory profile already
+         isolates each fork's H2 database via ${surefire.forkNumber} in the JDBC URL. -->
+    <surefire.forkCount>0.7C</surefire.forkCount>
     <history.level>full</history.level>
     <mail.server.port>5025</mail.server.port>
     <authorizationCheckRevokes>auto</authorizationCheckRevokes>
@@ -470,6 +475,55 @@
             <dependency>org.operaton.bpm:operaton-bpm-archunit</dependency>
           </dependenciesToScan>
         </configuration>
+        <executions>
+          <!-- With forkCount > 1, Surefire's JUnit Platform provider can dispatch a
+               @Nested class to a different JVM fork than its enclosing class, running
+               it twice (once as part of the enclosing class's own cascade, once
+               standalone in the other fork) - this happens regardless of the
+               include/exclude file patterns above, since it's how Surefire's JUnit5
+               test-plan-based fork distribution works, not a file-scan artifact.
+               Excluding nested classes from the scan doesn't prevent it either (tried
+               that - it broke discovery of classes whose only tests live in @Nested
+               children, e.g. JobExecutorTestCase, since Surefire's own "does this class
+               have tests" pre-filter also consults that same scan). All 3 classes in
+               this module using @Nested (ProcessEngineExtensionEngineRetentionTest,
+               JobExecutorTestCase, SchemaLogTest) are tagged @Tag("sequential") and run
+               here, single-forked, instead.
+
+               Also here: the org.operaton.bpm.engine.test.concurrency package, which
+               hand-orchestrates real background threads with blocking wait()/notify()
+               and no timeout to deterministically reproduce race conditions. Under
+               forkCount > 1, CPU contention across the concurrent forks can delay
+               thread scheduling enough to break that timing choreography and hang a
+               test indefinitely (observed once: CompetingHistoryCleanupAcquisitionTest
+               deadlocked between the main thread and its JobExecutor's acquisition
+               thread, both waiting on ThreadControl.waitForSync()/sync()). Tagged via
+               the package's shared base classes (ConcurrencyTestHelper,
+               AbstractCompetingTransactionsOptimisticLockingTest - @Tag is inherited
+               through the class hierarchy) plus the handful of classes with no shared
+               base. -->
+          <execution>
+            <id>default-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>sequential</excludedGroups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>sequential-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <forkCount>1</forkCount>
+              <groups>sequential</groups>
+            </configuration>
+          </execution>
+        </executions>
         </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -18,11 +18,16 @@
     <!-- without a special test profile we don't want to exclude anything, this expressions should never match -->
     <test.excludes>$.</test.excludes>
     <skipTests.operaton-engine>false</skipTests.operaton-engine>
-    <!-- Run tests across multiple concurrent JVM forks (0.7 * available CPU cores).
+    <!-- Run tests across multiple concurrent JVM forks (0.5 * available CPU cores).
          Each fork stays single-threaded internally (execution order is unaffected);
          only fork count changes. Safe because the h2-in-memory profile already
-         isolates each fork's H2 database via ${surefire.forkNumber} in the JDBC URL. -->
-    <surefire.forkCount>0.7C</surefire.forkCount>
+         isolates each fork's H2 database via ${surefire.forkNumber} in the JDBC URL.
+         0.5C was chosen empirically over higher multipliers: on a 10-core machine,
+         0.5C (5 forks) measured faster than 0.7C (7 forks), which was faster than 1C
+         (10 forks), which was faster than 1.5C (15 forks) - beyond a certain fork
+         count, oversubscription (JVM startup/classloading cost per fork, GC/memory
+         pressure) outweighs the added parallelism. -->
+    <surefire.forkCount>0.5C</surefire.forkCount>
     <history.level>full</history.level>
     <mail.server.port>5025</mail.server.port>
     <authorizationCheckRevokes>auto</authorizationCheckRevokes>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/FallbackSerializerFactoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/FallbackSerializerFactoryTest.java
@@ -59,8 +59,8 @@ class FallbackSerializerFactoryTest {
     // given
     // that the process engine is configured with a fallback serializer factory
      ProcessEngineConfigurationImpl engineConfiguration = new StandaloneInMemProcessEngineConfiguration()
-       .setJdbcUrl("jdbc:h2:mem:operaton-forceclose")
-       .setProcessEngineName("engine-forceclose");
+       .setJdbcUrl("jdbc:h2:mem:operaton-fallbackserializer")
+       .setProcessEngineName("engine-fallbackserializer");
 
      engineConfiguration.setFallbackSerializerFactory(new ExampleSerializerFactory());
 
@@ -87,8 +87,8 @@ class FallbackSerializerFactoryTest {
     // that the process engine is configured with a serializer for a certain format
     // and a fallback serializer factory for the same format
      ProcessEngineConfigurationImpl engineConfiguration = new StandaloneInMemProcessEngineConfiguration()
-       .setJdbcUrl("jdbc:h2:mem:operaton-forceclose")
-       .setProcessEngineName("engine-forceclose");
+       .setJdbcUrl("jdbc:h2:mem:operaton-fallbackserializer")
+       .setProcessEngineName("engine-fallbackserializer");
 
      engineConfiguration.setCustomPreVariableSerializers(List.of(new ExampleConstantSerializer()));
      engineConfiguration.setFallbackSerializerFactory(new ExampleSerializerFactory());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -44,6 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * entities that have already been removed in a concurrent transaction lead to
  * {@link OptimisticLockingException}s.
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml. Tag inherited by subclasses.
+@Tag("sequential")
 public abstract class AbstractCompetingTransactionsOptimisticLockingTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CancelAcquiredJobTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CancelAcquiredJobTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -36,6 +37,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * @author Daniel Meyer
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CancelAcquiredJobTest {
 
   @RegisterExtension

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingActivityInstanceCancellationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingActivityInstanceCancellationTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -38,6 +39,10 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Roman Smirnov
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingActivityInstanceCancellationTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskFetchingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskFetchingTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
 import org.operaton.bpm.engine.RuntimeService;
@@ -42,6 +43,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Thorben Lindhauer
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingExternalTaskFetchingTest {
 
   @RegisterExtension

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingForkTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingForkTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -38,6 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Roman Smirnov
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingForkTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJobAcquisitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJobAcquisitionTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -53,6 +54,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Tom Baeyens
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingJobAcquisitionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJoinTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJoinTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -38,6 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Tom Baeyens
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingJoinTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.CaseService;
@@ -40,6 +41,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Roman Smirnov
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingParentCompletionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingProcessCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingProcessCompletionTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -40,6 +41,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Tom Baeyens
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingProcessCompletionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.test.concurrency;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
@@ -39,6 +40,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Roman Smirnov
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingSentrySatisfactionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSignalsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSignalsTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -37,6 +38,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Tom Baeyens
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingSignalsTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSubprocessCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSubprocessCompletionTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -40,6 +41,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Tom Baeyens
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingSubprocessCompletionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSuspensionTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -41,6 +42,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Thorben Lindhauer
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class CompetingSuspensionTest {
 
   protected static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestHelper.java
@@ -118,8 +118,12 @@ public abstract class ConcurrencyTestHelper {
       this.executingThread = executingThread;
     }
 
+    // Bounded so a broken sync choreography fails the test instead of blocking
+    // the fork forever
+    public static final long DEFAULT_SYNC_TIMEOUT_MILLIS = 5 * 60 * 1000L;
+
     public void waitForSync() {
-      waitForSync(Long.MAX_VALUE);
+      waitForSync(DEFAULT_SYNC_TIMEOUT_MILLIS);
     }
 
     public void waitForSync(long timeout) {
@@ -132,13 +136,19 @@ public abstract class ConcurrencyTestHelper {
           }
         }
         try {
-          if (!syncAvailable) {
+          long deadline = System.currentTimeMillis() + timeout;
+          while (!syncAvailable) {
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0) {
+              fail("timed out after " + timeout + " ms waiting for sync");
+            }
             try {
-              wait(timeout);
+              wait(remaining);
             } catch (InterruptedException e) {
               if (!reportFailure || exception == null) {
                 fail("unexpected interruption");
               }
+              return;
             }
           }
         } finally {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestHelper.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -28,6 +29,13 @@ import org.operaton.bpm.engine.impl.util.ExceptionUtil;
 
 import static org.assertj.core.api.Assertions.fail;
 
+// Tagged "sequential": these tests hand-orchestrate real background threads with
+// blocking wait()/notify() and no timeout, to deterministically reproduce race
+// conditions. Under forkCount > 1 (this module runs multiple concurrent JVMs), CPU
+// contention across forks can delay thread scheduling enough to break these tests'
+// timing assumptions and hang them indefinitely - see the surefire-plugin config in
+// this module's pom.xml. Tag inherited by all subclasses (ConcurrencyTestCase et al).
+@Tag("sequential")
 public abstract class ConcurrencyTestHelper {
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentJobExecutorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentJobExecutorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.ManagementService;
@@ -60,6 +61,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Thorben Lindhauer
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class ConcurrentJobExecutorTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -41,6 +42,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Daniel Meyer
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class ConcurrentVariableUpdateTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/UuidGeneratorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/UuidGeneratorTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.uuid.EthernetAddress;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Daniel Meyer
  *
  */
+// Tagged "sequential": hand-orchestrates real background threads with blocking
+// wait()/notify() and no timeout - see ConcurrencyTestHelper's tag comment and the
+// surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class UuidGeneratorTest {
 
   private static final int THREAD_COUNT = 10;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorTestCase.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorTestCase.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -49,6 +50,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Tom Baeyens
  */
+// Tagged "sequential": with forkCount > 1, Surefire's JUnit Platform provider can
+// dispatch a @Nested class to a different JVM fork than its enclosing class,
+// running it twice (once as part of the enclosing class's own cascade, once
+// standalone) - see the surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class JobExecutorTestCase {
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/db/SchemaLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/db/SchemaLogTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.core.io.Resource;
@@ -43,6 +44,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * @author Miklas Boskamp
  *
  */
+// Tagged "sequential": with forkCount > 1, Surefire's JUnit Platform provider can
+// dispatch a @Nested class to a different JVM fork than its enclosing class,
+// running it twice (once as part of the enclosing class's own cascade, once
+// standalone) - see the surefire-plugin config in this module's pom.xml.
+@Tag("sequential")
 class SchemaLogTest {
 
   protected static final String BASE_PATH = "org/operaton/bpm/engine/db";

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionEngineRetentionTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionEngineRetentionTest.java
@@ -3,6 +3,7 @@ package org.operaton.bpm.engine.test.junit5;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -11,6 +12,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+/**
+ * The nested classes below share static state across their own separate
+ * class-lifecycle boundaries (see {@link #processEngineName}) to simulate
+ * behavior across separate test classes within one JVM. Tagged "sequential"
+ * so the build always runs it with forkCount=1: with forkCount &gt; 1, Surefire's
+ * JUnit Platform provider can dispatch a {@code @Nested} class to a different
+ * JVM fork than its enclosing class, running it twice (once as part of the
+ * enclosing class's own cascade, once standalone) - see the surefire-plugin
+ * config in this module's pom.xml. In this test, the standalone re-run happens
+ * in a fresh JVM where this shared state was never set up.
+ */
+@Tag("sequential")
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class ProcessEngineExtensionEngineRetentionTest {
 

--- a/engine/src/test/resources/audithistory.operaton.cfg.xml
+++ b/engine/src/test/resources/audithistory.operaton.cfg.xml
@@ -6,12 +6,12 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
   
-    <property name="processEngineName" value="audit-history-engine" />
-  
+    <property name="processEngineName" value="audit-history-engine-junit5" />
+
     <!-- Database configurations -->
     <property name="history" value="audit" />
     <property name="databaseSchemaUpdate" value="true" />
-    <property name="jdbcUrl" value="jdbc:h2:mem:audit-history-engine" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:audit-history-engine-junit5" />
     
     <!-- job executor configurations -->
     <property name="jobExecutorActivate" value="false" />

--- a/engine/src/test/resources/org/operaton/bpm/application/impl/embedded/deployment-to-custom-default-engine.xml
+++ b/engine/src/test/resources/org/operaton/bpm/application/impl/embedded/deployment-to-custom-default-engine.xml
@@ -9,7 +9,7 @@
       <configuration>org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration</configuration>
 
       <properties>
-          <property name="jdbcUrl">jdbc:h2:mem:embeddedEngine</property>
+          <property name="jdbcUrl">jdbc:h2:mem:embeddedEngineCustomDefault</property>
           <property name="jobExecutorDeploymentAware">true</property>
           <property name="jobExecutorPreferTimerJobs">true</property>
           <property name="jobExecutorAcquireByDueDate">true</property>

--- a/engine/src/test/resources/org/operaton/bpm/application/impl/embedded/deployment-with-custom-engine.xml
+++ b/engine/src/test/resources/org/operaton/bpm/application/impl/embedded/deployment-with-custom-engine.xml
@@ -9,7 +9,7 @@
     <configuration>org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration</configuration>
     
     <properties>
-        <property name="jdbcUrl">jdbc:h2:mem:embeddedEngine</property>
+        <property name="jdbcUrl">jdbc:h2:mem:embeddedEngineCustom</property>
         <property name="jobExecutorDeploymentAware">true</property>
         <property name="jobExecutorPreferTimerJobs">true</property>
         <property name="jobExecutorAcquireByDueDate">true</property>

--- a/engine/src/test/resources/org/operaton/bpm/application/impl/embedded/deployment-without-dmn.xml
+++ b/engine/src/test/resources/org/operaton/bpm/application/impl/embedded/deployment-without-dmn.xml
@@ -9,7 +9,7 @@
     <configuration>org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration</configuration>
     
     <properties>
-        <property name="jdbcUrl">jdbc:h2:mem:embeddedEngine</property>
+        <property name="jdbcUrl">jdbc:h2:mem:embeddedEngineNoDmn</property>
         <property name="jobExecutorDeploymentAware">true</property>
         <property name="jobExecutorPreferTimerJobs">true</property>
         <property name="jobExecutorAcquireByDueDate">true</property>

--- a/engine/src/test/resources/org/operaton/bpm/application/impl/event/pa.event.listener.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/application/impl/event/pa.event.listener.operaton.cfg.xml
@@ -8,7 +8,7 @@
   
     <property name="processEngineName" value="ProcessApplicationEventListenerTest-engine" />
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:BPMNParseListenerTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:ProcessApplicationEventListenerTest;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/async/default.job.retry.property.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/async/default.job.retry.property.operaton.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:defaultJobRetryProperty;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/deployment/deploy.diagram.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/deployment/deploy.diagram.operaton.cfg.xml
@@ -8,7 +8,7 @@
   
     <property name="processEngineName" value="BPMNParseListenerTest-engine" />
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:BPMNParseListenerTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:deployDiagramTest;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/task.listener.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/task.listener.operaton.cfg.xml
@@ -8,7 +8,7 @@
   
     <property name="processEngineName" value="BuiltinTaskListenerTest-engine" />
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:BPMNParseListenerTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:BuiltinTaskListenerTest;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/cfg/identity/customIdentitySession-operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/cfg/identity/customIdentitySession-operaton.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:customIdentitySession;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/initialization/customdefaultretries.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/initialization/customdefaultretries.operaton.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:customdefaultretries;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/initialization/defaultretries.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/initialization/defaultretries.operaton.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:defaultretries;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/initialization/globalretries.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/standalone/initialization/globalretries.operaton.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:operaton;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:globalretries;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />


### PR DESCRIPTION
This change enables the execution of tests on multiple cores and marks tests with tag "sequential" that do not support parallel test execution.