### PR TITLE
fix(jakarta-ee): remove mutable instance state from stateless EJBs (Java:S8983)

### DIFF
--- a/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/EjbBpmPlatformBootstrap.java
+++ b/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/EjbBpmPlatformBootstrap.java
@@ -21,6 +21,8 @@ import java.util.logging.Logger;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.ejb.EJB;
+import jakarta.ejb.Lock;
+import jakarta.ejb.LockType;
 import jakarta.ejb.Singleton;
 import jakarta.ejb.Startup;
 import jakarta.ejb.TransactionAttribute;
@@ -103,10 +105,14 @@ public class EjbBpmPlatformBootstrap {
 
   // getters //////////////////////////////////////////////
 
+  @Lock(LockType.READ)
+  @TransactionAttribute(TransactionAttributeType.SUPPORTS)
   public ProcessEngineService getProcessEngineService() {
     return processEngineService;
   }
 
+  @Lock(LockType.READ)
+  @TransactionAttribute(TransactionAttributeType.SUPPORTS)
   public ProcessApplicationService getProcessApplicationService() {
     return processApplicationService;
   }

--- a/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/EjbProcessApplicationService.java
+++ b/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/EjbProcessApplicationService.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.container.impl.ejb;
 
 import java.util.Set;
-import jakarta.annotation.PostConstruct;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Local;
 import jakarta.ejb.Stateless;
@@ -41,22 +40,14 @@ public class EjbProcessApplicationService implements ProcessApplicationService {
   @EJB
   protected EjbBpmPlatformBootstrap ejbBpmPlatform;
 
-  /** the processApplicationServiceDelegate */
-  protected ProcessApplicationService processApplicationServiceDelegate;
-
-  @PostConstruct
-  protected void initProcessEngineServiceDelegate() {
-    processApplicationServiceDelegate = ejbBpmPlatform.getProcessApplicationService();
-  }
-
   @Override
   public Set<String> getProcessApplicationNames() {
-    return processApplicationServiceDelegate.getProcessApplicationNames();
+    return ejbBpmPlatform.getProcessApplicationService().getProcessApplicationNames();
   }
 
   @Override
   public ProcessApplicationInfo getProcessApplicationInfo(String processApplicationName) {
-    return processApplicationServiceDelegate.getProcessApplicationInfo(processApplicationName);
+    return ejbBpmPlatform.getProcessApplicationService().getProcessApplicationInfo(processApplicationName);
   }
 
 }

--- a/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/EjbProcessEngineService.java
+++ b/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/EjbProcessEngineService.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.container.impl.ejb;
 
 import java.util.List;
 import java.util.Set;
-import jakarta.annotation.PostConstruct;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Local;
 import jakarta.ejb.Stateless;
@@ -42,32 +41,24 @@ public class EjbProcessEngineService implements ProcessEngineService {
   @EJB
   protected EjbBpmPlatformBootstrap ejbBpmPlatform;
 
-  /** the processEngineServiceDelegate */
-  protected ProcessEngineService processEngineServiceDelegate;
-
-  @PostConstruct
-  protected void initProcessEngineServiceDelegate() {
-    processEngineServiceDelegate = ejbBpmPlatform.getProcessEngineService();
-  }
-
   @Override
   public ProcessEngine getDefaultProcessEngine() {
-    return processEngineServiceDelegate.getDefaultProcessEngine();
+    return ejbBpmPlatform.getProcessEngineService().getDefaultProcessEngine();
   }
 
   @Override
   public List<ProcessEngine> getProcessEngines() {
-    return processEngineServiceDelegate.getProcessEngines();
+    return ejbBpmPlatform.getProcessEngineService().getProcessEngines();
   }
 
   @Override
   public Set<String> getProcessEngineNames() {
-    return processEngineServiceDelegate.getProcessEngineNames();
+    return ejbBpmPlatform.getProcessEngineService().getProcessEngineNames();
   }
 
   @Override
   public ProcessEngine getProcessEngine(String name) {
-    return processEngineServiceDelegate.getProcessEngine(name);
+    return ejbBpmPlatform.getProcessEngineService().getProcessEngine(name);
   }
 
 }

--- a/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/ExecutorServiceBean.java
+++ b/jakarta-ee/ejb-service/src/main/java/org/operaton/bpm/container/impl/ejb/ExecutorServiceBean.java
@@ -17,8 +17,6 @@
 package org.operaton.bpm.container.impl.ejb;
 
 import java.util.List;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Resource;
 import jakarta.ejb.Local;
 import jakarta.ejb.Stateless;
@@ -46,32 +44,32 @@ public class ExecutorServiceBean implements ExecutorService {
   @Resource(mappedName="eis/JcaExecutorServiceConnectionFactory")
   protected JcaExecutorServiceConnectionFactory executorConnectionFactory;
 
-  protected JcaExecutorServiceConnection executorConnection;
-
-  @PostConstruct
-  protected void openConnection() {
+  @Override
+  public boolean schedule(Runnable runnable, boolean isLongRunning) {
+    JcaExecutorServiceConnection executorConnection = openConnection();
     try {
-      executorConnection = executorConnectionFactory.getConnection();
-    } catch (ResourceException e) {
-      throw new ProcessEngineException("Could not open connection to executor service connection factory ", e);
-    }
-  }
-
-  @PreDestroy
-  protected void closeConnection() {
-    if(executorConnection != null) {
+      return executorConnection.schedule(runnable, isLongRunning);
+    } finally {
       executorConnection.closeConnection();
     }
   }
 
   @Override
-  public boolean schedule(Runnable runnable, boolean isLongRunning) {
-    return executorConnection.schedule(runnable, isLongRunning);
+  public Runnable getExecuteJobsRunnable(List<String> jobIds, ProcessEngineImpl processEngine) {
+    JcaExecutorServiceConnection executorConnection = openConnection();
+    try {
+      return executorConnection.getExecuteJobsRunnable(jobIds, processEngine);
+    } finally {
+      executorConnection.closeConnection();
+    }
   }
 
-  @Override
-  public Runnable getExecuteJobsRunnable(List<String> jobIds, ProcessEngineImpl processEngine) {
-    return executorConnection.getExecuteJobsRunnable(jobIds, processEngine);
+  protected JcaExecutorServiceConnection openConnection() {
+    try {
+      return executorConnectionFactory.getConnection();
+    } catch (ResourceException e) {
+      throw new ProcessEngineException("Could not open connection to executor service connection factory ", e);
+    }
   }
 
 }


### PR DESCRIPTION
Good Evening,

I've continued analyzing and fixing Sonar Issues. Concrete the three SonarCloud java:S8983 findings in jakarta-ee/ejb-service by removing mutable state from stateless EJBs.

## Changes

- **EjbProcessEngineService** and **EjbProcessApplicationService** Removed cached delegate fields and resolve delegates per invocation via EjbBpmPlatform.
- **ExecutorServiceBean** Removed the cached JCA connection. Acquire and close the connection per business method invocation.
- **EjbBpmPlatformBootstrap** Added @Lock(READ) and @TransactionAttribute(SUPPORTS) to delegate getters to preserve concurrency and transaction behavior.

## WHy

The ExecutorServiceBean change fixes a real resource leak: connections were held for the lifetime of pooled bean instances, preventing them from being returned to the JCA pool and risking pool exhaustion. The new open/use/close pattern matches the JCA contract.

## Validation
VErified concurrency and transaction semantics remain unchanged.
Confirmed the returned Runnable does not depend on the connection handle.
Failure behavior remains safe (per-call failures are retried by the job executor).
No remaining references to the removed fields or lifecycle methods.
mvn -pl jakarta-ee/ejb-service compile 

## Reviewer focus @kthoms 

I'd appreciate a review of:
- The per-invocation delegate lookup and its concurrency/transaction semantics.
- The JCA connection lifecycle change in `ExecutorServiceBean`.
- Any concerns with the `@Lock(READ)` / `@TransactionAttribute(SUPPORTS)` changes on `EjbBpmPlatformBootstrap` ?

Thanks for the review and have a nice weekend