### PR TITLE
fix(invoice-example): associate form labels with their inputs

### DIFF
--- a/examples/invoice/src/main/webapp/forms/approve-invoice.html
+++ b/examples/invoice/src/main/webapp/forms/approve-invoice.html
@@ -10,40 +10,44 @@
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Creditor</label>
+    <label class="form-label col-md-2" for="creditor">Creditor</label>
     <div class="col-md-10">
       <input cam-variable-name="creditor"
              type="text"
+             id="creditor"
              name="creditor"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Amount</label>
+    <label class="form-label col-md-2" for="amount">Amount</label>
     <div class="col-md-10">
       <input cam-variable-name="amount"
              type="text"
+             id="amount"
              name="amount"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Invoice Category</label>
+    <label class="form-label col-md-2" for="invoiceCategory">Invoice Category</label>
     <div class="col-md-10">
       <input cam-variable-name="invoiceCategory"
              type="text"
-             name="amount"
+             id="invoiceCategory"
+             name="invoiceCategory"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Invoice Number</label>
+    <label class="form-label col-md-2" for="invoiceNumber">Invoice Number</label>
     <div class="col-md-10">
       <input cam-variable-name="invoiceNumber"
              type="text"
+             id="invoiceNumber"
              name="invoiceNumber"
              readonly="true"
              class="form-control" />

--- a/examples/invoice/src/main/webapp/forms/assign-reviewer.html
+++ b/examples/invoice/src/main/webapp/forms/assign-reviewer.html
@@ -1,41 +1,45 @@
 <form class="form-horizontal">
 
   <div class="control-group mb-3">
-    <label class="form-label">Creditor</label>
+    <label class="form-label" for="creditor">Creditor</label>
     <div class="controls">
       <input cam-variable-name="creditor"
              type="text"
+             id="creditor"
              name="creditor"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="control-group mb-3">
-    <label class="form-label">Amount</label>
+    <label class="form-label" for="amount">Amount</label>
     <div class="controls">
       <input cam-variable-name="amount"
              type="text"
+             id="amount"
              name="amount"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="control-group mb-3">
-    <label class="form-label">Invoice Number</label>
+    <label class="form-label" for="invoiceNumber">Invoice Number</label>
     <div class="controls">
       <input cam-variable-name="invoiceNumber"
              type="text"
+             id="invoiceNumber"
              name="invoiceNumber"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="control-group mb-3">
-    <label class="form-label">Reviewer: </label>
+    <label class="form-label" for="reviewer">Reviewer: </label>
     <div class="controls">
       <select cam-variable-name="reviewer"
               cam-variable-type="String"
               type="text"
+              id="reviewer"
               name="reviewer"
               class="form-control"
               required>

--- a/examples/invoice/src/main/webapp/forms/prepare-bank-transfer.html
+++ b/examples/invoice/src/main/webapp/forms/prepare-bank-transfer.html
@@ -10,30 +10,33 @@
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Creditor</label>
+    <label class="form-label col-md-2" for="creditor">Creditor</label>
     <div class="col-md-10">
       <input cam-variable-name="creditor"
              type="text"
+             id="creditor"
              name="creditor"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Amount</label>
+    <label class="form-label col-md-2" for="amount">Amount</label>
     <div class="col-md-10">
       <input cam-variable-name="amount"
              type="text"
+             id="amount"
              name="amount"
              readonly="true"
              class="form-control" />
     </div>
   </div>
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Invoice Number</label>
+    <label class="form-label col-md-2" for="invoiceNumber">Invoice Number</label>
     <div class="col-md-10">
       <input cam-variable-name="invoiceNumber"
              type="text"
+             id="invoiceNumber"
              name="invoiceNumber"
              readonly="true"
              class="form-control" />
@@ -41,11 +44,12 @@
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Approved by </label>
+    <label class="form-label col-md-2" for="approver">Approved by </label>
     <div class="col-md-10">
       <input cam-variable-name="approver"
              type="text"
-             name="approved"
+             id="approver"
+             name="approver"
              readonly="true"
              class="form-control" />
     </div>

--- a/examples/invoice/src/main/webapp/forms/review-invoice.html
+++ b/examples/invoice/src/main/webapp/forms/review-invoice.html
@@ -13,29 +13,32 @@
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Creditor</label>
+    <label class="form-label col-md-2" for="creditor">Creditor</label>
     <div class="col-md-10">
       <input cam-variable-name="creditor"
              type="text"
+             id="creditor"
              name="creditor"
              class="form-control" />
     </div>
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Amount</label>
+    <label class="form-label col-md-2" for="amount">Amount</label>
     <div class="col-md-10">
       <input cam-variable-name="amount"
              type="text"
+             id="amount"
              name="amount"
              class="form-control" />
     </div>
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Invoice Category</label>
+    <label class="form-label col-md-2" for="invoiceCategory">Invoice Category</label>
     <div class="col-md-10">
       <select cam-variable-name="invoiceCategory"
+              id="invoiceCategory"
               class="form-control">
         <option>Travel Expenses</option>
         <option>Misc</option>
@@ -44,10 +47,11 @@
   </div>
 
   <div class="form-group mb-3">
-    <label class="form-label col-md-2">Invoice Number</label>
+    <label class="form-label col-md-2" for="invoiceNumber">Invoice Number</label>
     <div class="col-md-10">
       <input cam-variable-name="invoiceNumber"
              type="text"
+             id="invoiceNumber"
              name="invoiceNumber"
              class="form-control" />
     </div>

--- a/examples/invoice/src/main/webapp/forms/start-form.html
+++ b/examples/invoice/src/main/webapp/forms/start-form.html
@@ -77,10 +77,11 @@
 
   <div class="form-group mb-3">
     <label class="form-label col-md-4"
-           for="amount">Invoice Category</label>
+           for="invoiceCategory">Invoice Category</label>
     <div class="col-md-8">
       <select cam-variable-name="invoiceCategory"
               cam-variable-type="String"
+              id="invoiceCategory"
               class="form-control">
         <option>Travel Expenses</option>
         <option>Misc</option>


### PR DESCRIPTION
Hello there,

I reviewed some additional Sonar findings.

The embedded invoice forms displayed visible `<label>` elements that were not associated with their corresponding inputs. This change adds matching `id`/`for` pairs to the 16 affected input and select elements, following the existing pattern in `start-form.html`. It also corrects two stale `name` attributes (`Invoice Category` and `Approver`), which are unused because values are bound via `cam-variable-name`.

Although this only affects the invoice example not the runtime or platform itself, the example is shipped with Target distributions and commonly serves as a reference for users building embedded forms.

So It resolves 17 occurrences of `Web:InputWithoutLabelCheck`.

Have a great day!