### PR TITLE
fix(regexp): avoid superlinear regex scanning

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/container/impl/metadata/PropertyHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/metadata/PropertyHelper.java
@@ -44,9 +44,10 @@ public final class PropertyHelper {
   }
 
   /**
-   * Regex for Ant-style property placeholders
+   * Regex for Ant-style property placeholders. Matching only the placeholder keeps it linear: the
+   * literal prefix anchors each attempt instead of rescanning from every offset (java:S8786).
    */
-  private static final Pattern PROPERTY_TEMPLATE = Pattern.compile("([^$]*+)\\$\\{([^\\n\\r\\u0085\\u2028\\u2029][^}\\n\\r\\u0085\\u2028\\u2029]*+)\\}([^$]*+)");
+  private static final Pattern PROPERTY_TEMPLATE = Pattern.compile("\\$\\{([^\\n\\r\\u0085\\u2028\\u2029][^}\\n\\r\\u0085\\u2028\\u2029]*+)\\}");
 
   public static boolean getBooleanProperty(Map<String, String> properties, String name, boolean defaultValue) {
     String value = properties.get(name);
@@ -149,15 +150,12 @@ public final class PropertyHelper {
   public static String resolveProperty(Properties props, String original) {
     Matcher matcher = PROPERTY_TEMPLATE.matcher(original);
     StringBuilder buffer = new StringBuilder();
-    boolean found = false;
     while(matcher.find()) {
-      found = true;
-      String propertyName = matcher.group(2).trim();
-      buffer.append(matcher.group(1))
-        .append(props.containsKey(propertyName) ? props.getProperty(propertyName) : "")
-        .append(matcher.group(3));
+      String propertyName = matcher.group(1).trim();
+      String replacement = props.containsKey(propertyName) ? props.getProperty(propertyName) : "";
+      matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
     }
-    return found ? buffer.toString() : original;
+    return matcher.appendTail(buffer).toString();
   }
 
   protected static String convertToCamelCase(String value, String token) {

--- a/engine/src/main/java/org/operaton/bpm/container/impl/metadata/PropertyHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/metadata/PropertyHelper.java
@@ -60,9 +60,6 @@ public final class PropertyHelper {
 
   /**
    * Converts a value to the type of the given field.
-   * @param value
-   * @param field
-   * @return
    */
   public static Object convertToClass(String value, Class<?> clazz) {
     Object propertyValue;
@@ -145,14 +142,14 @@ public final class PropertyHelper {
    *
    * @param props contains possible replacements
    * @param original may contain Ant-style templates
-   * @return the original string with replaced properties or the unchanged original string if no placeholder found.
+   * @return original with placeholders replaced; equal to original if no placeholder found.
    */
   public static String resolveProperty(Properties props, String original) {
     Matcher matcher = PROPERTY_TEMPLATE.matcher(original);
     StringBuilder buffer = new StringBuilder();
     while(matcher.find()) {
       String propertyName = matcher.group(1).trim();
-      String replacement = props.containsKey(propertyName) ? props.getProperty(propertyName) : "";
+      String replacement = props.getProperty(propertyName, "");
       matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
     }
     return matcher.appendTail(buffer).toString();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/task/TaskDecorator.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/task/TaskDecorator.java
@@ -202,7 +202,27 @@ public class TaskDecorator {
    * Extract a candidate list from a string.
    */
   protected List<String> extractCandidates(String str) {
-    return Arrays.asList(str.split("\\s*+,\\s*+"));
+    String[] parts = str.split(",\\s*+", -1);
+    if (parts.length == 1) {
+      return List.of(str);
+    }
+    int size = 0;
+    for (int i = 0; i < parts.length; i++) {
+      int end = parts[i].length();
+      while (i < parts.length - 1 && end > 0 && isSpace(parts[i].charAt(end - 1))) {
+        end--;
+      }
+      parts[i] = parts[i].substring(0, end);
+      if (!parts[i].isEmpty()) {
+        size = i + 1; // mirrors String#split dropping trailing empty elements
+      }
+    }
+    return Arrays.asList(Arrays.copyOf(parts, size));
+  }
+
+  /** The regex {@code \s} class, which is narrower than {@link String#strip()}. */
+  private static boolean isSpace(char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == 0x0B || c == '\f' || c == '\r';
   }
 
   // getters ///////////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/task/TaskDecorator.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/task/TaskDecorator.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.task;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -204,20 +205,25 @@ public class TaskDecorator {
   protected List<String> extractCandidates(String str) {
     String[] parts = str.split(",\\s*+", -1);
     if (parts.length == 1) {
-      return List.of(str);
+      return Arrays.asList(parts);
     }
-    int size = 0;
-    for (int i = 0; i < parts.length; i++) {
-      int end = parts[i].length();
-      while (i < parts.length - 1 && end > 0 && isSpace(parts[i].charAt(end - 1))) {
-        end--;
-      }
-      parts[i] = parts[i].substring(0, end);
-      if (!parts[i].isEmpty()) {
-        size = i + 1; // mirrors String#split dropping trailing empty elements
-      }
+    List<String> result = new ArrayList<>(parts.length);
+    for (int i = 0; i < parts.length - 1; i++) {
+      result.add(stripTrailingSpace(parts[i]));
     }
-    return Arrays.asList(Arrays.copyOf(parts, size));
+    result.add(parts[parts.length - 1]);
+    while (!result.isEmpty() && result.get(result.size() - 1).isEmpty()) {
+      result.remove(result.size() - 1); // mirrors String#split dropping trailing empty elements
+    }
+    return result;
+  }
+
+  private static String stripTrailingSpace(String part) {
+    int end = part.length();
+    while (end > 0 && isSpace(part.charAt(end - 1))) {
+      end--;
+    }
+    return part.substring(0, end);
   }
 
   /** The regex {@code \s} class, which is narrower than {@link String#strip()}. */

--- a/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
@@ -170,6 +170,14 @@ class PropertyHelperTest {
   }
 
   @Test
+  void testResolvePropertyKeepsDollarSignsThatOpenNoPlaceholder() {
+    Properties source = new Properties();
+    source.put("operaton.test.someKey", "1234");
+    String result = PropertyHelper.resolveProperty(source, "$HOME/pa$$word-${operaton.test.someKey}$");
+    assertThat(result).isEqualTo("$HOME/pa$$word-1234$");
+  }
+
+  @Test
   void testResolvePropertyNoTemplate() {
     Properties source = new Properties();
     source.put("operaton.test.someKey", "1234");

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/task/TaskDecoratorExtractCandidatesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/task/TaskDecoratorExtractCandidatesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.task;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskDecoratorExtractCandidatesTest {
+
+  protected final TaskDecorator taskDecorator = new TaskDecorator(null, null);
+
+  @ParameterizedTest
+  @CsvSource(delimiterString = "|", value = {
+      "john|john",
+      "john,peter,mary|john,peter,mary",
+      "john, peter, mary|john,peter,mary",
+      "john ,  peter  ,   mary  |john,peter,mary",
+      ",john|,john",
+      "john,|john",
+      "john,  |john",
+      "john,,mary|john,,mary",
+      "john, ,mary|john,,mary",
+      "' '|' '",
+      "','|,",
+      "'  ,  '|,"
+  })
+  void shouldMirrorPreviousSplitBehavior(String input, String expectedCsv) {
+    List<String> expected = Arrays.asList(expectedCsv.split(","));
+
+    List<String> actual = taskDecorator.extractCandidates(input);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
@@ -34,7 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DatabaseNamingConsistencyTest {
 
-  public static final String COLUMN_NAME_REGEX = "(?<![a-zA-Z_])(?=[A-Z_]*[a-z])([a-zA-Z_]+_)[,\\s]";
+  // Quantifier bounds keep the scan linear (java:S8786); no scanned identifier exceeds 74 chars.
+  public static final String COLUMN_NAME_REGEX = "(?<![a-zA-Z_])(?=[A-Z_]{0,200}[a-z])([a-zA-Z_]{1,200}_)[,\\s]";
   public static final String[] SCANNED_FOLDERS = {
       "org/operaton/bpm/engine/impl/mapping/entity/",
       "org/operaton/bpm/engine/db/create", "org/operaton/bpm/engine/db/drop",

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/WebappsDatabaseNamingConsistencyTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/WebappsDatabaseNamingConsistencyTest.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class WebappsDatabaseNamingConsistencyTest {
 
-  public static final String COLUMN_NAME_REGEX = "(?<![a-zA-Z_])(?=[A-Z_]*[a-z])([a-zA-Z_]+_)[,\\s]";
+  // Quantifier bounds keep the scan linear (java:S8786); no scanned identifier exceeds 74 chars.
+  public static final String COLUMN_NAME_REGEX = "(?<![a-zA-Z_])(?=[A-Z_]{0,200}[a-z])([a-zA-Z_]{1,200}_)[,\\s]";
   public static final String[] SCANNED_FOLDERS = { "org/operaton/bpm/cockpit/plugin/base/queries",
       "org/operaton/bpm/admin/plugin/base/queries" };
 


### PR DESCRIPTION
## What this PR does

Fixes the remaining four `java:S8786` (super-linear regex backtracking) findings.

### Why the previous fix wasn't enough

The earlier fix in `dc88275fa` (#3350) added possessive quantifiers (`*+`, `++`). That reduces backtracking *within* a single match attempt, but it doesn't prevent the real issue: when a match fails, the regex engine retries from the next character, rescanning the rest of the input each time. The result is still quadratic runtime. We confirmed this with worst-case inputs (up to 51 s / 13.5 s).

This PR removes the quadratic scan itself, so it supersedes the previous approach for these four cases.

### Changes

| File | Fix |
|------|-----|
| `PropertyHelper.resolveProperty` | Match only the `${...}` placeholder and rebuild the surrounding text with `appendReplacement`/`appendTail`, anchoring each match on the literal `${`. |
| `TaskDecorator.extractCandidates` | Split on `,\s*+` (anchored by the comma) and trim each part afterward. |
| `DatabaseNamingConsistencyTest` / `WebappsDatabaseNamingConsistencyTest` | Limit the unbounded character classes in `COLUMN_NAME_REGEX` to 200 characters, bounding the work per match attempt. |

**Performance:** resolving a 200k-character property value drops from **51 s to <1 ms**, and parsing a candidate list containing 120k whitespace characters drops from **13.5 s to <1 ms**. Since the second case can be triggered through a process variable, this is a DoS fix, not just a lint cleanup.

### Behavior change

`resolveProperty` no longer drops text before a stray `$`. For example:

- Before: `"$HOME/${key}/x"` → `"HOME/1234/x"`
- Now: `"$HOME/1234/x"`

This only affects values containing a literal `$` before a placeholder. The old behavior silently discarded text, so this is treated as a bug fix. A regression test covers the new behavior.

### Verification

- Ran Sonar's `SuperLinearRegexCheck` (same version as SonarCloud): all four findings disappear.
- Differential fuzzing (~27M inputs):
  - `extractCandidates`: no behavioral differences.
  - `resolveProperty`: all differences are the documented stray-`$` case.
- Compared the bounded column-name regex against all existing SQL/mapping resources and injected test cases: identical results. The longest real identifier is 74 characters, well below the 200-character limit.

## Questions @kthoms 

1. Is the `resolveProperty` behavior change acceptable as a normal bug fix, or should it be called out in the release notes?
2. Is a limit of 200 characters for `COLUMN_NAME_REGEX` reasonable, or would you prefer it as a named constant?