### PR TITLE
test(webapps): isolate LoginUiIT per test to fix flaky logins

### DIFF
--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -18,8 +18,7 @@ package org.operaton.bpm.run.qa.webapps;
 
 import java.net.URI;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
@@ -37,14 +36,22 @@ import org.operaton.bpm.integrationtest.util.SeleniumScreenshotExtension;
  */
 public abstract class AbstractWebappUiIT extends AbstractWebIT {
 
-  protected static WebDriver driver;
+  protected WebDriver driver;
 
   @RegisterExtension
   @SuppressWarnings("unused")
-  private final SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(driver);
+  private final SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(() -> driver);
 
-  @BeforeAll
-  static void createDriver() {
+  /**
+   * A fresh browser is created for every test method (and disposed afterwards). The webapps share
+   * a single JSESSIONID/XSRF-TOKEN pair across cockpit/tasklist/admin/welcome, so reusing one
+   * browser across tests leaks authenticated-session and CSRF-token state: the first login
+   * succeeds, but a stale JSESSIONID that outlives an in-browser cookie wipe prevents the server
+   * from re-issuing an XSRF-TOKEN, so every subsequent login is rejected. A brand-new browser
+   * guarantees each test starts from the clean state that reliably logs in.
+   */
+  @BeforeEach
+  void createDriver() {
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
         .withVerbose(true)
         .usingAnyFreePort()
@@ -82,9 +89,12 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
     appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());
   }
 
-  @AfterAll
-  static void quitDriver() {
-    driver.quit();
+  @AfterEach
+  void quitDriver() {
+    if (driver != null) {
+      driver.quit();
+      driver = null;
+    }
   }
 
 }

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -20,6 +20,7 @@ import java.net.URI;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -51,7 +52,8 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
    * guarantees each test starts from the clean state that reliably logs in.
    */
   @BeforeEach
-  void createDriver() {
+  void setUp(TestInfo testInfo) {
+    // create driver
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
         .withVerbose(true)
         .usingAnyFreePort()
@@ -64,6 +66,11 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
         .addArguments("--disable-dev-shm-usage");
 
     driver = new ChromeDriver(chromeDriverService, chromeOptions);
+
+    // create client
+    preventRaceConditions();
+    createClient(getWebappCtxPath());
+    appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());
   }
 
   public static ExpectedCondition<Boolean> currentURIIs(final URI pageURI) {
@@ -82,13 +89,6 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
     return webDriver -> webDriver.getCurrentUrl().contains(url);
   }
 
-  @BeforeEach
-  void createClient() {
-    preventRaceConditions();
-    createClient(getWebappCtxPath());
-    appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());
-  }
-
   @AfterEach
   void quitDriver() {
     if (driver != null) {
@@ -96,5 +96,4 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
       driver = null;
     }
   }
-
 }

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
@@ -16,12 +16,10 @@
  */
 package org.operaton.bpm.run.qa.webapps;
 
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -206,10 +204,11 @@ class LoginIT extends AbstractWebappUiIT {
     wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#!/welcome")));
   }
 
+  @Override
   @BeforeEach
-  void setup(TestInfo testInfo) {
-    Optional<Method> testMethod = testInfo.getTestMethod();
-    testMethod.ifPresent(method -> this.name = method.getName());
+  void setUp(TestInfo testInfo) {
+    super.setUp(testInfo);
+    testInfo.getTestMethod().ifPresent(method -> this.name = method.getName());
   }
 
   void initLoginIT(String[] commands) {

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/AbstractWebappUiIntegrationTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.integrationtest.util.SeleniumScreenshotExtension;
 
 public abstract class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest {
 
-  protected static WebDriver driver;
+  protected WebDriver driver;
 
   @RegisterExtension
   public SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(() -> driver);

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/AbstractWebappUiIntegrationTest.java
@@ -18,8 +18,8 @@ package org.operaton.bpm.integrationtest;
 
 import java.net.URI;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -34,10 +34,18 @@ public abstract class AbstractWebappUiIntegrationTest extends AbstractWebIntegra
   protected static WebDriver driver;
 
   @RegisterExtension
-  public SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(driver);
+  public SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(() -> driver);
 
-  @BeforeAll
-  static void createDriver() {
+  /**
+   * A fresh browser is created for every test method (and disposed afterwards). The webapps share
+   * a single JSESSIONID/XSRF-TOKEN pair across cockpit/tasklist/admin/welcome, so reusing one
+   * browser across tests leaks authenticated-session and CSRF-token state: the first login
+   * succeeds, but a stale JSESSIONID that outlives an in-browser cookie wipe prevents the server
+   * from re-issuing an XSRF-TOKEN, so every subsequent login is rejected. A brand-new browser
+   * guarantees each test starts from the clean state that reliably logs in.
+   */
+  @BeforeEach
+  void createDriver() {
 
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
             .withVerbose(true)
@@ -73,9 +81,12 @@ public abstract class AbstractWebappUiIntegrationTest extends AbstractWebIntegra
 
   }
 
-  @AfterAll
-  static void quitDriver() {
-    driver.quit();
+  @AfterEach
+  void quitDriver() {
+    if (driver != null) {
+      driver.quit();
+      driver = null;
+    }
   }
 
 }

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/LoginUiIT.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/LoginUiIT.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -63,11 +62,10 @@ class LoginUiIT extends AbstractWebappUiIntegrationTest {
   }
 
   void login(String appName) {
-    driver.manage().deleteAllCookies();
+    // each test runs in a fresh browser (see AbstractWebappUiIntegrationTest), so no cookie or
+    // storage reset is required here - the browser starts without any session or CSRF state
     String appUrl = "%sapp/%s/default/".formatted(getAppBaseUrlAsString(), appName);
     driver.get(appUrl);
-    clearBrowserStorage();
-    driver.navigate().refresh();
 
     WebDriverWait loginWait = new WebDriverWait(driver, LOGIN_TIMEOUT);
 
@@ -87,12 +85,6 @@ class LoginUiIT extends AbstractWebappUiIntegrationTest {
     loginWait.until(invisibilityOfElementLocated(By.cssSelector("input[type=\"password\"]")));
 
     wait = new WebDriverWait(driver, POST_LOGIN_TIMEOUT);
-  }
-
-  // clear persisted browser state between retries so stale auth/csrf data cannot leak
-  // across webapp reloads or container redeployments
-  void clearBrowserStorage() {
-    ((JavascriptExecutor) driver).executeScript("window.localStorage.clear(); window.sessionStorage.clear();");
   }
 
   void sendKeys(WebElement element, String keys)  {

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/LoginUiIT.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/LoginUiIT.java
@@ -56,6 +56,9 @@ class LoginUiIT extends AbstractWebappUiIntegrationTest {
         return;
       } catch (WebDriverException e) {
         last = e;
+        // clear cookies so the next attempt starts from a clean session/CSRF state
+        // instead of retrying against whatever the failed attempt left behind
+        driver.manage().deleteAllCookies();
       }
     }
     throw last;

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/util/SeleniumScreenshotExtension.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/util/SeleniumScreenshotExtension.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.function.Supplier;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -40,14 +41,13 @@ public class SeleniumScreenshotExtension implements AfterTestExecutionCallback, 
 
   private static final String OUTPUT_DIR_PROPERTY_NAME = "selenium.screenshot.directory";
   private static final Logger log = LoggerFactory.getLogger(SeleniumScreenshotExtension.class);
-  protected WebDriver webDriver;
 
-  public SeleniumScreenshotExtension(WebDriver driver) {
-    if (driver instanceof RemoteWebDriver) {
-      webDriver = new Augmenter().augment(driver);
-    } else {
-      webDriver = driver;
-    }
+  // resolved lazily so a driver that is (re)created per test - after this extension instance
+  // is constructed - is still captured for the screenshot
+  protected final Supplier<WebDriver> driverSupplier;
+
+  public SeleniumScreenshotExtension(Supplier<WebDriver> driverSupplier) {
+    this.driverSupplier = driverSupplier;
   }
 
   @Override
@@ -71,6 +71,13 @@ public class SeleniumScreenshotExtension implements AfterTestExecutionCallback, 
       return;
     }
 
+    WebDriver driver = driverSupplier.get();
+    if (driver == null) {
+      log.info("No screenshot created, because no WebDriver is available.");
+      return;
+    }
+
+    WebDriver webDriver = (driver instanceof RemoteWebDriver) ? new Augmenter().augment(driver) : driver;
     File scrFile = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.FILE);
     String now = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
     String scrFilename = "%s-%s-%s.png".formatted(context.getRequiredTestClass().getSimpleName(), context.getRequiredTestMethod().getName(), now);


### PR DESCRIPTION
## Problem

`org.operaton.bpm.integrationtest.LoginUiIT` flakes on CI. In the failing runs, `shouldLoginToCockpit` passes while `shouldLoginToTasklist`, `shouldLoginToAdmin` and `shouldLoginToWelcome` all fail **identically** at `waiting for input[type="password"] to become invisible` (the submit never logs in) — on both WildFly and Tomcat, and the failure survives the existing 3× in-session retry (~93 s per test).

Example failures:
- https://github.com/operaton/operaton/actions/runs/29712354986/job/88258277393 (`shouldLoginToAdmin`)
- https://github.com/operaton/operaton/actions/runs/29712341650/job/88258237415 (`shouldLoginToWelcome`)

## Root cause

All four tests shared **one static `ChromeDriver`** (`@BeforeAll`/`@AfterAll`). The four webapps (cockpit/tasklist/admin/welcome) share a single `JSESSIONID`/`XSRF-TOKEN` pair, and `CsrfPreventionFilter.setCSRFToken()` only issues a new token when the session has none. Once a stale authenticated session outlived the in-browser cookie wipe, the browser never received a usable CSRF token, so every subsequent login POST was rejected. Only the first (clean) login in the shared browser reliably succeeded — which is exactly the observed "first test passes, rest fail" signature. Tests running *after* LoginUiIT passed, confirming the server was healthy and the contamination was confined to the shared browser.

Prior interaction-level fixes (`click`→`submit`, localStorage/sessionStorage clear, retries, longer timeouts) all failed with the identical pattern because they tweaked the login *inside* the contaminated browser instead of isolating the tests.

## Fix

- Create/quit a **fresh `ChromeDriver` per test** (`@BeforeEach`/`@AfterEach`), so every test starts from the clean state that reliably logs in.
- Resolve the driver lazily (`Supplier<WebDriver>`) in `SeleniumScreenshotExtension`, since it is constructed before `@BeforeEach`.
- Drop the now-redundant cookie/storage reset from `login()`. The robust waits + retries stay as defense against genuine cold-start slowness.

## Verification

Relying on CI: this PR runs the webapps integration suite on tomcat + wildfly (h2). Confirming across multiple runs to demonstrate the flakiness is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)