### PR TITLE
fix(deps): Pin vulnerable transitive dependencies until the framework…

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -64,6 +64,25 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- Jackson 3 - Place before Spring Boot to override the vulnerable version
+        managed by spring-boot-dependencies (3.1.4, CVE-2026-59889). Remove once
+        Spring Boot manages jackson-bom >= 3.1.5. -->
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson3}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <!-- Netty - Place before Spring Boot, which manages 4.2.15 (CVE-2026-56745
+        et al.). Remove once spring-boot-dependencies manages netty >= 4.2.16. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -303,7 +303,6 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <version.netty>4.2.16.Final</version.netty>
         <version.undertow>2.3.26.Final</version.undertow>
       </properties>
       <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,6 +32,8 @@
     <version.gson>2.14.0</version.gson>
     <version.hibernate>6.6.10.Final</version.hibernate>
     <version.jackson>2.21.5</version.jackson>
+    <version.jackson3>3.1.5</version.jackson3>
+    <version.netty>4.2.16.Final</version.netty>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.6.2</version.httpclient5>
     <version.httpcore5>5.4</version.httpcore5>

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -12,7 +12,22 @@
   <description>${project.name}</description>
   <properties>
     <surefire.memArgs>-Xmx2048m</surefire.memArgs>
+    <version.netty>4.2.16.Final</version.netty>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- runtime and deployment do not import the quarkus-bom, so netty resolves
+        from vertx-core's pom (4.2.15, CVE-2026-56745 et al.). Remove once the
+        Quarkus/Vert.x versions in use ship netty >= 4.2.16. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <modules>
     <module>deployment</module>
     <module>runtime</module>


### PR DESCRIPTION
…s fix them


This is pinning netty and jackson because their respective Quarkus / Spring Boot versions have not shipped a version with an unaffected version, yet.

This is a proposal, it's to be discussed if we want to merge this before the release. Also to be discussed, if it should be cherry-picked into the 2.1. release branch