### PR TITLE
fix(deps): Pin vulnerable transitive dependencies (backport of #3390)

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -64,6 +64,25 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- Jackson 3 - Place before Spring Boot to override the vulnerable version
+        managed by spring-boot-dependencies (3.1.4, CVE-2026-59889). Remove once
+        Spring Boot manages jackson-bom >= 3.1.5. -->
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson3}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <!-- Netty - Place before Spring Boot, which manages 4.2.15 (CVE-2026-56745
+        et al.). Remove once spring-boot-dependencies manages netty >= 4.2.16. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -303,7 +303,6 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <version.netty>4.2.16.Final</version.netty>
         <version.undertow>2.3.26.Final</version.undertow>
       </properties>
       <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,6 +32,8 @@
     <version.gson>2.13.2</version.gson>
     <version.hibernate>6.6.10.Final</version.hibernate>
     <version.jackson>2.21.5</version.jackson>
+    <version.jackson3>3.1.5</version.jackson3>
+    <version.netty>4.2.16.Final</version.netty>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.6.2</version.httpclient5>
     <version.httpcore5>5.4.3</version.httpcore5>

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -12,7 +12,22 @@
   <description>${project.name}</description>
   <properties>
     <surefire.memArgs>-Xmx2048m</surefire.memArgs>
+    <version.netty>4.2.16.Final</version.netty>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- runtime and deployment do not import the quarkus-bom, so netty resolves
+        from vertx-core's pom (4.2.15, CVE-2026-56745 et al.). Remove once the
+        Quarkus/Vert.x versions in use ship netty >= 4.2.16. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <modules>
     <module>deployment</module>
     <module>runtime</module>


### PR DESCRIPTION
Backport of #3390 to `release/2.1.x` for the upcoming **2.1.3** release.

Clean cherry-pick of merge commit `b5a531b7` (original author @javahippie / Tim Zöller preserved).

## What it does
Pins vulnerable transitive dependencies until the frameworks ship fixed versions:
- **netty → 4.2.16.Final** — overrides the 4.2.15 pulled in by Spring Boot 4 and Quarkus/Vert.x (CVE-2026-56745 et al.). Promotes the existing `engine-rest` pin to `parent` and adds a `netty-bom` import in `quarkus-extension`.
- **jackson-bom → 3.1.5** (`tools.jackson`) — overrides the 3.1.4 managed by Spring Boot 4 (CVE-2026-59889).

## Applicability to 2.1.x
`release/2.1.x` is on Spring Boot 4.0.7 + Quarkus 3.33.3 (main: 4.1.0 / 3.33.1), so both pins apply. Cherry-pick applied with no conflicts.

Relying on this PR's CI to validate the build.
