### PR TITLE
docs(security): update supported versions; mark 1.1.x EOL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,11 @@ Versions not listed as supported will no longer be maintained.
 All versions of this project are distributed under
 the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
-| Version | Maintained           |
-|---------|----------------------|
-| 1.0.x   | ✅ Fully maintained  |
+| Version | Maintained                           |
+|---------|--------------------------------------|
+| 2.1.x   | ✅ Fully maintained                  |
+| 1.1.x   | ❌ End of life (final release: 1.1.5) |
+| 1.0.x   | ❌ End of life                       |
 
 🔒 We generally provide security updates for the **latest major version**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 |---------|--------------------------------------|
 | 2.1.x   | ✅ Fully maintained                  |
 | 1.1.x   | ❌ End of life (final release: 1.1.5) |
-| 1.0.x   | ❌ End of life                       |
+| 1.0.x   | ❌ End of life (final release: 1.0.3) |
 
 🔒 We generally provide security updates for the **latest major version**.
 


### PR DESCRIPTION
Updates the **Supported Versions** table in `SECURITY.md`, which was stale (it listed only `1.0.x`).

## Change
| Version | Maintained |
|---------|------------|
| 2.1.x | ✅ Fully maintained |
| 1.1.x | ❌ End of life (final release: 1.1.5) |
| 1.0.x | ❌ End of life |

- **1.1.x is now end-of-life** — `1.1.5` (released today) is its final version.
- `2.1.x` is the actively-maintained line.
- `1.0.x` marked EOL (predates the now-EOL 1.1.x).
- `2.2.x` intentionally omitted until 2.2.0 GA.

GitHub serves the Security policy from the default branch, so this targets `main`.
