### PR TITLE
fix(build): install CycloneDX CLI via direct download in CI (unblock release SBOM step)

### DIFF
--- a/.devenv/scripts/build/build-sbom.sh
+++ b/.devenv/scripts/build/build-sbom.sh
@@ -17,12 +17,27 @@
 set -euo pipefail
 echo "Generating SBOM files for Operaton modules..."
 
+# Pinned CycloneDX CLI version used for CI installs (see GitHub releases).
+CYCLONEDX_VERSION="v0.33.1"
+
 if command -v cyclonedx >/dev/null 2>&1; then
   echo "CycloneDX CLI already available."
 else
-  if [ "$CI" != "" ]; then
-    echo "Installing CycloneDX via Homebrew for CI environment..."
-    /home/linuxbrew/.linuxbrew/bin/brew install cyclonedx/cyclonedx/cyclonedx-cli
+  if [ "${CI:-}" != "" ]; then
+    # Download the pinned binary directly from GitHub releases. Homebrew now
+    # refuses the untrusted cyclonedx/cyclonedx tap in CI, so we bypass it.
+    case "$(uname -m)" in
+      x86_64|amd64) CYCLONEDX_ARCH="x64" ;;
+      aarch64|arm64) CYCLONEDX_ARCH="arm64" ;;
+      *) echo "❌ Unsupported CI architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    echo "Installing CycloneDX CLI ${CYCLONEDX_VERSION} (cyclonedx-linux-${CYCLONEDX_ARCH}) for CI environment..."
+    CYCLONEDX_BIN_DIR="${RUNNER_TEMP:-/tmp}/cyclonedx-cli"
+    mkdir -p "$CYCLONEDX_BIN_DIR"
+    curl -fsSL -o "$CYCLONEDX_BIN_DIR/cyclonedx" \
+      "https://github.com/CycloneDX/cyclonedx-cli/releases/download/${CYCLONEDX_VERSION}/cyclonedx-linux-${CYCLONEDX_ARCH}"
+    chmod +x "$CYCLONEDX_BIN_DIR/cyclonedx"
+    export PATH="$CYCLONEDX_BIN_DIR:$PATH"
   elif command -v brew >/dev/null 2>&1; then
     echo "CycloneDX CLI not found — installing via Homebrew..."
     brew install cyclonedx/cyclonedx/cyclonedx-cli


### PR DESCRIPTION
## Problem
The release pipeline's SBOM step fails in CI. `build-sbom.sh` installs the CycloneDX CLI with:

```sh
/home/linuxbrew/.linuxbrew/bin/brew install cyclonedx/cyclonedx/cyclonedx-cli
```

Current Homebrew refuses the untrusted `cyclonedx/cyclonedx` tap by default:

```
Skipping cyclonedx/cyclonedx because it is not trusted. Run `brew trust cyclonedx/cyclonedx` to trust it.
##[error]Broken pipe
##[error]Process completed with exit code 1
```

→ CycloneDX CLI never installs → `build-sbom.sh` fails → `Release Build` → `Documentation` step exits 1. The Maven build itself succeeds; only the SBOM step breaks. **This blocks `release.yml` for every line** (surfaced by the 1.1.5 release dry run).

## Fix
Replace the CI Homebrew install with a **direct pinned-binary download** from the [CycloneDX CLI GitHub releases](https://github.com/CycloneDX/cyclonedx-cli/releases) — reproducible and free of any tap-trust dependency:
- Pins `v0.33.1`, downloads `cyclonedx-linux-<arch>` (arch-detected: x64/arm64) into `$RUNNER_TEMP`, `chmod +x`, prepends to `PATH`.
- Local-dev `brew` path is left unchanged.
- Also guards `$CI` against `set -u` (`${CI:-}`).

## Follow-up
Once merged, cherry-pick to `release/2.1.x` and `release/1.1.x` so today's 2.1.3 / 1.1.5 releases pick it up, then re-run the release dry runs to confirm green.
