### PR TITLE
fix(build): CycloneDX CLI direct download in CI (backport of #3403)

### DIFF
--- a/.devenv/scripts/build/build-sbom.sh
+++ b/.devenv/scripts/build/build-sbom.sh
@@ -17,12 +17,27 @@
 set -euo pipefail
 echo "Generating SBOM files for Operaton modules..."
 
+# Pinned CycloneDX CLI version used for CI installs (see GitHub releases).
+CYCLONEDX_VERSION="v0.33.1"
+
 if command -v cyclonedx >/dev/null 2>&1; then
   echo "CycloneDX CLI already available."
 else
-  if [ "$CI" != "" ]; then
-    echo "Installing CycloneDX via Homebrew for CI environment..."
-    /home/linuxbrew/.linuxbrew/bin/brew install cyclonedx/cyclonedx/cyclonedx-cli
+  if [ "${CI:-}" != "" ]; then
+    # Download the pinned binary directly from GitHub releases. Homebrew now
+    # refuses the untrusted cyclonedx/cyclonedx tap in CI, so we bypass it.
+    case "$(uname -m)" in
+      x86_64|amd64) CYCLONEDX_ARCH="x64" ;;
+      aarch64|arm64) CYCLONEDX_ARCH="arm64" ;;
+      *) echo "❌ Unsupported CI architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    echo "Installing CycloneDX CLI ${CYCLONEDX_VERSION} (cyclonedx-linux-${CYCLONEDX_ARCH}) for CI environment..."
+    CYCLONEDX_BIN_DIR="${RUNNER_TEMP:-/tmp}/cyclonedx-cli"
+    mkdir -p "$CYCLONEDX_BIN_DIR"
+    curl -fsSL -o "$CYCLONEDX_BIN_DIR/cyclonedx" \
+      "https://github.com/CycloneDX/cyclonedx-cli/releases/download/${CYCLONEDX_VERSION}/cyclonedx-linux-${CYCLONEDX_ARCH}"
+    chmod +x "$CYCLONEDX_BIN_DIR/cyclonedx"
+    export PATH="$CYCLONEDX_BIN_DIR:$PATH"
   elif command -v brew >/dev/null 2>&1; then
     echo "CycloneDX CLI not found — installing via Homebrew..."
     brew install cyclonedx/cyclonedx/cyclonedx-cli


### PR DESCRIPTION
Backport of #3403 (merge commit `e29b044b`) to `release/1.1.x`, so the 1.1.5 release picks up the SBOM-step fix.

Clean cherry-pick — replaces the untrusted-Homebrew-tap CycloneDX install with a pinned direct binary download. Required before re-running the 1.1.5 release dry run (the SBOM step in `release.yml` runs from this branch's `.devenv`).

Note: not exercised by normal PR CI — validated by re-running the release dry run after merge.