### PR TITLE
fix(tests): Fix flaky webapp tests by instantiating ChromDriver per t…

### DIFF
--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -18,9 +18,9 @@ package org.operaton.bpm.run.qa.webapps;
 
 import java.net.URI;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -37,14 +37,23 @@ import org.operaton.bpm.integrationtest.util.SeleniumScreenshotExtension;
  */
 public abstract class AbstractWebappUiIT extends AbstractWebIT {
 
-  protected static WebDriver driver;
+  protected WebDriver driver;
 
   @RegisterExtension
   @SuppressWarnings("unused")
-  private final SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(driver);
+  private final SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(() -> driver);
 
-  @BeforeAll
-  static void createDriver() {
+  /**
+   * A fresh browser is created for every test method (and disposed afterwards). The webapps share
+   * a single JSESSIONID/XSRF-TOKEN pair across cockpit/tasklist/admin/welcome, so reusing one
+   * browser across tests leaks authenticated-session and CSRF-token state: the first login
+   * succeeds, but a stale JSESSIONID that outlives an in-browser cookie wipe prevents the server
+   * from re-issuing an XSRF-TOKEN, so every subsequent login is rejected. A brand-new browser
+   * guarantees each test starts from the clean state that reliably logs in.
+   */
+  @BeforeEach
+  void setUp(TestInfo testInfo) {
+    // create driver
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
         .withVerbose(true)
         .usingAnyFreePort()
@@ -57,6 +66,11 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
         .addArguments("--disable-dev-shm-usage");
 
     driver = new ChromeDriver(chromeDriverService, chromeOptions);
+
+    // create client
+    preventRaceConditions();
+    createClient(getWebappCtxPath());
+    appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());
   }
 
   public static ExpectedCondition<Boolean> currentURIIs(final URI pageURI) {
@@ -75,16 +89,11 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
     return webDriver -> webDriver.getCurrentUrl().contains(url);
   }
 
-  @BeforeEach
-  void createClient() {
-    preventRaceConditions();
-    createClient(getWebappCtxPath());
-    appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());
+  @AfterEach
+  void quitDriver() {
+    if (driver != null) {
+      driver.quit();
+      driver = null;
+    }
   }
-
-  @AfterAll
-  static void quitDriver() {
-    driver.quit();
-  }
-
 }

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
@@ -16,12 +16,10 @@
  */
 package org.operaton.bpm.run.qa.webapps;
 
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -206,10 +204,11 @@ class LoginIT extends AbstractWebappUiIT {
     wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#!/welcome")));
   }
 
+  @Override
   @BeforeEach
-  void setup(TestInfo testInfo) {
-    Optional<Method> testMethod = testInfo.getTestMethod();
-    testMethod.ifPresent(method -> this.name = method.getName());
+  void setUp(TestInfo testInfo) {
+    super.setUp(testInfo);
+    testInfo.getTestMethod().ifPresent(method -> this.name = method.getName());
   }
 
   void initLoginIT(String[] commands) {

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/AbstractWebappUiIntegrationTest.java
@@ -18,8 +18,8 @@ package org.operaton.bpm.integrationtest;
 
 import java.net.URI;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -31,13 +31,21 @@ import org.operaton.bpm.integrationtest.util.SeleniumScreenshotExtension;
 
 public abstract class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest {
 
-  protected static WebDriver driver;
+  protected WebDriver driver;
 
   @RegisterExtension
-  public SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(driver);
+  public SeleniumScreenshotExtension screenshotRule = new SeleniumScreenshotExtension(() -> driver);
 
-  @BeforeAll
-  static void createDriver() {
+  /**
+   * A fresh browser is created for every test method (and disposed afterwards). The webapps share
+   * a single JSESSIONID/XSRF-TOKEN pair across cockpit/tasklist/admin/welcome, so reusing one
+   * browser across tests leaks authenticated-session and CSRF-token state: the first login
+   * succeeds, but a stale JSESSIONID that outlives an in-browser cookie wipe prevents the server
+   * from re-issuing an XSRF-TOKEN, so every subsequent login is rejected. A brand-new browser
+   * guarantees each test starts from the clean state that reliably logs in.
+   */
+  @BeforeEach
+  void createDriver() {
 
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
             .withVerbose(true)
@@ -73,9 +81,12 @@ public abstract class AbstractWebappUiIntegrationTest extends AbstractWebIntegra
 
   }
 
-  @AfterAll
-  static void quitDriver() {
-    driver.quit();
+  @AfterEach
+  void quitDriver() {
+    if (driver != null) {
+      driver.quit();
+      driver = null;
+    }
   }
 
 }

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/LoginUiIT.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/LoginUiIT.java
@@ -56,15 +56,19 @@ class LoginUiIT extends AbstractWebappUiIntegrationTest {
         return;
       } catch (WebDriverException e) {
         last = e;
+        // clear cookies so the next attempt starts from a clean session/CSRF state
+        // instead of retrying against whatever the failed attempt left behind
+        driver.manage().deleteAllCookies();
       }
     }
     throw last;
   }
 
   void login(String appName) {
-    driver.manage().deleteAllCookies();
-
-    driver.get("%sapp/%s/default/".formatted(getAppBaseUrlAsString(), appName));
+    // each test runs in a fresh browser (see AbstractWebappUiIntegrationTest), so no cookie or
+    // storage reset is required here - the browser starts without any session or CSRF state
+    String appUrl = "%sapp/%s/default/".formatted(getAppBaseUrlAsString(), appName);
+    driver.get(appUrl);
 
     WebDriverWait loginWait = new WebDriverWait(driver, LOGIN_TIMEOUT);
 

--- a/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/util/SeleniumScreenshotExtension.java
+++ b/qa/integration-tests-webapps/src/test/java/org/operaton/bpm/integrationtest/util/SeleniumScreenshotExtension.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.function.Supplier;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -40,14 +41,13 @@ public class SeleniumScreenshotExtension implements AfterTestExecutionCallback, 
 
   private static final String OUTPUT_DIR_PROPERTY_NAME = "selenium.screenshot.directory";
   private static final Logger log = LoggerFactory.getLogger(SeleniumScreenshotExtension.class);
-  protected WebDriver webDriver;
 
-  public SeleniumScreenshotExtension(WebDriver driver) {
-    if (driver instanceof RemoteWebDriver) {
-      webDriver = new Augmenter().augment(driver);
-    } else {
-      webDriver = driver;
-    }
+  // resolved lazily so a driver that is (re)created per test - after this extension instance
+  // is constructed - is still captured for the screenshot
+  protected final Supplier<WebDriver> driverSupplier;
+
+  public SeleniumScreenshotExtension(Supplier<WebDriver> driverSupplier) {
+    this.driverSupplier = driverSupplier;
   }
 
   @Override
@@ -71,6 +71,13 @@ public class SeleniumScreenshotExtension implements AfterTestExecutionCallback, 
       return;
     }
 
+    WebDriver driver = driverSupplier.get();
+    if (driver == null) {
+      log.info("No screenshot created, because no WebDriver is available.");
+      return;
+    }
+
+    WebDriver webDriver = (driver instanceof RemoteWebDriver) ? new Augmenter().augment(driver) : driver;
     File scrFile = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.FILE);
     String now = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
     String scrFilename = "%s-%s-%s.png".formatted(context.getRequiredTestClass().getSimpleName(), context.getRequiredTestMethod().getName(), now);


### PR DESCRIPTION
…est method

The statically held ChromDriver instance caused flaky test execution, especially failing to log in

(cherry picked from commit 5bd4521e4db6873a89f1ce79d9decf9ef89ee681)