### PR TITLE
feat(connect): Add A2A protocol connector

### DIFF
--- a/bom/connect/pom.xml
+++ b/bom/connect/pom.xml
@@ -31,6 +31,11 @@
       </dependency>
       <dependency>
         <groupId>org.operaton.connect</groupId>
+        <artifactId>operaton-connect-a2a</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.operaton.connect</groupId>
         <artifactId>operaton-connect-connectors-all</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -149,6 +149,14 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- A2A protocol SDK, used by the A2A connect connector -->
+      <dependency>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-bom</artifactId>
+        <version>${version.a2a-sdk}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>

--- a/connect/a2a/README.md
+++ b/connect/a2a/README.md
@@ -81,7 +81,7 @@ strings, so `3000` and `"3000"` both work.
 | Input | Meaning |
 |---|---|
 | `operation` | **Required.** `sendSync`, `sendAsync` or `getTask`. |
-| `url` | **Required.** Either a service base URL such as `https://agent.example.com`, in which case the agent card is read from `https://agent.example.com/.well-known/agent-card.json`, or a full agent card URL ending in `.json`, which is fetched as given. |
+| `url` | **Required.** Either a service base URL such as `https://agent.example.com`, in which case the agent card is read from `https://agent.example.com/.well-known/agent-card.json`, or a full agent card URL ending in `.json`, which is fetched as given. **This locates the card only.** The endpoint actually called for A2A requests is the one the card advertises in `supportedInterfaces[].url`, so an agent whose card says `http://localhost:8000` is unusable from anywhere but its own host. If calls fail while the card fetch succeeds, check what the card advertises. |
 | `headers` | A map of HTTP headers sent with every A2A call, including the agent card fetch. This is where `Authorization` goes. |
 
 ### Message

--- a/connect/a2a/README.md
+++ b/connect/a2a/README.md
@@ -1,0 +1,329 @@
+# Operaton Connect - A2A
+
+Call an AI agent from a BPMN service task over the [Agent2Agent (A2A) protocol](https://a2a-protocol.org/),
+without writing Java.
+
+The activity stays a plain `bpmn:serviceTask`. Everything is configured with `operaton:inputParameter` and
+`operaton:outputParameter`, so a new agent call is a matter of dragging a task onto the canvas and filling in
+fields.
+
+```xml
+<serviceTask id="askAgent" name="Ask the agent">
+  <extensionElements>
+    <operaton:connector>
+      <operaton:connectorId>a2a</operaton:connectorId>
+      <operaton:inputOutput>
+        <operaton:inputParameter name="operation">sendSync</operaton:inputParameter>
+        <operaton:inputParameter name="url">${agentUrl}</operaton:inputParameter>
+        <operaton:inputParameter name="message">${question}</operaton:inputParameter>
+        <operaton:outputParameter name="answer">${text}</operaton:outputParameter>
+      </operaton:inputOutput>
+    </operaton:connector>
+  </extensionElements>
+</serviceTask>
+```
+
+- Protocol: **A2A v1.0**
+- Transport: **JSON-RPC 2.0** only (see [Limitations](#known-limitations))
+- Built on the [A2A Java SDK](https://github.com/a2aproject/a2a-java) `org.a2aproject.sdk:a2a-java-sdk-client`
+
+## Installation
+
+The connector is not part of `operaton-connect-connectors-all`, so it has to be added deliberately.
+
+1. Add the connect plugin to the engine, exactly as for the HTTP connector:
+
+   ```xml
+   <property name="processEnginePlugins">
+     <list>
+       <bean class="org.operaton.connect.plugin.impl.ConnectProcessEnginePlugin" />
+     </list>
+   </property>
+   ```
+
+2. Put `operaton-connect-a2a` and its dependencies on the engine classpath:
+
+   ```xml
+   <dependency>
+     <groupId>org.operaton.connect</groupId>
+     <artifactId>operaton-connect-a2a</artifactId>
+   </dependency>
+   ```
+
+The connector registers itself through `java.util.ServiceLoader`
+(`META-INF/services/org.operaton.connect.spi.ConnectorProvider`) under the id **`a2a`**.
+
+### Modeler support
+
+`src/main/resources/element-templates/operaton-a2a-connector.json` is an element template giving a labelled form
+for every field below. Copy it into your modeler's `resources/element-templates` directory. It validates against
+the published `@camunda/element-templates-json-schema`. Binding types use the `camunda:` prefix because that is
+what that schema defines; if your modeler build expects `operaton:`-prefixed binding types, rename them.
+
+## Operations
+
+| `operation` | What it does |
+|---|---|
+| `sendSync` | Sends the message, then polls until the task reaches a final state. For agents that answer quickly. Bounded by `waitTimeout`. |
+| `sendAsync` | Sends the message and returns immediately with the task id, context id and state. With a `callbackUrl` the agent is asked to push a notification; without one, poll with `getTask`. |
+| `getTask` | Reads the current state of a task you already know the id of. |
+
+`sendSync` polls rather than holding a server-sent-event stream open, because a stream would pin a job executor
+thread for as long as the agent takes to think. The cost is up to one `pollInterval` of extra latency.
+
+## Inputs
+
+Every input can be a literal or an expression such as `${someVariable}`. Numbers and booleans may be written as
+strings, so `3000` and `"3000"` both work.
+
+### Agent
+
+| Input | Meaning |
+|---|---|
+| `operation` | **Required.** `sendSync`, `sendAsync` or `getTask`. |
+| `url` | **Required.** Either a service base URL such as `https://agent.example.com`, in which case the agent card is read from `https://agent.example.com/.well-known/agent-card.json`, or a full agent card URL ending in `.json`, which is fetched as given. |
+| `headers` | A map of HTTP headers sent with every A2A call, including the agent card fetch. This is where `Authorization` goes. |
+
+### Message
+
+| Input | Meaning |
+|---|---|
+| `message` | The plain text to send. The easy, one-field case. |
+| `parts` | A list of maps for anything beyond plain text. See [Parts](#parts). |
+| `metadata` | A map attached to the outgoing **message**. |
+| `extensions` | A2A extension URIs the message activates, as a list or a comma-separated string. |
+| `referenceTaskIds` | Earlier task ids the agent should treat as context. |
+| `requestMetadata` | A map attached to the send **request** rather than to the message. |
+| `tenant` | The A2A tenant to scope the call to. |
+| `acceptedOutputModes` | MIME types you can handle back, e.g. `text/plain, application/json`. |
+| `historyLength` | How many earlier messages the agent should return. |
+
+### Conversation
+
+| Input | Meaning |
+|---|---|
+| `contextId` | Continues an existing conversation. Pass `${a2aContextId}` from an earlier agent task to make a multi-turn exchange span several activities. |
+| `taskId` | Required for `getTask`. On a send operation, appends the message to that existing task. |
+
+### Push notification (`sendAsync`)
+
+| Input | Meaning |
+|---|---|
+| `callbackUrl` | Where the agent POSTs the notification. Omit it to use the polling fallback instead. |
+| `callbackToken` | A token the agent echoes back, so your webhook can tell a real notification from a forged one. |
+| `callbackAuthScheme` | e.g. `Bearer`. |
+| `callbackAuthCredentials` | The credential the agent presents to your webhook. |
+
+### Timeouts
+
+Nothing is unbounded.
+
+| Input | Default | Meaning |
+|---|---|---|
+| `connectTimeout` | `10000` | TCP connect timeout in ms. |
+| `readTimeout` | `30000` | Read timeout of a single HTTP call in ms. |
+| `waitTimeout` | `120000` | Total time `sendSync` waits for a final state before raising `a2a-timeout`. |
+| `pollInterval` | `2000` | How often `sendSync` polls while waiting. |
+
+### Reliability
+
+| Input | Default | Meaning |
+|---|---|---|
+| `idempotencyKey` | none | A value stable across job retries and unique per activity instance. The element template defaults it to `${execution.getProcessInstanceId()}-${execution.getActivityInstanceId()}`. |
+| `reattachOnRetry` | `true` | Look for a task an earlier failed attempt already created before sending again. |
+| `maxVariableSize` | `65536` | The largest value written into a process variable. |
+| `messageId` | derived | Overrides the derived message id. Rarely needed. |
+| `includeHistory` | `false` | Whether to expose the conversation history as an output. |
+
+### Parts
+
+`parts` is a list of maps, each with a `type`. Any part may also carry a `metadata` map.
+
+```xml
+<operaton:inputParameter name="parts">
+  <operaton:list>
+    <operaton:map>
+      <operaton:entry key="type">file</operaton:entry>
+      <operaton:entry key="uri">${documentUrl}</operaton:entry>
+      <operaton:entry key="mimeType">application/pdf</operaton:entry>
+      <operaton:entry key="name">invoice.pdf</operaton:entry>
+    </operaton:map>
+  </operaton:list>
+</operaton:inputParameter>
+```
+
+| `type` | Keys |
+|---|---|
+| `text` | `text` |
+| `file` | either `uri`, or inline `bytes` as base64, plus optional `mimeType` and `name` |
+| `data` | `data`, any structured value |
+
+A2A has no input-side artifacts: artifacts are produced by the agent, and `parts` is the outgoing counterpart.
+
+## Outputs
+
+Map any of these with `<operaton:outputParameter name="yourVariable">${output}</operaton:outputParameter>`.
+
+| Output | Meaning |
+|---|---|
+| `text` | The agent's answer as plain text: the text parts of the final status message joined by newlines. The usual one to map. |
+| `statusMessage` | The full final message as a map, including all parts. |
+| `artifacts` | **All** artifacts the agent produced, as a list of maps, each with its `parts`. |
+| `artifactText` | The text parts of all artifacts joined by newlines. |
+| `task` | The whole task as a map: `id`, `contextId`, `status`, `artifacts`, `metadata`. |
+| `taskId` | The A2A task id. Needed to correlate a push notification. |
+| `contextId` | The A2A context id. Pass to a later activity to continue the conversation. |
+| `state` | One of `TASK_STATE_SUBMITTED`, `TASK_STATE_WORKING`, `TASK_STATE_INPUT_REQUIRED`, `TASK_STATE_AUTH_REQUIRED`, `TASK_STATE_COMPLETED`, `TASK_STATE_CANCELED`, `TASK_STATE_FAILED`, `TASK_STATE_REJECTED`. |
+| `taskMetadata` | Metadata the agent returned on the task. |
+| `messageMetadata` | Metadata the agent returned on the final message. |
+| `history` | The conversation history, only when `includeHistory` is `true`. |
+| `truncated` | `true` when a value was too large for a process variable. See [Large payloads](#large-payloads). |
+
+## Errors
+
+| Error code | When |
+|---|---|
+| `a2a-task-failed` | The task ended in `TASK_STATE_FAILED`. |
+| `a2a-task-rejected` | The task ended in `TASK_STATE_REJECTED`. |
+| `a2a-task-canceled` | The task ended in `TASK_STATE_CANCELED`. |
+| `a2a-auth-required` | The agent needs credentials it was not given. |
+| `a2a-timeout` | `sendSync` gave up after `waitTimeout`. |
+| `a2a-protocol-error` | A permanent protocol or transport failure, such as HTTP 4xx or a malformed response. |
+
+Catch them with an error boundary event:
+
+```xml
+<error id="a2aTaskFailedError" name="A2A task failed" errorCode="a2a-task-failed" />
+...
+<boundaryEvent id="agentFailed" attachedToRef="askAgent">
+  <errorEventDefinition errorRef="a2aTaskFailedError" />
+</boundaryEvent>
+```
+
+**Retryable versus terminal.** Connection resets, read timeouts, HTTP 408, 425, 429 and 5xx are left as a
+`ConnectorRequestException`, so the job executor retries and eventually raises an incident. Only the codes above
+become a `BpmnError`.
+
+**Output parameters are not mapped when an error is thrown.** The task id is therefore included in the error
+message, so a process can still find the task with `getTask`.
+
+**`TASK_STATE_INPUT_REQUIRED` is deliberately not an error.** The activity completes normally with all outputs
+mapped, so you can branch on `${a2aState}` with a gateway and send the follow-up from a second agent task,
+passing the same `contextId` and `taskId`.
+
+## Webhook correlation for `sendAsync`
+
+The connector does not receive push notifications; that endpoint is yours. What it guarantees is that everything
+needed to correlate is committed as a process variable before the process reaches its wait state.
+
+1. Model `sendAsync` with `callbackUrl` pointing at your endpoint, and map `taskId` to a variable such as
+   `a2aTaskId`.
+2. Let the process wait at a receive task.
+3. In your endpoint, verify the `callbackToken`, then correlate:
+
+   ```java
+   runtimeService.createMessageCorrelation("a2aCallback")
+                 .processInstanceVariableEquals("a2aTaskId", taskIdFromCallback)
+                 .correlateWithResult();
+   ```
+
+4. Attach a timer boundary event to the receive task as the backstop for a notification that never arrives.
+
+**Handle the early callback.** A fast agent can call your webhook before the process instance has committed and
+reached the receive task. Correlation then finds nothing. Your endpoint must treat "no matching execution" as a
+retryable condition and try again with a short backoff, rather than dropping the notification.
+
+See `src/test/resources/org/operaton/connect/a2a/examples/a2a-send-async.bpmn`.
+
+## Large payloads
+
+Process variables live in `ACT_RU_VARIABLE` and are copied into `ACT_HI_DETAIL`. A multi-megabyte base64 blob
+written there is copied on every update, bloats the history tables and slows down every query that touches the
+instance. So:
+
+- **Returned files.** A file that arrives as a URI is passed through as a URI, which costs nothing. A file that
+  arrives inline is only passed through while its base64 is at most `maxVariableSize`. Above that, the part keeps
+  its `mimeType`, `name` and `sizeBytes` and gains `truncated: true`, but the bytes are dropped, and the
+  top-level `truncated` output becomes `true`.
+- **Returned text.** Text longer than `maxVariableSize` is cut short with a marker.
+- **Sent files.** An inline `bytes` part larger than `maxVariableSize` is rejected outright rather than silently
+  truncated, because sending half a file is worse than failing.
+
+**The trade-off.** The alternative would be to store large payloads somewhere else automatically, which means
+picking a blob store and owning its lifecycle, retention and cleanup, and giving the engine a new external
+dependency. That decision belongs to the process application, not to a connector. So the connector refuses to
+put the payload in the database and tells you it did, and the intended handling is to have the agent return a
+URI, or to fetch the bytes yourself from a delegate or external task when you need them.
+
+If you genuinely want inline bytes in a variable, raise `maxVariableSize` deliberately and size your database
+accordingly.
+
+## Idempotency, and what it cannot promise
+
+Operaton retries failed jobs, and a duplicate agent run costs money and may have side effects. Two things make
+this less likely:
+
+1. **A deterministic message id**, derived from `idempotencyKey`. An agent that deduplicates on `messageId` will
+   not run the work twice.
+2. **A reattach probe.** When no `contextId` is supplied, one is derived from `idempotencyKey`, which means the
+   context holds exactly one task per activity instance. Before sending, the connector calls `ListTasks` for that
+   context and, if it finds a task, reattaches with `GetTask` instead of sending again. If the agent does not
+   implement `ListTasks`, the probe is skipped silently. If the probe fails for a transport reason, the job is
+   retried rather than risking a duplicate send.
+
+**Be aware of the honest limits.** A2A does not let a client choose the task id: `MessageSendParams` has no field
+for it, and the agent assigns `Task.id` when it creates the task. A `Message.taskId` refers to a task that
+already exists. Combined with the fact that an Operaton job retry rolls back the transaction, and with it any
+variable the previous attempt wrote, the connector cannot simply remember the task id it got last time. So
+exactly-once cannot be guaranteed by the client alone. For an expensive agent, prefer:
+
+- `sendAsync` plus a receive task, so the send is committed the moment it succeeds, or
+- `operaton:failedJobRetryTimeCycle="R0/PT0S"` on the service task, so a failed send never silently re-dispatches
+  and instead raises an incident for a human.
+
+Set `reattachOnRetry` to `false` to skip the probe and its extra round trip.
+
+## Security
+
+- Header values are resolvable from process variables or engine configuration, so no secret has to sit in the
+  diagram.
+- Header **values** and request bodies are never logged. Header **names** are logged at debug level, so a missing
+  `Authorization` can be diagnosed without leaking the token.
+- Validate the `callbackToken` in your webhook before correlating.
+
+## Known limitations
+
+- **JSON-RPC only.** gRPC and HTTP+JSON are not registered as transports, and the client's transport preference
+  is set to win over the agent card, so an agent that only speaks gRPC is not supported.
+- **No streaming.** `SendStreamingMessage` and `SubscribeToTask` are not used, and the HTTP client's
+  server-sent-event methods throw `UnsupportedOperationException`. `sendSync` polls instead. Incremental artifact
+  chunks are therefore not observed; the connector reads the assembled task.
+- **Not in `connectors-all`.** That artifact shades its dependencies and relocates `org.apache`, which is not a
+  safe thing to do to protobuf. Add this module explicitly.
+- **No WildFly distro module.** Wiring this into `distro/wildfly` means shipping protobuf, Guava and
+  `proto-google-common-protos` as JBoss modules, which is a decision for the distribution, not for this module.
+  On WildFly, deploy the connector with your process application for now.
+- **Agent card caching.** Clients are cached per agent URL, headers and timeouts, up to 64 entries, after which
+  the cache is emptied wholesale. A card change is not noticed until the cache is cleared or the engine restarts.
+- **`maxVariableSize` counts characters** for text, not UTF-8 bytes, so a multi-byte string can exceed the limit
+  in bytes by up to a factor of four.
+
+## Examples
+
+Under `src/test/resources/org/operaton/connect/a2a/examples/`:
+
+| File | Shows |
+|---|---|
+| `a2a-send-sync.bpmn` | `sendSync` with an error boundary event, headers from variables, and metadata |
+| `a2a-send-async.bpmn` | `sendAsync` with a push notification, a receive task, a file part by reference, and a timer boundary event |
+| `a2a-poll-fallback.bpmn` | `sendAsync` without a callback, then `getTask` on a timer loop, for agents without `capabilities.pushNotifications` |
+
+## Design
+
+The A2A SDK is used behind `A2aAgent`, a small interface whose methods only take and return strings, maps and
+lists. `SdkA2aAgent` is the only class that imports `org.a2aproject.sdk`, so an SDK or protocol bump touches it
+and `TimeoutAwareA2AHttpClient` and nothing else.
+
+`TimeoutAwareA2AHttpClient` exists because the SDK's own `JdkA2AHttpClient` never sets a per-request timeout, and
+neither `A2AHttpClient` nor its builders expose one. Without it an unresponsive agent would hold a job executor
+thread until the OS gave up on the socket.

--- a/connect/a2a/README.md
+++ b/connect/a2a/README.md
@@ -166,7 +166,7 @@ Map any of these with `<operaton:outputParameter name="yourVariable">${output}</
 
 | Output | Meaning |
 |---|---|
-| `text` | The agent's answer as plain text: the text parts of the final status message joined by newlines. The usual one to map. |
+| `text` | The agent's answer as plain text, and the usual one to map. Taken from the text parts of the final status message; when the agent closes the task without one and answers only with artifacts, which is common (google-adk agents do it), it falls back to the artifact text so the one-field case stays one field. |
 | `statusMessage` | The full final message as a map, including all parts. |
 | `artifacts` | **All** artifacts the agent produced, as a list of maps, each with its `parts`. |
 | `artifactText` | The text parts of all artifacts joined by newlines. |
@@ -267,9 +267,14 @@ this less likely:
    not run the work twice.
 2. **A reattach probe.** When no `contextId` is supplied, one is derived from `idempotencyKey`, which means the
    context holds exactly one task per activity instance. Before sending, the connector calls `ListTasks` for that
-   context and, if it finds a task, reattaches with `GetTask` instead of sending again. If the agent does not
-   implement `ListTasks`, the probe is skipped silently. If the probe fails for a transport reason, the job is
-   retried rather than risking a duplicate send.
+   context and, if it finds a task, reattaches with `GetTask` instead of sending again. Only a genuine transport
+   failure during the probe (an `IOException`, or HTTP 408/425/429/5xx) fails the job; anything else degrades to a
+   normal send.
+
+   **`ListTasks` is optional in A2A and many agents do not implement it**, answering `-32601 Method not found`.
+   That is expected and costs you only the extra round trip, but it does mean the probe is no protection on such
+   an agent, and the deterministic `messageId` is all that is left. Verified against a google-adk agent, which
+   does not implement `ListTasks` but does honour a client-supplied `contextId`.
 
 **Be aware of the honest limits.** A2A does not let a client choose the task id: `MessageSendParams` has no field
 for it, and the agent assigns `Task.id` when it creates the task. A `Message.taskId` refers to a task that

--- a/connect/a2a/README.md
+++ b/connect/a2a/README.md
@@ -50,6 +50,13 @@ The connector is not part of `operaton-connect-connectors-all`, so it has to be 
    </dependency>
    ```
 
+### Where the connector can be used
+
+Operaton's `ConnectorParseListener` hooks five element types, so the same `operaton:connector` block works on a
+**service task**, a **send task**, a **business rule task**, and on a **message end event** or **message
+intermediate throw event**. The element template offers the first three; the two event types need a
+`messageEventDefinition`, which a template's `appliesTo` cannot express, so configure those by hand.
+
 The connector registers itself through `java.util.ServiceLoader`
 (`META-INF/services/org.operaton.connect.spi.ConnectorProvider`) under the id **`a2a`**.
 

--- a/connect/a2a/pom.xml
+++ b/connect/a2a/pom.xml
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>operaton-connect-root</artifactId>
+    <groupId>org.operaton.connect</groupId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>operaton-connect-a2a</artifactId>
+  <name>Operaton - Connect - A2A</name>
+  <description>${project.name}</description>
+  <dependencyManagement>
+    <dependencies>
+      <!-- imported for the H2 driver version, used by the in-memory engine tests -->
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-database-settings</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.operaton.connect</groupId>
+      <artifactId>operaton-connect-core</artifactId>
+    </dependency>
+    <!-- The connector raises BpmnError so that agent failures can be handled with error boundary
+         events. The engine is always present when the connector is invoked by the connect plugin,
+         so it is a provided dependency and never shipped with this module. -->
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.a2aproject.sdk</groupId>
+      <artifactId>a2a-java-sdk-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine</artifactId>
+      <classifier>junit6</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine-plugin-connect</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <!-- check for api differences between latest minor release -->
+  <profiles>
+    <profile>
+      <id>check-api-compatibility</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>clirr-maven-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>org/operaton/connect/a2a/impl/**</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aConnector.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aConnector.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a;
+
+import org.operaton.connect.spi.Connector;
+
+/**
+ * A connector which calls an AI agent over the
+ * <a href="https://a2a-protocol.org/">Agent2Agent (A2A) protocol</a>.
+ *
+ * <p>
+ * The connector is meant to be used declaratively from a BPMN {@code serviceTask}, so that adding an
+ * agent call to a process does not require writing Java:
+ * </p>
+ *
+ * <pre>{@code
+ * <serviceTask id="askAgent">
+ *   <extensionElements>
+ *     <operaton:connector>
+ *       <operaton:connectorId>a2a</operaton:connectorId>
+ *       <operaton:inputOutput>
+ *         <operaton:inputParameter name="operation">sendSync</operaton:inputParameter>
+ *         <operaton:inputParameter name="url">https://agent.example.com</operaton:inputParameter>
+ *         <operaton:inputParameter name="message">${question}</operaton:inputParameter>
+ *         <operaton:outputParameter name="answer">${text}</operaton:outputParameter>
+ *       </operaton:inputOutput>
+ *     </operaton:connector>
+ *   </extensionElements>
+ * </serviceTask>
+ * }</pre>
+ *
+ * @see A2aRequest for the supported input parameters
+ * @see A2aResponse for the produced output parameters
+ * @since 2.2
+ */
+public interface A2aConnector extends Connector<A2aRequest> {
+
+  /** The connector id to reference from {@code operaton:connectorId}. */
+  String ID = "a2a";
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aConnectorProvider.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aConnectorProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a;
+
+import org.operaton.connect.spi.ConnectorProvider;
+
+/**
+ * Provides the {@link A2aConnector}. Registered through {@link java.util.ServiceLoader}.
+ *
+ * @since 2.2
+ */
+public interface A2aConnectorProvider extends ConnectorProvider {
+
+  @Override
+  A2aConnector createConnectorInstance();
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aRequest.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aRequest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a;
+
+import org.operaton.connect.spi.ConnectorRequest;
+
+/**
+ * The input parameters of an {@link A2aConnector} call.
+ *
+ * <p>
+ * Every parameter can be set from BPMN as an {@code operaton:inputParameter}, either as a literal value
+ * or as an expression resolving against process variables. Parameters not listed here are ignored.
+ * </p>
+ *
+ * @since 2.2
+ */
+public interface A2aRequest extends ConnectorRequest<A2aResponse> {
+
+  /** Which A2A call to make: {@link #OPERATION_SEND_SYNC}, {@link #OPERATION_SEND_ASYNC} or {@link #OPERATION_GET_TASK}. */
+  String PARAM_OPERATION = "operation";
+
+  /** Send the message and wait for the task to reach a final state. */
+  String OPERATION_SEND_SYNC = "sendSync";
+  /** Send the message, register a push notification callback and return immediately. */
+  String OPERATION_SEND_ASYNC = "sendAsync";
+  /** Fetch the current state of a task that is already known. */
+  String OPERATION_GET_TASK = "getTask";
+
+  /**
+   * The agent location. Both forms are accepted:
+   * <ul>
+   *   <li>a service base URL, e.g. {@code https://agent.example.com} - the agent card is then read from
+   *       {@code https://agent.example.com/.well-known/agent-card.json}</li>
+   *   <li>an explicit agent card URL ending in {@code .json}, which is fetched as-is</li>
+   * </ul>
+   */
+  String PARAM_URL = "url";
+
+  /** A {@code Map<String, String>} of HTTP headers sent with every A2A call, e.g. {@code Authorization}. */
+  String PARAM_HEADERS = "headers";
+
+  /** The plain text of the message to send. The simple, one-field case. */
+  String PARAM_MESSAGE = "message";
+
+  /**
+   * Additional message parts, as a {@code List<Map<String, Object>>}. Each entry needs a {@code type} of
+   * {@code text}, {@code file} or {@code data}:
+   * <ul>
+   *   <li>{@code {type: "text", text: "..."}}</li>
+   *   <li>{@code {type: "file", uri: "https://...", mimeType: "application/pdf", name: "report.pdf"}}</li>
+   *   <li>{@code {type: "file", bytes: "<base64>", mimeType: "...", name: "..."}}</li>
+   *   <li>{@code {type: "data", data: {...}}}</li>
+   * </ul>
+   * A {@code metadata} map may be added to any part.
+   */
+  String PARAM_PARTS = "parts";
+
+  /** A {@code Map<String, Object>} of metadata attached to the outgoing message. */
+  String PARAM_METADATA = "metadata";
+
+  /** A {@code List<String>} of A2A extension URIs the message activates. */
+  String PARAM_EXTENSIONS = "extensions";
+
+  /** A {@code List<String>} of task ids the agent should treat as context for this message. */
+  String PARAM_REFERENCE_TASK_IDS = "referenceTaskIds";
+
+  /** Continues an existing conversation. Set this to span a multi-turn exchange over several activities. */
+  String PARAM_CONTEXT_ID = "contextId";
+
+  /** Continues an existing task, or reattaches to one. Also used as the target of {@link #OPERATION_GET_TASK}. */
+  String PARAM_TASK_ID = "taskId";
+
+  /** Overrides the deterministic message id. Rarely needed. */
+  String PARAM_MESSAGE_ID = "messageId";
+
+  /** A {@code Map<String, Object>} of metadata attached to the send request rather than to the message. */
+  String PARAM_REQUEST_METADATA = "requestMetadata";
+
+  /** The A2A tenant to scope the call to. */
+  String PARAM_TENANT = "tenant";
+
+  /** A {@code List<String>} of MIME types the process can accept back, e.g. {@code text/plain}. */
+  String PARAM_ACCEPTED_OUTPUT_MODES = "acceptedOutputModes";
+
+  /** How many past messages of the conversation the agent should return. */
+  String PARAM_HISTORY_LENGTH = "historyLength";
+
+  /** Where the agent should POST push notifications. Required for {@link #OPERATION_SEND_ASYNC}. */
+  String PARAM_CALLBACK_URL = "callbackUrl";
+
+  /** A token the agent echoes back in the push notification, so the receiver can validate it. */
+  String PARAM_CALLBACK_TOKEN = "callbackToken";
+
+  /** The authentication scheme the agent should use when calling {@link #PARAM_CALLBACK_URL}. */
+  String PARAM_CALLBACK_AUTH_SCHEME = "callbackAuthScheme";
+
+  /** The credentials the agent should present when calling {@link #PARAM_CALLBACK_URL}. */
+  String PARAM_CALLBACK_AUTH_CREDENTIALS = "callbackAuthCredentials";
+
+  /** Connect timeout in milliseconds. Defaults to {@value #DEFAULT_CONNECT_TIMEOUT_MS}. */
+  String PARAM_CONNECT_TIMEOUT = "connectTimeout";
+
+  /** Read timeout of a single HTTP call in milliseconds. Defaults to {@value #DEFAULT_READ_TIMEOUT_MS}. */
+  String PARAM_READ_TIMEOUT = "readTimeout";
+
+  /**
+   * Total time in milliseconds {@link #OPERATION_SEND_SYNC} waits for a final task state before raising
+   * {@code a2a-timeout}. Defaults to {@value #DEFAULT_WAIT_TIMEOUT_MS}.
+   */
+  String PARAM_WAIT_TIMEOUT = "waitTimeout";
+
+  /** How often {@link #OPERATION_SEND_SYNC} polls while waiting, in milliseconds. Defaults to {@value #DEFAULT_POLL_INTERVAL_MS}. */
+  String PARAM_POLL_INTERVAL = "pollInterval";
+
+  /**
+   * Whether to look for a task a previous, rolled back attempt already created before sending again.
+   * Defaults to {@code true}. See the module README for what this can and cannot guarantee.
+   */
+  String PARAM_REATTACH_ON_RETRY = "reattachOnRetry";
+
+  /**
+   * A value that is stable across job retries of the same activity and unique per activity instance. It is
+   * hashed into the message id and, when no {@link #PARAM_CONTEXT_ID} is given, into the context id.
+   * The element template defaults it to {@code ${execution.getProcessInstanceId()}-${execution.getActivityInstanceId()}}.
+   */
+  String PARAM_IDEMPOTENCY_KEY = "idempotencyKey";
+
+  /**
+   * The largest value in bytes that is written into a process variable. Larger file parts are replaced by a
+   * reference and larger texts are truncated. Defaults to {@value #DEFAULT_MAX_VARIABLE_SIZE}.
+   */
+  String PARAM_MAX_VARIABLE_SIZE = "maxVariableSize";
+
+  /** Whether to expose the conversation history as an output. Defaults to {@code false}. */
+  String PARAM_INCLUDE_HISTORY = "includeHistory";
+
+  int DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+  int DEFAULT_READ_TIMEOUT_MS = 30_000;
+  int DEFAULT_WAIT_TIMEOUT_MS = 120_000;
+  int DEFAULT_POLL_INTERVAL_MS = 2_000;
+  int DEFAULT_MAX_VARIABLE_SIZE = 64 * 1024;
+
+  /**
+   * Sets the operation to perform.
+   *
+   * @param operation one of {@link #OPERATION_SEND_SYNC}, {@link #OPERATION_SEND_ASYNC}, {@link #OPERATION_GET_TASK}
+   * @return this request
+   */
+  A2aRequest operation(String operation);
+
+  /**
+   * Sets the agent location.
+   *
+   * @param url a service base URL or an agent card URL
+   * @return this request
+   */
+  A2aRequest url(String url);
+
+  /**
+   * Adds a single HTTP header to send with every A2A call.
+   *
+   * @param field the header name
+   * @param value the header value
+   * @return this request
+   */
+  A2aRequest header(String field, String value);
+
+  /**
+   * Sets the plain text of the message to send.
+   *
+   * @param message the message text
+   * @return this request
+   */
+  A2aRequest message(String message);
+
+  /**
+   * Sets the task to continue, reattach to, or query.
+   *
+   * @param taskId the A2A task id
+   * @return this request
+   */
+  A2aRequest taskId(String taskId);
+
+  /**
+   * Sets the conversation to continue.
+   *
+   * @param contextId the A2A context id
+   * @return this request
+   */
+  A2aRequest contextId(String contextId);
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aResponse.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aResponse.java
@@ -29,8 +29,10 @@ import org.operaton.connect.spi.ConnectorResponse;
 public interface A2aResponse extends ConnectorResponse {
 
   /**
-   * The agent's answer as plain text: the text parts of the final status message joined by newlines. Empty
-   * when the agent answered only with artifacts or non-text parts.
+   * The agent's answer as plain text: the text parts of the final status message joined by newlines. When the
+   * agent closes the task without a status message and answers only with artifacts, this falls back to
+   * {@link #PARAM_ARTIFACT_TEXT}, so the simple case stays a single field whichever way the agent answers.
+   * Empty only when there is no text anywhere.
    */
   String PARAM_TEXT = "text";
 

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aResponse.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/A2aResponse.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a;
+
+import java.util.List;
+import java.util.Map;
+
+import org.operaton.connect.spi.ConnectorResponse;
+
+/**
+ * The output parameters of an {@link A2aConnector} call. Each one can be mapped to a process variable with an
+ * {@code operaton:outputParameter}, for example {@code <operaton:outputParameter name="answer">${text}</operaton:outputParameter>}.
+ *
+ * @since 2.2
+ */
+public interface A2aResponse extends ConnectorResponse {
+
+  /**
+   * The agent's answer as plain text: the text parts of the final status message joined by newlines. Empty
+   * when the agent answered only with artifacts or non-text parts.
+   */
+  String PARAM_TEXT = "text";
+
+  /** The full final status message, including all of its parts, as a {@code Map}. */
+  String PARAM_STATUS_MESSAGE = "statusMessage";
+
+  /** All artifacts the agent produced, as a {@code List<Map>}, each with its {@code parts}. */
+  String PARAM_ARTIFACTS = "artifacts";
+
+  /** The text parts of all artifacts joined by newlines. A convenience for the common single-text-artifact case. */
+  String PARAM_ARTIFACT_TEXT = "artifactText";
+
+  /** The whole A2A task as a {@code Map}: id, contextId, status, artifacts and metadata. */
+  String PARAM_TASK = "task";
+
+  /** The A2A task id. Needed to correlate a push notification back to the waiting process instance. */
+  String PARAM_TASK_ID = "taskId";
+
+  /** The A2A context id. Pass it to a later activity to continue the same conversation. */
+  String PARAM_CONTEXT_ID = "contextId";
+
+  /**
+   * The A2A task state, one of {@code TASK_STATE_SUBMITTED}, {@code TASK_STATE_WORKING},
+   * {@code TASK_STATE_INPUT_REQUIRED}, {@code TASK_STATE_AUTH_REQUIRED}, {@code TASK_STATE_COMPLETED},
+   * {@code TASK_STATE_CANCELED}, {@code TASK_STATE_FAILED} or {@code TASK_STATE_REJECTED}.
+   */
+  String PARAM_STATE = "state";
+
+  /** Metadata the agent returned on the task, as a {@code Map}. */
+  String PARAM_TASK_METADATA = "taskMetadata";
+
+  /** Metadata the agent returned on the final status message, as a {@code Map}. */
+  String PARAM_MESSAGE_METADATA = "messageMetadata";
+
+  /** The conversation history as a {@code List<Map>}, present only when {@code includeHistory} is set. */
+  String PARAM_HISTORY = "history";
+
+  /**
+   * {@code true} when at least one value was too large for a process variable and was truncated or replaced
+   * by a reference. See {@link A2aRequest#PARAM_MAX_VARIABLE_SIZE}.
+   */
+  String PARAM_TRUNCATED = "truncated";
+
+  /** @return the agent's answer as plain text, never {@code null} */
+  String getText();
+
+  /** @return the A2A task id, or {@code null} if the agent replied with a message instead of a task */
+  String getTaskId();
+
+  /** @return the A2A context id, or {@code null} if the agent did not provide one */
+  String getContextId();
+
+  /** @return the A2A task state, or {@code null} if the agent replied with a message instead of a task */
+  String getState();
+
+  /** @return the artifacts the agent produced, never {@code null} */
+  List<Map<String, Object>> getArtifacts();
+
+  /** @return {@code true} if any value was truncated or replaced by a reference */
+  boolean isTruncated();
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aAgent.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aAgent.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Everything the connector needs from an A2A agent, expressed without any reference to the A2A SDK.
+ *
+ * <p>
+ * This is the seam that keeps a protocol or SDK version bump contained: {@link SdkA2aAgent} is the only
+ * implementation and the only place that imports {@code org.a2aproject.sdk}. Everything on this interface is
+ * either a {@code String}, a number, or a plain {@code Map}/{@code List} that can be written straight into a
+ * process variable.
+ * </p>
+ */
+public interface A2aAgent extends AutoCloseable {
+
+  /**
+   * How to reach an agent. Two agents are considered the same, and share a cached client, when their configs
+   * are equal, so this record deliberately has value semantics.
+   *
+   * @param url the agent base URL or agent card URL
+   * @param headers HTTP headers to send with every call; values are secret and never logged
+   * @param connectTimeoutMs connect timeout in milliseconds
+   * @param readTimeoutMs read timeout of a single HTTP call in milliseconds
+   * @param maxVariableSize largest value in bytes to put into a process variable
+   */
+  record Config(String url,
+                Map<String, String> headers,
+                int connectTimeoutMs,
+                int readTimeoutMs,
+                int maxVariableSize) {
+  }
+
+  /**
+   * A message to send to an agent.
+   *
+   * @param messageId the client-chosen message id; deterministic so that an agent can deduplicate a retry
+   * @param contextId the conversation to continue, or {@code null} to let the agent start one
+   * @param taskId the task to continue, or {@code null} to let the agent create one
+   * @param text the plain text of the message, or {@code null}
+   * @param parts additional parts, each a map with a {@code type} of {@code text}, {@code file} or {@code data}
+   * @param metadata metadata to attach to the message
+   * @param extensions A2A extension URIs the message activates
+   * @param referenceTaskIds tasks the agent should treat as context
+   * @param requestMetadata metadata to attach to the send request rather than to the message
+   * @param tenant the tenant to scope the call to, or {@code null}
+   * @param acceptedOutputModes MIME types the caller can accept back
+   * @param historyLength how much conversation history to return, or {@code null}
+   * @param callbackUrl where the agent should POST push notifications, or {@code null} for none
+   * @param callbackToken a token the agent echoes back in the push notification
+   * @param callbackAuthScheme the authentication scheme for the callback
+   * @param callbackAuthCredentials the credentials for the callback
+   * @param returnImmediately whether the agent may return before the task reaches a final state
+   */
+  record SendCommand(String messageId,
+                     String contextId,
+                     String taskId,
+                     String text,
+                     List<Map<String, Object>> parts,
+                     Map<String, Object> metadata,
+                     List<String> extensions,
+                     List<String> referenceTaskIds,
+                     Map<String, Object> requestMetadata,
+                     String tenant,
+                     List<String> acceptedOutputModes,
+                     Integer historyLength,
+                     String callbackUrl,
+                     String callbackToken,
+                     String callbackAuthScheme,
+                     String callbackAuthCredentials,
+                     boolean returnImmediately) {
+  }
+
+  /**
+   * The state of an A2A task, already flattened into values that can be written to process variables.
+   *
+   * @param taskId the task id, or {@code null} when the agent answered with a bare message
+   * @param contextId the context id, or {@code null}
+   * @param state the {@code TASK_STATE_*} name, or {@code null} when the agent answered with a bare message
+   * @param statusMessage the final status message including its parts, or {@code null}
+   * @param artifacts every artifact the agent produced, never {@code null}
+   * @param taskMetadata metadata on the task, never {@code null}
+   * @param history the conversation history, never {@code null}
+   * @param truncated whether any value was truncated or replaced by a reference to stay within
+   *        {@link Config#maxVariableSize()}
+   */
+  record TaskSnapshot(String taskId,
+                      String contextId,
+                      String state,
+                      Map<String, Object> statusMessage,
+                      List<Map<String, Object>> artifacts,
+                      Map<String, Object> taskMetadata,
+                      List<Map<String, Object>> history,
+                      boolean truncated) {
+  }
+
+  /**
+   * Sends a message to the agent.
+   *
+   * @param command what to send
+   * @return the task as it stands when the agent responds, which may not be a final state
+   * @throws A2aCallException if the call fails
+   */
+  TaskSnapshot send(SendCommand command);
+
+  /**
+   * Fetches the current state of a task.
+   *
+   * @param taskId the task to fetch
+   * @param historyLength how much conversation history to return, or {@code null} for the agent's default
+   * @return the current state of the task
+   * @throws A2aCallException if the call fails, including when the agent does not know the task
+   */
+  TaskSnapshot getTask(String taskId, Integer historyLength);
+
+  /**
+   * Looks for the most recent task in a context, so that a retry can reattach to a task an earlier attempt
+   * already created instead of dispatching a second one.
+   *
+   * @param contextId the context to search
+   * @return the id of the most recent task in that context, or empty if there is none or if the agent does not
+   *         implement {@code ListTasks}
+   */
+  Optional<String> findLatestTaskId(String contextId);
+
+  @Override
+  void close();
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aCallException.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aCallException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+/**
+ * A failed A2A call, classified as either worth retrying or permanent.
+ *
+ * <p>
+ * The distinction decides what the process sees: a retryable failure is turned into a
+ * {@link org.operaton.connect.ConnectorRequestException} so the job executor retries it, while a permanent
+ * failure becomes a {@code BpmnError} with code {@code a2a-protocol-error} that an error boundary event can
+ * catch. Classification happens in {@link SdkA2aAgent}, the only class that sees SDK exception types.
+ * </p>
+ */
+public class A2aCallException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final boolean retryable;
+
+  public A2aCallException(String message, Throwable cause, boolean retryable) {
+    super(message, cause);
+    this.retryable = retryable;
+  }
+
+  /**
+   * @return {@code true} if the call failed for a reason that may go away on its own, such as a connection
+   *         reset, a timeout, an HTTP 429 or an HTTP 5xx
+   */
+  public boolean isRetryable() {
+    return retryable;
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorImpl.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorImpl.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.operaton.connect.a2a.A2aConnector;
+import org.operaton.connect.a2a.A2aRequest;
+import org.operaton.connect.a2a.A2aResponse;
+import org.operaton.connect.impl.AbstractConnector;
+
+import static org.operaton.connect.a2a.impl.A2aConnectorLogger.LOG;
+
+/**
+ * Runs one A2A operation per service task.
+ *
+ * <p>
+ * The three operations differ only in how long they stay: {@code sendAsync} sends and leaves, {@code sendSync}
+ * sends and then polls until the task settles or the wait budget runs out, and {@code getTask} only reads.
+ * All three finish by handing the resulting task to {@link A2aResponseImpl} for output mapping, and let
+ * {@link A2aErrors} decide whether the process sees a {@code BpmnError}, a retry, or normal outputs.
+ * </p>
+ */
+public class A2aConnectorImpl extends AbstractConnector<A2aRequest, A2aResponse> implements A2aConnector {
+
+  /**
+   * Clients are cached because building one reads the agent card over HTTP, which is not something to do on
+   * every process instance.
+   */
+  private static final int MAX_CACHED_AGENTS = 64;
+
+  private final Map<A2aAgent.Config, A2aAgent> agents = new ConcurrentHashMap<>();
+
+  private Function<A2aAgent.Config, A2aAgent> agentFactory = SdkA2aAgent::new;
+
+  public A2aConnectorImpl() {
+    super(A2aConnector.ID);
+  }
+
+  public A2aConnectorImpl(String connectorId) {
+    super(connectorId);
+  }
+
+  @Override
+  public A2aRequest createRequest() {
+    return new A2aRequestImpl(this);
+  }
+
+  @Override
+  public A2aResponse execute(A2aRequest request) {
+    String operation = A2aParams.string(request, A2aRequest.PARAM_OPERATION);
+    if (operation == null) {
+      throw LOG.operationRequired();
+    }
+    String url = A2aParams.string(request, A2aRequest.PARAM_URL);
+    if (url == null) {
+      throw LOG.urlRequired();
+    }
+
+    int maxVariableSize = A2aParams.integer(request, A2aRequest.PARAM_MAX_VARIABLE_SIZE,
+        A2aRequest.DEFAULT_MAX_VARIABLE_SIZE);
+    Map<String, String> headers = A2aParams.stringMap(request, A2aRequest.PARAM_HEADERS);
+    if (!headers.isEmpty()) {
+      LOG.headersSet(String.join(", ", headers.keySet()));
+    }
+
+    A2aAgent.Config config = new A2aAgent.Config(url,
+        headers,
+        A2aParams.integer(request, A2aRequest.PARAM_CONNECT_TIMEOUT, A2aRequest.DEFAULT_CONNECT_TIMEOUT_MS),
+        A2aParams.integer(request, A2aRequest.PARAM_READ_TIMEOUT, A2aRequest.DEFAULT_READ_TIMEOUT_MS),
+        maxVariableSize);
+    A2aAgent agent = agentFor(config);
+
+    A2aAgent.TaskSnapshot snapshot = invoke(agent, request, operation, url);
+    A2aErrors.failIfUnsuccessful(snapshot);
+    return new A2aResponseImpl(snapshot,
+        A2aParams.bool(request, A2aRequest.PARAM_INCLUDE_HISTORY, false),
+        maxVariableSize);
+  }
+
+  /** Runs the operation through the interceptor chain and normalises whatever comes back out of it. */
+  private A2aAgent.TaskSnapshot invoke(A2aAgent agent, A2aRequest request, String operation, String url) {
+    A2aRequestInvocation invocation = new A2aRequestInvocation(agent,
+        () -> dispatch(agent, request, operation, url), request, requestInterceptors);
+    try {
+      return (A2aAgent.TaskSnapshot) invocation.proceed();
+    } catch (A2aCallException e) {
+      throw A2aErrors.translate(e, url);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      // Only an interceptor can get us here; the agent itself throws A2aCallException.
+      throw LOG.transportFailure(url, e);
+    }
+  }
+
+  protected A2aAgent.TaskSnapshot dispatch(A2aAgent agent, A2aRequest request, String operation, String url) {
+    return switch (operation) {
+      case A2aRequest.OPERATION_GET_TASK -> getTask(agent, request);
+      case A2aRequest.OPERATION_SEND_SYNC -> sendAndWait(agent, request);
+      case A2aRequest.OPERATION_SEND_ASYNC -> sendAsync(agent, request);
+      default -> throw LOG.unknownOperation(operation);
+    };
+  }
+
+  private A2aAgent.TaskSnapshot getTask(A2aAgent agent, A2aRequest request) {
+    String taskId = A2aParams.string(request, A2aRequest.PARAM_TASK_ID);
+    if (taskId == null) {
+      throw LOG.taskIdRequiredForGetTask();
+    }
+    return agent.getTask(taskId, A2aParams.integerOrNull(request, A2aRequest.PARAM_HISTORY_LENGTH));
+  }
+
+  /**
+   * Sends and returns without waiting. With a {@code callbackUrl} the agent is asked to push a notification when
+   * it is done; without one, nothing pushes and the process is expected to poll with {@code getTask} on a timer.
+   * Both are legitimate, so a missing callback URL is not an error.
+   */
+  private A2aAgent.TaskSnapshot sendAsync(A2aAgent agent, A2aRequest request) {
+    return sendOrReattach(agent, request, true);
+  }
+
+  /**
+   * Sends, then polls until the task settles. Polling rather than holding an SSE stream open keeps a job
+   * executor thread free of long-lived connections, at the cost of up to one poll interval of latency.
+   */
+  private A2aAgent.TaskSnapshot sendAndWait(A2aAgent agent, A2aRequest request) {
+    A2aAgent.TaskSnapshot snapshot = sendOrReattach(agent, request, false);
+
+    long waitTimeout = A2aParams.integer(request, A2aRequest.PARAM_WAIT_TIMEOUT, A2aRequest.DEFAULT_WAIT_TIMEOUT_MS);
+    long pollInterval = A2aParams.integer(request, A2aRequest.PARAM_POLL_INTERVAL, A2aRequest.DEFAULT_POLL_INTERVAL_MS);
+    Integer historyLength = A2aParams.integerOrNull(request, A2aRequest.PARAM_HISTORY_LENGTH);
+    long deadline = System.currentTimeMillis() + waitTimeout;
+
+    while (!A2aErrors.isSettled(snapshot.state())) {
+      long remaining = deadline - System.currentTimeMillis();
+      if (remaining <= 0) {
+        throw A2aErrors.timedOut(snapshot, waitTimeout);
+      }
+      LOG.waitingForTask(snapshot.taskId(), snapshot.state(), remaining);
+      sleep(Math.min(pollInterval, remaining), snapshot.taskId());
+      snapshot = agent.getTask(snapshot.taskId(), historyLength);
+    }
+    return snapshot;
+  }
+
+  /**
+   * Reattaches to a task an earlier, rolled back attempt already created, rather than paying an agent twice for
+   * the same work.
+   *
+   * <p>
+   * This is only attempted when the context id was derived from the idempotency key, because such a context
+   * holds exactly one task per activity instance. When the modeler supplies a context id explicitly the context
+   * belongs to a longer conversation and an earlier task in it is not ours to reattach to.
+   * </p>
+   */
+  private A2aAgent.TaskSnapshot sendOrReattach(A2aAgent agent, A2aRequest request, boolean returnImmediately) {
+    String idempotencyKey = A2aParams.string(request, A2aRequest.PARAM_IDEMPOTENCY_KEY);
+    String explicitContextId = A2aParams.string(request, A2aRequest.PARAM_CONTEXT_ID);
+    String contextId = explicitContextId != null ? explicitContextId : A2aIds.contextId(idempotencyKey);
+    boolean contextIsOurs = explicitContextId == null && idempotencyKey != null;
+
+    if (contextIsOurs && A2aParams.bool(request, A2aRequest.PARAM_REATTACH_ON_RETRY, true)) {
+      Optional<String> running = agent.findLatestTaskId(contextId);
+      if (running.isPresent()) {
+        LOG.reattachedToTask(running.get(), contextId);
+        return agent.getTask(running.get(), A2aParams.integerOrNull(request, A2aRequest.PARAM_HISTORY_LENGTH));
+      }
+    }
+
+    A2aAgent.SendCommand command = buildCommand(request, contextId, idempotencyKey, returnImmediately);
+    LOG.sendingMessage(returnImmediately ? A2aRequest.OPERATION_SEND_ASYNC : A2aRequest.OPERATION_SEND_SYNC,
+        A2aParams.string(request, A2aRequest.PARAM_URL), command.messageId());
+    return agent.send(command);
+  }
+
+  private A2aAgent.SendCommand buildCommand(A2aRequest request,
+                                            String contextId,
+                                            String idempotencyKey,
+                                            boolean returnImmediately) {
+    String text = A2aParams.string(request, A2aRequest.PARAM_MESSAGE);
+    List<Map<String, Object>> parts = A2aParams.mapList(request, A2aRequest.PARAM_PARTS);
+    if (text == null && parts.isEmpty()) {
+      throw LOG.messageOrPartsRequired();
+    }
+    String messageId = A2aParams.string(request, A2aRequest.PARAM_MESSAGE_ID);
+    if (messageId == null) {
+      messageId = A2aIds.messageId(idempotencyKey);
+    }
+    return new A2aAgent.SendCommand(messageId,
+        contextId,
+        A2aParams.string(request, A2aRequest.PARAM_TASK_ID),
+        text,
+        parts,
+        A2aParams.objectMap(request, A2aRequest.PARAM_METADATA),
+        A2aParams.stringList(request, A2aRequest.PARAM_EXTENSIONS),
+        A2aParams.stringList(request, A2aRequest.PARAM_REFERENCE_TASK_IDS),
+        A2aParams.objectMap(request, A2aRequest.PARAM_REQUEST_METADATA),
+        A2aParams.string(request, A2aRequest.PARAM_TENANT),
+        A2aParams.stringList(request, A2aRequest.PARAM_ACCEPTED_OUTPUT_MODES),
+        A2aParams.integerOrNull(request, A2aRequest.PARAM_HISTORY_LENGTH),
+        A2aParams.string(request, A2aRequest.PARAM_CALLBACK_URL),
+        A2aParams.string(request, A2aRequest.PARAM_CALLBACK_TOKEN),
+        A2aParams.string(request, A2aRequest.PARAM_CALLBACK_AUTH_SCHEME),
+        A2aParams.string(request, A2aRequest.PARAM_CALLBACK_AUTH_CREDENTIALS),
+        returnImmediately);
+  }
+
+  private void sleep(long millis, String taskId) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw LOG.interrupted(taskId);
+    }
+  }
+
+  protected A2aAgent agentFor(A2aAgent.Config config) {
+    // ponytail: fixed-size cache emptied wholesale when full. Swap for an LRU if one engine talks to
+    // more than MAX_CACHED_AGENTS distinct agents and card fetches start showing up in latency.
+    if (agents.size() >= MAX_CACHED_AGENTS && !agents.containsKey(config)) {
+      closeAgents();
+    }
+    return agents.computeIfAbsent(config, agentFactory);
+  }
+
+  /**
+   * Replaces how clients are created, so that a test can run the whole connector, including its polling and
+   * reattachment logic, against a scripted agent instead of a real one. Discards any cached clients.
+   *
+   * @param agentFactory builds an agent from a config; {@code SdkA2aAgent::new} in production
+   */
+  public void setAgentFactory(Function<A2aAgent.Config, A2aAgent> agentFactory) {
+    closeAgents();
+    this.agentFactory = agentFactory;
+  }
+
+  /** Closes and forgets every cached client. Safe to call at any time; the next request rebuilds what it needs. */
+  public void closeAgents() {
+    for (A2aAgent agent : agents.values()) {
+      try {
+        agent.close();
+      } catch (RuntimeException e) {
+        LOG.exceptionWhileClosingAgent(e);
+      }
+    }
+    agents.clear();
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorLogger.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorLogger.java
@@ -110,9 +110,16 @@ public class A2aConnectorLogger extends ConnectLogger {
         sizeBytes, maxBytes));
   }
 
+  /**
+   * The configured URL locates the agent card, but the endpoint actually called comes from the card itself, so
+   * the cause is included: without it, a card advertising an address unreachable from this host looks identical
+   * to the agent simply being down.
+   */
   public ConnectorRequestException transportFailure(String url, Exception cause) {
     return new ConnectorRequestException(exceptionMessage("018",
-        "Could not reach the A2A agent at '{}'. The job will be retried", url), cause);
+        "Could not reach the A2A agent configured at '{}'. The job will be retried. Note that the endpoint "
+            + "called is the one advertised by the agent card, which may differ from this URL. Cause: {}",
+        url, cause.getMessage()), cause);
   }
 
   public ConnectorRequestException interrupted(String taskId) {

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorLogger.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorLogger.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import org.operaton.connect.ConnectorRequestException;
+import org.operaton.connect.impl.ConnectLogger;
+
+/**
+ * Logging for the A2A connector.
+ *
+ * <p>
+ * Header values and message bodies are never logged. Header <em>names</em> are logged at debug level so that a
+ * missing {@code Authorization} header can be diagnosed without leaking the token.
+ * </p>
+ */
+public class A2aConnectorLogger extends ConnectLogger {
+
+  public static final String PROJECT_CODE = "A2A";
+
+  public static final A2aConnectorLogger LOG =
+      createLogger(A2aConnectorLogger.class, PROJECT_CODE, "org.operaton.bpm.connect.a2a", "01");
+
+  public void sendingMessage(String operation, String url, String messageId) {
+    logDebug("001", "Sending A2A '{}' to '{}' with message id '{}'", operation, url, messageId);
+  }
+
+  public void headersSet(String headerNames) {
+    logDebug("002", "Sending A2A request with headers: {} (values redacted)", headerNames);
+  }
+
+  public void reattachedToTask(String taskId, String contextId) {
+    logInfo("003", "Reattached to already running A2A task '{}' in context '{}' instead of sending again", taskId, contextId);
+  }
+
+  public void reattachProbeUnsupported(String url) {
+    logDebug("004", "Agent at '{}' does not support ListTasks, cannot probe for a task to reattach to", url);
+  }
+
+  public void waitingForTask(String taskId, String state, long remainingMs) {
+    logDebug("005", "A2A task '{}' is '{}', waiting up to {} ms more", taskId, state, remainingMs);
+  }
+
+  public void valueTruncated(String what, int sizeBytes, int maxBytes) {
+    logInfo("006", "A2A {} of {} bytes exceeds maxVariableSize of {} bytes and was truncated or replaced by a reference",
+        what, sizeBytes, maxBytes);
+  }
+
+  public void inputRequired(String taskId, String contextId) {
+    logInfo("007", "A2A task '{}' in context '{}' requires further input; mapped to outputs without raising an error",
+        taskId, contextId);
+  }
+
+  public ConnectorRequestException operationRequired() {
+    return new ConnectorRequestException(exceptionMessage("008",
+        "Input parameter 'operation' is required and must be one of 'sendSync', 'sendAsync', 'getTask'"));
+  }
+
+  public ConnectorRequestException unknownOperation(String operation) {
+    return new ConnectorRequestException(exceptionMessage("009",
+        "Unknown A2A operation '{}'. Supported operations are 'sendSync', 'sendAsync', 'getTask'", operation));
+  }
+
+  public ConnectorRequestException urlRequired() {
+    return new ConnectorRequestException(exceptionMessage("010", "Input parameter 'url' is required"));
+  }
+
+  public ConnectorRequestException taskIdRequiredForGetTask() {
+    return new ConnectorRequestException(exceptionMessage("011",
+        "Input parameter 'taskId' is required for the 'getTask' operation"));
+  }
+
+  public ConnectorRequestException invalidNumber(String parameter, Object value) {
+    return new ConnectorRequestException(exceptionMessage("013",
+        "Input parameter '{}' must be a number but was '{}'", parameter, value));
+  }
+
+  public ConnectorRequestException invalidMap(String parameter, Object value) {
+    return new ConnectorRequestException(exceptionMessage("014",
+        "Input parameter '{}' must be a map but was of type '{}'", parameter,
+        value == null ? "null" : value.getClass().getName()));
+  }
+
+  public ConnectorRequestException invalidList(String parameter, Object value) {
+    return new ConnectorRequestException(exceptionMessage("015",
+        "Input parameter '{}' must be a list but was of type '{}'", parameter,
+        value == null ? "null" : value.getClass().getName()));
+  }
+
+  public ConnectorRequestException unknownPartType(Object type) {
+    return new ConnectorRequestException(exceptionMessage("016",
+        "Unknown part type '{}'. Supported types are 'text', 'file' and 'data'", type));
+  }
+
+  public ConnectorRequestException inlineFileTooLarge(int sizeBytes, int maxBytes) {
+    return new ConnectorRequestException(exceptionMessage("017",
+        "Inline file part of {} bytes exceeds maxVariableSize of {} bytes. Send the file by uri instead",
+        sizeBytes, maxBytes));
+  }
+
+  public ConnectorRequestException transportFailure(String url, Exception cause) {
+    return new ConnectorRequestException(exceptionMessage("018",
+        "Could not reach the A2A agent at '{}'. The job will be retried", url), cause);
+  }
+
+  public ConnectorRequestException interrupted(String taskId) {
+    return new ConnectorRequestException(exceptionMessage("019",
+        "Interrupted while waiting for A2A task '{}'", taskId));
+  }
+
+  public ConnectorRequestException messageOrPartsRequired() {
+    return new ConnectorRequestException(exceptionMessage("020",
+        "Input parameter 'message' or 'parts' is required to send a message to an agent"));
+  }
+
+  public ConnectorRequestException filePartNeedsUriOrBytes() {
+    return new ConnectorRequestException(exceptionMessage("022",
+        "A file part needs either a 'uri' or inline 'bytes'"));
+  }
+
+  public void exceptionWhileClosingAgent(Exception cause) {
+    logDebug("021", "Exception while closing an A2A client: {}", cause.getMessage());
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorProviderImpl.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aConnectorProviderImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import org.operaton.connect.a2a.A2aConnector;
+import org.operaton.connect.a2a.A2aConnectorProvider;
+
+/**
+ * Registers the A2A connector with {@code Connectors} through {@link java.util.ServiceLoader}.
+ */
+public class A2aConnectorProviderImpl implements A2aConnectorProvider {
+
+  @Override
+  public String getConnectorId() {
+    return A2aConnector.ID;
+  }
+
+  @Override
+  public A2aConnector createConnectorInstance() {
+    return new A2aConnectorImpl();
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aErrors.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aErrors.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.Set;
+
+import org.operaton.bpm.engine.delegate.BpmnError;
+
+import static org.operaton.connect.a2a.impl.A2aConnectorLogger.LOG;
+
+/**
+ * Turns A2A task states and failed calls into something a BPMN diagram can react to.
+ *
+ * <p>
+ * The rule is: anything that the agent decided is over and went badly becomes a {@code BpmnError} with a
+ * stable code that an error boundary event can catch. Anything that might succeed on a second attempt stays an
+ * exception, so the job executor retries it and eventually raises an incident. A task waiting for more input
+ * is neither, and is mapped to normal outputs.
+ * </p>
+ */
+final class A2aErrors {
+
+  static final String STATE_SUBMITTED = "TASK_STATE_SUBMITTED";
+  static final String STATE_WORKING = "TASK_STATE_WORKING";
+  static final String STATE_INPUT_REQUIRED = "TASK_STATE_INPUT_REQUIRED";
+  static final String STATE_AUTH_REQUIRED = "TASK_STATE_AUTH_REQUIRED";
+  static final String STATE_COMPLETED = "TASK_STATE_COMPLETED";
+  static final String STATE_CANCELED = "TASK_STATE_CANCELED";
+  static final String STATE_FAILED = "TASK_STATE_FAILED";
+  static final String STATE_REJECTED = "TASK_STATE_REJECTED";
+
+  /** The agent is done with this task, for better or worse. */
+  private static final Set<String> FINAL_STATES =
+      Set.of(STATE_COMPLETED, STATE_CANCELED, STATE_FAILED, STATE_REJECTED);
+
+  /** The agent has stopped and is waiting for the caller to do something. */
+  private static final Set<String> INTERRUPTED_STATES =
+      Set.of(STATE_INPUT_REQUIRED, STATE_AUTH_REQUIRED);
+
+  static final String CODE_TASK_FAILED = "a2a-task-failed";
+  static final String CODE_TASK_REJECTED = "a2a-task-rejected";
+  static final String CODE_TASK_CANCELED = "a2a-task-canceled";
+  static final String CODE_AUTH_REQUIRED = "a2a-auth-required";
+  static final String CODE_TIMEOUT = "a2a-timeout";
+  static final String CODE_PROTOCOL_ERROR = "a2a-protocol-error";
+
+  private A2aErrors() {
+  }
+
+  /**
+   * @return {@code true} when there is no point waiting any longer, either because the task is over or
+   *         because the agent is waiting on us
+   */
+  static boolean isSettled(String state) {
+    return state == null || FINAL_STATES.contains(state) || INTERRUPTED_STATES.contains(state);
+  }
+
+  /**
+   * Raises a {@code BpmnError} if the task ended badly. A completed task, and a task waiting for input,
+   * return normally so that their outputs get mapped.
+   *
+   * @param snapshot the settled task
+   */
+  static void failIfUnsuccessful(A2aAgent.TaskSnapshot snapshot) {
+    String state = snapshot.state();
+    if (state == null || STATE_COMPLETED.equals(state)) {
+      return;
+    }
+    switch (state) {
+      case STATE_FAILED -> throw bpmnError(CODE_TASK_FAILED, snapshot);
+      case STATE_REJECTED -> throw bpmnError(CODE_TASK_REJECTED, snapshot);
+      case STATE_CANCELED -> throw bpmnError(CODE_TASK_CANCELED, snapshot);
+      case STATE_AUTH_REQUIRED -> throw bpmnError(CODE_AUTH_REQUIRED, snapshot);
+      case STATE_INPUT_REQUIRED -> LOG.inputRequired(snapshot.taskId(), snapshot.contextId());
+      default -> {
+        // submitted or working: sendAsync returns these on purpose, so they are not a failure
+      }
+    }
+  }
+
+  /**
+   * Raises the timeout error for a task that never settled.
+   *
+   * @param snapshot the last known state of the task
+   * @param waitedMs how long we waited
+   */
+  static BpmnError timedOut(A2aAgent.TaskSnapshot snapshot, long waitedMs) {
+    return new BpmnError(CODE_TIMEOUT, "A2A task '%s' in context '%s' was still '%s' after %d ms. %s"
+        .formatted(snapshot.taskId(), snapshot.contextId(), snapshot.state(), waitedMs, recoveryHint(snapshot)));
+  }
+
+  /**
+   * Translates a failed call into either a retryable exception or a {@code BpmnError}.
+   *
+   * @param cause the failed call
+   * @param url the agent URL, for the message
+   * @return the exception to throw
+   */
+  static RuntimeException translate(A2aCallException cause, String url) {
+    if (cause.isRetryable()) {
+      return LOG.transportFailure(url, cause);
+    }
+    return new BpmnError(CODE_PROTOCOL_ERROR, cause.getMessage());
+  }
+
+  private static BpmnError bpmnError(String code, A2aAgent.TaskSnapshot snapshot) {
+    return new BpmnError(code, "A2A task '%s' in context '%s' ended in state '%s'. %s"
+        .formatted(snapshot.taskId(), snapshot.contextId(), snapshot.state(), recoveryHint(snapshot)));
+  }
+
+  /**
+   * Output parameters are not mapped when an error is thrown, so the ids a process needs to follow up on the
+   * task have to travel inside the error message.
+   */
+  private static String recoveryHint(A2aAgent.TaskSnapshot snapshot) {
+    return "Use operation 'getTask' with taskId '%s' to read the full task.".formatted(snapshot.taskId());
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aIds.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aIds.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.UUID;
+
+/**
+ * Derives the ids the connector sends to an agent.
+ *
+ * <p>
+ * A2A does not let a client choose the task id: the agent assigns it when it creates the task. What a client
+ * does own is the message id and, optionally, the context id. Both are derived here from a value that is
+ * stable across job retries of the same activity, which is what makes deduplication and reattachment possible
+ * at all. See the module README for the limits of that.
+ * </p>
+ */
+final class A2aIds {
+
+  /** Enough hex to make a collision between two activity instances not worth worrying about. */
+  private static final int HASH_LENGTH = 32;
+
+  private A2aIds() {
+  }
+
+  /**
+   * @param idempotencyKey a value stable across retries of one activity instance, or {@code null}
+   * @return a deterministic message id, or a random one if no key was given
+   */
+  static String messageId(String idempotencyKey) {
+    return idempotencyKey == null ? random("msg") : "msg-" + hash(idempotencyKey);
+  }
+
+  /**
+   * @param idempotencyKey a value stable across retries of one activity instance, or {@code null}
+   * @return a deterministic context id, or a random one if no key was given
+   */
+  static String contextId(String idempotencyKey) {
+    return idempotencyKey == null ? random("ctx") : "ctx-" + hash(idempotencyKey);
+  }
+
+  private static String random(String prefix) {
+    return prefix + "-" + UUID.randomUUID();
+  }
+
+  private static String hash(String value) {
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest).substring(0, HASH_LENGTH);
+    } catch (NoSuchAlgorithmException e) {
+      // SHA-256 is required of every JVM, so this cannot happen.
+      throw new IllegalStateException("SHA-256 is not available", e);
+    }
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aParams.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aParams.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.operaton.connect.spi.ConnectorRequest;
+
+import static org.operaton.connect.a2a.impl.A2aConnectorLogger.LOG;
+
+/**
+ * Reads connector input parameters and coerces them into the types the connector needs.
+ *
+ * <p>
+ * This exists because a literal {@code operaton:inputParameter} in a BPMN diagram is always a {@code String},
+ * while the same parameter written as an expression can produce an {@code Integer}, a {@code Boolean}, a
+ * {@code Map} or a {@code List}. Both forms have to work, otherwise a modeler has to know which one the
+ * connector wants.
+ * </p>
+ */
+final class A2aParams {
+
+  private A2aParams() {
+  }
+
+  /**
+   * @return the parameter as a string with surrounding whitespace removed, or {@code null} if unset or blank
+   */
+  static String string(ConnectorRequest<?> request, String name) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return null;
+    }
+    String text = value.toString().trim();
+    return text.isEmpty() ? null : text;
+  }
+
+  /**
+   * @return the parameter as an int, or {@code fallback} if unset
+   * @throws org.operaton.connect.ConnectorRequestException if the value is not a number
+   */
+  static int integer(ConnectorRequest<?> request, String name, int fallback) {
+    Integer value = integerOrNull(request, name);
+    return value == null ? fallback : value;
+  }
+
+  /**
+   * @return the parameter as an Integer, or {@code null} if unset
+   * @throws org.operaton.connect.ConnectorRequestException if the value is not a number
+   */
+  static Integer integerOrNull(ConnectorRequest<?> request, String name) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    try {
+      return Integer.valueOf(value.toString().trim());
+    } catch (NumberFormatException e) {
+      throw LOG.invalidNumber(name, value);
+    }
+  }
+
+  /**
+   * @return the parameter as a boolean, or {@code fallback} if unset. Anything other than {@code true},
+   *         ignoring case, counts as {@code false}.
+   */
+  static boolean bool(ConnectorRequest<?> request, String name, boolean fallback) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return fallback;
+    }
+    if (value instanceof Boolean flag) {
+      return flag;
+    }
+    return Boolean.parseBoolean(value.toString().trim());
+  }
+
+  /**
+   * @return the parameter as a map of strings to strings, never {@code null}. Entries with a null value are
+   *         dropped, since an HTTP header without a value is not meaningful.
+   */
+  static Map<String, String> stringMap(ConnectorRequest<?> request, String name) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return Collections.emptyMap();
+    }
+    if (!(value instanceof Map<?, ?> map)) {
+      throw LOG.invalidMap(name, value);
+    }
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      if (entry.getKey() != null && entry.getValue() != null) {
+        result.put(entry.getKey().toString(), entry.getValue().toString());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * @return the parameter as a map of strings to arbitrary values, never {@code null}
+   */
+  static Map<String, Object> objectMap(ConnectorRequest<?> request, String name) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return Collections.emptyMap();
+    }
+    if (!(value instanceof Map<?, ?> map)) {
+      throw LOG.invalidMap(name, value);
+    }
+    Map<String, Object> result = new LinkedHashMap<>();
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      if (entry.getKey() != null) {
+        result.put(entry.getKey().toString(), entry.getValue());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * @return the parameter as a list of strings, never {@code null}. A plain string is split on commas, so that
+   *         {@code text/plain, application/json} works as a literal in the diagram.
+   */
+  static List<String> stringList(ConnectorRequest<?> request, String name) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return Collections.emptyList();
+    }
+    if (value instanceof String text) {
+      List<String> result = new ArrayList<>();
+      for (String item : text.split(",")) {
+        String trimmed = item.trim();
+        if (!trimmed.isEmpty()) {
+          result.add(trimmed);
+        }
+      }
+      return result;
+    }
+    if (!(value instanceof List<?> list)) {
+      throw LOG.invalidList(name, value);
+    }
+    List<String> result = new ArrayList<>();
+    for (Object item : list) {
+      if (item != null) {
+        result.add(item.toString());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * @return the parameter as a list of maps, never {@code null}. Used for message parts.
+   */
+  @SuppressWarnings("unchecked")
+  static List<Map<String, Object>> mapList(ConnectorRequest<?> request, String name) {
+    Object value = request.getRequestParameter(name);
+    if (value == null) {
+      return Collections.emptyList();
+    }
+    if (!(value instanceof List<?> list)) {
+      throw LOG.invalidList(name, value);
+    }
+    List<Map<String, Object>> result = new ArrayList<>();
+    for (Object item : list) {
+      if (item == null) {
+        continue;
+      }
+      if (!(item instanceof Map<?, ?>)) {
+        throw LOG.invalidMap(name, item);
+      }
+      result.add((Map<String, Object>) item);
+    }
+    return result;
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aRequestImpl.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aRequestImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.operaton.connect.a2a.A2aRequest;
+import org.operaton.connect.a2a.A2aResponse;
+import org.operaton.connect.impl.AbstractConnectorRequest;
+import org.operaton.connect.spi.Connector;
+
+/**
+ * Holds the input parameters of an A2A call. Values arrive either through the fluent methods, when the
+ * connector is used from Java, or through {@code setRequestParameter}, when the connect plugin applies the
+ * {@code operaton:inputParameter} mappings of a service task.
+ */
+public class A2aRequestImpl extends AbstractConnectorRequest<A2aResponse> implements A2aRequest {
+
+  @SuppressWarnings("rawtypes")
+  public A2aRequestImpl(Connector connector) {
+    super(connector);
+  }
+
+  @Override
+  public A2aRequest operation(String operation) {
+    setRequestParameter(PARAM_OPERATION, operation);
+    return this;
+  }
+
+  @Override
+  public A2aRequest url(String url) {
+    setRequestParameter(PARAM_URL, url);
+    return this;
+  }
+
+  @Override
+  public A2aRequest header(String field, String value) {
+    Map<String, String> headers = getRequestParameter(PARAM_HEADERS);
+    if (headers == null) {
+      headers = new LinkedHashMap<>();
+      setRequestParameter(PARAM_HEADERS, headers);
+    }
+    headers.put(field, value);
+    return this;
+  }
+
+  @Override
+  public A2aRequest message(String message) {
+    setRequestParameter(PARAM_MESSAGE, message);
+    return this;
+  }
+
+  @Override
+  public A2aRequest taskId(String taskId) {
+    setRequestParameter(PARAM_TASK_ID, taskId);
+    return this;
+  }
+
+  @Override
+  public A2aRequest contextId(String contextId) {
+    setRequestParameter(PARAM_CONTEXT_ID, contextId);
+    return this;
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aRequestInvocation.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aRequestInvocation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.operaton.connect.impl.AbstractRequestInvocation;
+import org.operaton.connect.spi.ConnectorRequest;
+import org.operaton.connect.spi.ConnectorRequestInterceptor;
+
+/**
+ * Routes one A2A operation through the connector's interceptor chain.
+ *
+ * <p>
+ * The whole operation is a single invocation, including the polling an operation may do internally, so that an
+ * interceptor sees one agent call per service task rather than one per HTTP request.
+ * </p>
+ */
+public class A2aRequestInvocation extends AbstractRequestInvocation<A2aAgent> {
+
+  private final Supplier<A2aAgent.TaskSnapshot> call;
+
+  public A2aRequestInvocation(A2aAgent agent,
+                              Supplier<A2aAgent.TaskSnapshot> call,
+                              ConnectorRequest<?> request,
+                              List<ConnectorRequestInterceptor> interceptorChain) {
+    super(agent, request, interceptorChain);
+    this.call = call;
+  }
+
+  @Override
+  public Object invokeTarget() {
+    return call.get();
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aResponseImpl.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aResponseImpl.java
@@ -71,9 +71,22 @@ public class A2aResponseImpl extends AbstractConnectorResponse implements A2aRes
     }
   }
 
+  /**
+   * The agent's answer as plain text.
+   *
+   * <p>
+   * Agents split into two camps: some close the task with a status message carrying the answer, others return
+   * nothing but artifacts. Reading only the status message would leave {@code ${text}} empty against the second
+   * kind, so artifacts are the fallback and the easy one-field case stays easy either way.
+   * </p>
+   */
   @Override
   public String getText() {
-    return bounded(textOf(partsOf(snapshot.statusMessage())), PARAM_TEXT);
+    String text = textOf(partsOf(snapshot.statusMessage()));
+    if (text.isEmpty()) {
+      text = textOf(artifactParts());
+    }
+    return bounded(text, PARAM_TEXT);
   }
 
   @Override
@@ -104,11 +117,15 @@ public class A2aResponseImpl extends AbstractConnectorResponse implements A2aRes
   }
 
   private String artifactText() {
+    return bounded(textOf(artifactParts()), PARAM_ARTIFACT_TEXT);
+  }
+
+  private List<Map<String, Object>> artifactParts() {
     List<Map<String, Object>> parts = new ArrayList<>();
     for (Map<String, Object> artifact : snapshot.artifacts()) {
       parts.addAll(partsOf(artifact));
     }
-    return bounded(textOf(parts), PARAM_ARTIFACT_TEXT);
+    return parts;
   }
 
   private Map<String, Object> task() {

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aResponseImpl.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/A2aResponseImpl.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.operaton.connect.a2a.A2aResponse;
+import org.operaton.connect.impl.AbstractConnectorResponse;
+
+import static org.operaton.connect.a2a.impl.A2aConnectorLogger.LOG;
+
+/**
+ * Exposes an A2A task as connector output parameters.
+ *
+ * <p>
+ * Alongside the structured values, two conveniences are produced because they are what most processes actually
+ * want: {@code text}, the text of the agent's final message, and {@code artifactText}, the text of everything
+ * it produced. Both are plain strings so they can go straight into a user task form or an email.
+ * </p>
+ */
+public class A2aResponseImpl extends AbstractConnectorResponse implements A2aResponse {
+
+  static final String PART_TYPE = "type";
+  static final String PART_TYPE_TEXT = "text";
+
+  private static final String TRUNCATION_MARKER = "... [truncated by maxVariableSize]";
+
+  private final A2aAgent.TaskSnapshot snapshot;
+  private final boolean includeHistory;
+  private final int maxVariableSize;
+
+  private boolean textTruncated;
+
+  public A2aResponseImpl(A2aAgent.TaskSnapshot snapshot, boolean includeHistory, int maxVariableSize) {
+    this.snapshot = snapshot;
+    this.includeHistory = includeHistory;
+    this.maxVariableSize = maxVariableSize;
+  }
+
+  @Override
+  protected void collectResponseParameters(Map<String, Object> responseParameters) {
+    responseParameters.put(PARAM_TEXT, getText());
+    responseParameters.put(PARAM_ARTIFACT_TEXT, artifactText());
+    responseParameters.put(PARAM_STATUS_MESSAGE, snapshot.statusMessage());
+    responseParameters.put(PARAM_ARTIFACTS, snapshot.artifacts());
+    responseParameters.put(PARAM_TASK, task());
+    responseParameters.put(PARAM_TASK_ID, snapshot.taskId());
+    responseParameters.put(PARAM_CONTEXT_ID, snapshot.contextId());
+    responseParameters.put(PARAM_STATE, snapshot.state());
+    responseParameters.put(PARAM_TASK_METADATA, snapshot.taskMetadata());
+    responseParameters.put(PARAM_MESSAGE_METADATA, messageMetadata());
+    responseParameters.put(PARAM_TRUNCATED, isTruncated());
+    if (includeHistory) {
+      responseParameters.put(PARAM_HISTORY, snapshot.history());
+    }
+  }
+
+  @Override
+  public String getText() {
+    return bounded(textOf(partsOf(snapshot.statusMessage())), PARAM_TEXT);
+  }
+
+  @Override
+  public String getTaskId() {
+    return snapshot.taskId();
+  }
+
+  @Override
+  public String getContextId() {
+    return snapshot.contextId();
+  }
+
+  @Override
+  public String getState() {
+    return snapshot.state();
+  }
+
+  @Override
+  public List<Map<String, Object>> getArtifacts() {
+    return snapshot.artifacts();
+  }
+
+  @Override
+  public boolean isTruncated() {
+    // getText() and artifactText() have to have run for textTruncated to be meaningful, and
+    // collectResponseParameters() calls both before it reads this.
+    return snapshot.truncated() || textTruncated;
+  }
+
+  private String artifactText() {
+    List<Map<String, Object>> parts = new ArrayList<>();
+    for (Map<String, Object> artifact : snapshot.artifacts()) {
+      parts.addAll(partsOf(artifact));
+    }
+    return bounded(textOf(parts), PARAM_ARTIFACT_TEXT);
+  }
+
+  private Map<String, Object> task() {
+    if (snapshot.taskId() == null) {
+      // The agent answered with a bare message rather than creating a task.
+      return null;
+    }
+    Map<String, Object> status = new LinkedHashMap<>();
+    status.put(PARAM_STATE, snapshot.state());
+    status.put("message", snapshot.statusMessage());
+
+    Map<String, Object> task = new LinkedHashMap<>();
+    task.put("id", snapshot.taskId());
+    task.put("contextId", snapshot.contextId());
+    task.put("status", status);
+    task.put("artifacts", snapshot.artifacts());
+    task.put("metadata", snapshot.taskMetadata());
+    return task;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> messageMetadata() {
+    Map<String, Object> message = snapshot.statusMessage();
+    if (message == null) {
+      return Map.of();
+    }
+    Object metadata = message.get("metadata");
+    return metadata instanceof Map ? (Map<String, Object>) metadata : Map.of();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> partsOf(Map<String, Object> messageOrArtifact) {
+    if (messageOrArtifact == null) {
+      return List.of();
+    }
+    Object parts = messageOrArtifact.get("parts");
+    return parts instanceof List ? (List<Map<String, Object>>) parts : List.of();
+  }
+
+  /** Joins the text of every text part, which is what a process almost always wants to read. */
+  private static String textOf(List<Map<String, Object>> parts) {
+    StringBuilder text = new StringBuilder();
+    for (Map<String, Object> part : parts) {
+      if (PART_TYPE_TEXT.equals(part.get(PART_TYPE)) && part.get(PART_TYPE_TEXT) != null) {
+        if (!text.isEmpty()) {
+          text.append('\n');
+        }
+        text.append(part.get(PART_TYPE_TEXT));
+      }
+    }
+    return text.toString();
+  }
+
+  /**
+   * Keeps a string small enough to be a process variable. Individual parts are already bounded when the task is
+   * read, but joining many of them can still add up.
+   */
+  private String bounded(String text, String what) {
+    if (text.length() <= maxVariableSize) {
+      return text;
+    }
+    LOG.valueTruncated(what, text.length(), maxVariableSize);
+    textTruncated = true;
+    return text.substring(0, maxVariableSize) + TRUNCATION_MARKER;
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/SdkA2aAgent.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/SdkA2aAgent.java
@@ -15,6 +15,7 @@
  */
 package org.operaton.connect.a2a.impl;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -179,11 +180,13 @@ public class SdkA2aAgent implements A2aAgent {
       // first result is the one to reattach to and ordering does not matter.
       return Optional.ofNullable(tasks.get(0).id());
     } catch (Exception e) {
-      A2aCallException classified = classify(e, "Probing for an existing A2A task failed");
-      if (classified.isRetryable()) {
+      // The probe is best-effort. ListTasks is optional in A2A and a great many agents answer it with
+      // "method not found", so anything short of a clear transport problem has to degrade to a plain send.
+      // Treating an unrecognised failure as retryable here would take down every send to such an agent.
+      if (isTransportFailure(e)) {
         // The agent may well be reachable again in a moment. Failing here is better than sending a second
         // message and paying for the same work twice.
-        throw classified;
+        throw classify(e, "Probing for an existing A2A task failed");
       }
       LOG.reattachProbeUnsupported(config.url());
       return Optional.empty();
@@ -519,6 +522,25 @@ public class SdkA2aAgent implements A2aAgent {
       return result;
     }
     return normalize(GSON.fromJson(GSON.toJson(value), Object.class));
+  }
+
+  /**
+   * Whether a failure is positively evidence of a transport problem, rather than merely unrecognised.
+   *
+   * <p>
+   * {@link #classify} deliberately treats an unknown failure as retryable, which is the right default when a call
+   * we need has failed. For the optional reattach probe the safe default is the opposite one, so this asks for
+   * proof instead of assuming.
+   * </p>
+   */
+  // package-private so the reattach-probe decision can be unit tested directly
+  static boolean isTransportFailure(Throwable cause) {
+    A2AClientHTTPError httpError = findCause(cause, A2AClientHTTPError.class);
+    if (httpError != null) {
+      int code = httpError.getCode();
+      return code == 408 || code == 425 || code == 429 || code >= 500;
+    }
+    return findCause(cause, IOException.class) != null;
   }
 
   private A2aCallException classify(Throwable cause, String message) {

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/SdkA2aAgent.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/SdkA2aAgent.java
@@ -1,0 +1,550 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.gson.Gson;
+import org.a2aproject.sdk.client.Client;
+import org.a2aproject.sdk.client.ClientEvent;
+import org.a2aproject.sdk.client.MessageEvent;
+import org.a2aproject.sdk.client.TaskEvent;
+import org.a2aproject.sdk.client.TaskUpdateEvent;
+import org.a2aproject.sdk.client.config.ClientConfig;
+import org.a2aproject.sdk.client.http.A2ACardResolver;
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransportConfig;
+import org.a2aproject.sdk.client.transport.spi.interceptors.ClientCallContext;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.ListTasksResult;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
+import org.a2aproject.sdk.spec.A2AClientJSONError;
+import org.a2aproject.sdk.spec.A2AProtocolError;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.Artifact;
+import org.a2aproject.sdk.spec.AuthenticationInfo;
+import org.a2aproject.sdk.spec.DataPart;
+import org.a2aproject.sdk.spec.FileContent;
+import org.a2aproject.sdk.spec.FilePart;
+import org.a2aproject.sdk.spec.FileWithBytes;
+import org.a2aproject.sdk.spec.FileWithUri;
+import org.a2aproject.sdk.spec.ListTasksParams;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.MessageSendConfiguration;
+import org.a2aproject.sdk.spec.MessageSendParams;
+import org.a2aproject.sdk.spec.Part;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.a2aproject.sdk.spec.TaskQueryParams;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TextPart;
+
+import static org.operaton.connect.a2a.impl.A2aConnectorLogger.LOG;
+
+/**
+ * The only class that knows the A2A Java SDK exists.
+ *
+ * <p>
+ * Everything it returns is a plain {@code String}, {@code Map} or {@code List}, so a change to the SDK or to the
+ * protocol version is contained here and in {@link TimeoutAwareA2AHttpClient}. In exchange this class is longer
+ * than the rest of the module put together, which is the intended trade.
+ * </p>
+ *
+ * <p>
+ * Streaming is deliberately switched off. The SDK would happily consume a server-sent-event stream, but doing so
+ * on a job executor thread means holding a connection open for as long as the agent takes to think. The connector
+ * sends once and polls instead.
+ * </p>
+ */
+public class SdkA2aAgent implements A2aAgent {
+
+  private static final String DEFAULT_AGENT_CARD_PATH = "/.well-known/agent-card.json";
+
+  /** Used only to flatten agent-supplied JSON into plain collections. */
+  private static final Gson GSON = new Gson();
+
+  private static final String KEY_TYPE = "type";
+  private static final String KEY_TEXT = "text";
+  private static final String KEY_FILE = "file";
+  private static final String KEY_DATA = "data";
+  private static final String KEY_METADATA = "metadata";
+  private static final String KEY_PARTS = "parts";
+  private static final String KEY_MIME_TYPE = "mimeType";
+  private static final String KEY_NAME = "name";
+  private static final String KEY_URI = "uri";
+  private static final String KEY_BYTES = "bytes";
+
+  private final Config config;
+  private final Client client;
+
+  public SdkA2aAgent(Config config) {
+    this.config = config;
+    A2AHttpClient httpClient = new TimeoutAwareA2AHttpClient(config.connectTimeoutMs(), config.readTimeoutMs());
+    try {
+      AgentCard card = resolveCard(httpClient, config);
+      this.client = Client.builder(card)
+          .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig(httpClient))
+          .clientConfig(ClientConfig.builder()
+              .setStreaming(false)
+              .setPolling(true)
+              // Only the JSON-RPC transport is registered, so the client's preference has to win over a card
+              // that would rather be spoken to over gRPC.
+              .setUseClientPreference(true)
+              .build())
+          .build();
+    } catch (Exception e) {
+      throw classify(e, "Could not connect to the A2A agent at '%s'".formatted(config.url()));
+    }
+  }
+
+  @Override
+  public TaskSnapshot send(SendCommand command) {
+    MessageSendParams.Builder params = MessageSendParams.builder().message(toMessage(command));
+    MessageSendConfiguration configuration = toConfiguration(command);
+    if (configuration != null) {
+      params.configuration(configuration);
+    }
+    if (!command.requestMetadata().isEmpty()) {
+      params.metadata(command.requestMetadata());
+    }
+    if (command.tenant() != null) {
+      params.tenant(command.tenant());
+    }
+
+    AtomicReference<ClientEvent> result = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    try {
+      client.sendMessage(params.build(), List.of((event, card) -> result.set(event)), failure::set, callContext());
+    } catch (Exception e) {
+      throw classify(e, "Sending a message to the A2A agent at '%s' failed".formatted(config.url()));
+    }
+    if (failure.get() != null) {
+      throw classify(failure.get(), "The A2A agent at '%s' reported an error".formatted(config.url()));
+    }
+    ClientEvent event = result.get();
+    if (event == null) {
+      throw new A2aCallException("The A2A agent at '%s' accepted the message but returned no task or message"
+          .formatted(config.url()), null, false);
+    }
+    return toSnapshot(event);
+  }
+
+  @Override
+  public TaskSnapshot getTask(String taskId, Integer historyLength) {
+    try {
+      Task task = client.getTask(TaskQueryParams.builder()
+          .id(taskId)
+          .historyLength(historyLength)
+          .build(), callContext());
+      return fromTask(task);
+    } catch (Exception e) {
+      throw classify(e, "Reading A2A task '%s' from '%s' failed".formatted(taskId, config.url()));
+    }
+  }
+
+  @Override
+  public Optional<String> findLatestTaskId(String contextId) {
+    try {
+      ListTasksResult result = client.listTasks(ListTasksParams.builder()
+          .contextId(contextId)
+          .pageSize(1)
+          .includeArtifacts(false)
+          .build(), callContext());
+      List<Task> tasks = result == null ? null : result.tasks();
+      if (tasks == null || tasks.isEmpty()) {
+        return Optional.empty();
+      }
+      // A derived context holds at most one task, the one an earlier attempt of this activity created, so the
+      // first result is the one to reattach to and ordering does not matter.
+      return Optional.ofNullable(tasks.get(0).id());
+    } catch (Exception e) {
+      A2aCallException classified = classify(e, "Probing for an existing A2A task failed");
+      if (classified.isRetryable()) {
+        // The agent may well be reachable again in a moment. Failing here is better than sending a second
+        // message and paying for the same work twice.
+        throw classified;
+      }
+      LOG.reattachProbeUnsupported(config.url());
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      client.close();
+    } catch (RuntimeException e) {
+      LOG.exceptionWhileClosingAgent(e);
+    }
+  }
+
+  private static AgentCard resolveCard(A2AHttpClient httpClient, Config config) {
+    String url = config.url();
+    String baseUrl;
+    String cardPath;
+    if (url.endsWith(".json")) {
+      URI uri = URI.create(url);
+      baseUrl = uri.getScheme() + "://" + uri.getAuthority();
+      cardPath = uri.getRawPath();
+    } else {
+      baseUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+      cardPath = DEFAULT_AGENT_CARD_PATH;
+    }
+    return A2ACardResolver.builder()
+        .httpClient(httpClient)
+        .baseUrl(baseUrl)
+        .agentCardPath(cardPath)
+        .authHeaders(config.headers())
+        .build()
+        .getAgentCard();
+  }
+
+  private ClientCallContext callContext() {
+    return new ClientCallContext(new HashMap<>(), new LinkedHashMap<>(config.headers()));
+  }
+
+  private Message toMessage(SendCommand command) {
+    List<Part<?>> parts = new ArrayList<>();
+    if (command.text() != null) {
+      parts.add(new TextPart(command.text()));
+    }
+    for (Map<String, Object> part : command.parts()) {
+      parts.add(toPart(part));
+    }
+
+    Message.Builder builder = Message.builder()
+        .role(Message.Role.ROLE_USER)
+        .messageId(command.messageId())
+        .parts(parts);
+    if (command.contextId() != null) {
+      builder.contextId(command.contextId());
+    }
+    if (command.taskId() != null) {
+      builder.taskId(command.taskId());
+    }
+    if (!command.referenceTaskIds().isEmpty()) {
+      builder.referenceTaskIds(command.referenceTaskIds());
+    }
+    if (!command.metadata().isEmpty()) {
+      builder.metadata(command.metadata());
+    }
+    if (!command.extensions().isEmpty()) {
+      builder.extensions(command.extensions());
+    }
+    return builder.build();
+  }
+
+  private Part<?> toPart(Map<String, Object> part) {
+    Object type = part.get(KEY_TYPE);
+    String typeName = type == null ? null : type.toString();
+    Map<String, Object> metadata = mapOrNull(part.get(KEY_METADATA));
+
+    if (KEY_TEXT.equals(typeName)) {
+      return new TextPart(string(part, KEY_TEXT), metadata);
+    }
+    if (KEY_DATA.equals(typeName)) {
+      return new DataPart(part.get(KEY_DATA), metadata);
+    }
+    if (KEY_FILE.equals(typeName)) {
+      return new FilePart(toFileContent(part), metadata);
+    }
+    throw LOG.unknownPartType(typeName);
+  }
+
+  private FileContent toFileContent(Map<String, Object> part) {
+    String mimeType = string(part, KEY_MIME_TYPE);
+    String name = string(part, KEY_NAME);
+    String uri = string(part, KEY_URI);
+    if (uri != null) {
+      return new FileWithUri(mimeType, name, uri);
+    }
+    String bytes = string(part, KEY_BYTES);
+    if (bytes == null) {
+      throw LOG.filePartNeedsUriOrBytes();
+    }
+    if (bytes.length() > config.maxVariableSize()) {
+      throw LOG.inlineFileTooLarge(bytes.length(), config.maxVariableSize());
+    }
+    return new FileWithBytes(mimeType, name, bytes);
+  }
+
+  private MessageSendConfiguration toConfiguration(SendCommand command) {
+    MessageSendConfiguration.Builder builder = MessageSendConfiguration.builder();
+    boolean configured = false;
+    if (!command.acceptedOutputModes().isEmpty()) {
+      builder.acceptedOutputModes(command.acceptedOutputModes());
+      configured = true;
+    }
+    if (command.historyLength() != null) {
+      builder.historyLength(command.historyLength());
+      configured = true;
+    }
+    if (command.callbackUrl() != null) {
+      builder.taskPushNotificationConfig(toPushNotificationConfig(command));
+      configured = true;
+    }
+    if (command.returnImmediately()) {
+      builder.returnImmediately(true);
+      configured = true;
+    }
+    return configured ? builder.build() : null;
+  }
+
+  /**
+   * The task id is left unset on purpose: the agent has not created the task yet, and binds this configuration to
+   * the task it creates for this message.
+   */
+  private static TaskPushNotificationConfig toPushNotificationConfig(SendCommand command) {
+    TaskPushNotificationConfig.Builder builder = TaskPushNotificationConfig.builder().url(command.callbackUrl());
+    if (command.callbackToken() != null) {
+      builder.token(command.callbackToken());
+    }
+    if (command.callbackAuthScheme() != null) {
+      builder.authentication(new AuthenticationInfo(command.callbackAuthScheme(), command.callbackAuthCredentials()));
+    }
+    if (command.tenant() != null) {
+      builder.tenant(command.tenant());
+    }
+    return builder.build();
+  }
+
+  private TaskSnapshot toSnapshot(ClientEvent event) {
+    if (event instanceof TaskEvent taskEvent) {
+      return fromTask(taskEvent.getTask());
+    }
+    if (event instanceof TaskUpdateEvent updateEvent) {
+      return fromTask(updateEvent.getTask());
+    }
+    if (event instanceof MessageEvent messageEvent) {
+      return fromMessage(messageEvent.getMessage());
+    }
+    throw new A2aCallException("The A2A agent at '%s' returned an unexpected event of type '%s'"
+        .formatted(config.url(), event.getClass().getName()), null, false);
+  }
+
+  /** An agent may answer a simple question directly, without creating a task at all. */
+  private TaskSnapshot fromMessage(Message message) {
+    AtomicBoolean truncated = new AtomicBoolean();
+    Map<String, Object> statusMessage = toMap(message, truncated);
+    return new TaskSnapshot(message.taskId(), message.contextId(), null, statusMessage,
+        List.of(), Map.of(), List.of(), truncated.get());
+  }
+
+  private TaskSnapshot fromTask(Task task) {
+    AtomicBoolean truncated = new AtomicBoolean();
+    TaskStatus status = task.status();
+    String state = status == null || status.state() == null ? null : status.state().name();
+    Map<String, Object> statusMessage = status == null || status.message() == null
+        ? null
+        : toMap(status.message(), truncated);
+
+    List<Map<String, Object>> artifacts = new ArrayList<>();
+    if (task.artifacts() != null) {
+      for (Artifact artifact : task.artifacts()) {
+        artifacts.add(toMap(artifact, truncated));
+      }
+    }
+    List<Map<String, Object>> history = new ArrayList<>();
+    if (task.history() != null) {
+      for (Message message : task.history()) {
+        history.add(toMap(message, truncated));
+      }
+    }
+    return new TaskSnapshot(task.id(), task.contextId(), state, statusMessage, artifacts,
+        normalizeMap(task.metadata()), history, truncated.get());
+  }
+
+  private Map<String, Object> toMap(Message message, AtomicBoolean truncated) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("messageId", message.messageId());
+    map.put("role", message.role() == null ? null : message.role().name());
+    map.put("contextId", message.contextId());
+    map.put("taskId", message.taskId());
+    map.put(KEY_PARTS, toMaps(message.parts(), truncated));
+    map.put(KEY_METADATA, normalizeMap(message.metadata()));
+    map.put("extensions", message.extensions() == null ? List.of() : List.copyOf(message.extensions()));
+    return map;
+  }
+
+  private Map<String, Object> toMap(Artifact artifact, AtomicBoolean truncated) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("artifactId", artifact.artifactId());
+    map.put(KEY_NAME, artifact.name());
+    map.put("description", artifact.description());
+    map.put(KEY_PARTS, toMaps(artifact.parts(), truncated));
+    map.put(KEY_METADATA, normalizeMap(artifact.metadata()));
+    map.put("extensions", artifact.extensions() == null ? List.of() : List.copyOf(artifact.extensions()));
+    return map;
+  }
+
+  private List<Map<String, Object>> toMaps(List<Part<?>> parts, AtomicBoolean truncated) {
+    List<Map<String, Object>> result = new ArrayList<>();
+    if (parts == null) {
+      return result;
+    }
+    for (Part<?> part : parts) {
+      result.add(toMap(part, truncated));
+    }
+    return result;
+  }
+
+  private Map<String, Object> toMap(Part<?> part, AtomicBoolean truncated) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    if (part instanceof TextPart textPart) {
+      map.put(KEY_TYPE, KEY_TEXT);
+      map.put(KEY_TEXT, boundedText(textPart.text(), truncated));
+      map.put(KEY_METADATA, normalizeMap(textPart.metadata()));
+      return map;
+    }
+    if (part instanceof DataPart dataPart) {
+      map.put(KEY_TYPE, KEY_DATA);
+      map.put(KEY_DATA, normalize(dataPart.data()));
+      map.put(KEY_METADATA, normalizeMap(dataPart.metadata()));
+      return map;
+    }
+    if (part instanceof FilePart filePart) {
+      map.put(KEY_TYPE, KEY_FILE);
+      putFileContent(map, filePart.file(), truncated);
+      map.put(KEY_METADATA, normalizeMap(filePart.metadata()));
+      return map;
+    }
+    map.put(KEY_TYPE, "unknown");
+    return map;
+  }
+
+  /**
+   * Writes a returned file into the output map. A file that arrives as a URI stays a URI, which costs nothing.
+   * A file that arrives inline is only passed on while it is small enough to belong in a process variable;
+   * beyond that only its description travels, so that a multi-megabyte payload cannot end up in the history
+   * tables.
+   */
+  private void putFileContent(Map<String, Object> map, FileContent content, AtomicBoolean truncated) {
+    if (content == null) {
+      return;
+    }
+    map.put(KEY_MIME_TYPE, content.mimeType());
+    map.put(KEY_NAME, content.name());
+    if (content instanceof FileWithUri fileWithUri) {
+      map.put(KEY_URI, fileWithUri.uri());
+      return;
+    }
+    if (content instanceof FileWithBytes fileWithBytes) {
+      String bytes = fileWithBytes.bytes();
+      if (bytes != null && bytes.length() > config.maxVariableSize()) {
+        LOG.valueTruncated("inline file part", bytes.length(), config.maxVariableSize());
+        truncated.set(true);
+        map.put("sizeBytes", bytes.length());
+        map.put("truncated", Boolean.TRUE);
+      } else {
+        map.put(KEY_BYTES, bytes);
+      }
+    }
+  }
+
+  private String boundedText(String text, AtomicBoolean truncated) {
+    if (text == null || text.length() <= config.maxVariableSize()) {
+      return text;
+    }
+    LOG.valueTruncated("text part", text.length(), config.maxVariableSize());
+    truncated.set(true);
+    return text.substring(0, config.maxVariableSize());
+  }
+
+  private static String string(Map<String, Object> map, String key) {
+    Object value = map.get(key);
+    return value == null ? null : value.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> mapOrNull(Object value) {
+    if (!(value instanceof Map<?, ?> map) || map.isEmpty()) {
+      return null;
+    }
+    return (Map<String, Object>) value;
+  }
+
+  private static Map<String, Object> normalizeMap(Map<String, Object> value) {
+    if (value == null || value.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, Object> result = new LinkedHashMap<>();
+    value.forEach((key, item) -> result.put(key, normalize(item)));
+    return result;
+  }
+
+  /**
+   * Turns whatever the SDK hands back into plain collections that can be stored as a process variable.
+   *
+   * <p>
+   * Data parts and metadata are free-form JSON, and depending on how the SDK deserialised them they can arrive
+   * as Gson tree nodes rather than as maps. Round-tripping the unknown cases through Gson is the cheapest way
+   * to get something a process variable can hold.
+   * </p>
+   */
+  private static Object normalize(Object value) {
+    if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean) {
+      return value;
+    }
+    if (value instanceof Map<?, ?> map) {
+      Map<String, Object> result = new LinkedHashMap<>();
+      map.forEach((key, item) -> result.put(String.valueOf(key), normalize(item)));
+      return result;
+    }
+    if (value instanceof List<?> list) {
+      List<Object> result = new ArrayList<>();
+      for (Object item : list) {
+        result.add(normalize(item));
+      }
+      return result;
+    }
+    return normalize(GSON.fromJson(GSON.toJson(value), Object.class));
+  }
+
+  private A2aCallException classify(Throwable cause, String message) {
+    A2AClientHTTPError httpError = findCause(cause, A2AClientHTTPError.class);
+    if (httpError != null) {
+      int code = httpError.getCode();
+      boolean retryable = code == 408 || code == 425 || code == 429 || code >= 500;
+      return new A2aCallException("%s: HTTP %d".formatted(message, code), cause, retryable);
+    }
+    if (findCause(cause, A2AProtocolError.class) != null || findCause(cause, A2AClientJSONError.class) != null) {
+      return new A2aCallException("%s: %s".formatted(message, cause.getMessage()), cause, false);
+    }
+    // Connection resets, DNS failures and read timeouts all end up here. Retrying is the right default, and a
+    // permanent problem still surfaces once the job runs out of retries.
+    return new A2aCallException("%s: %s".formatted(message, cause.getMessage()), cause, true);
+  }
+
+  private static <T extends Throwable> T findCause(Throwable throwable, Class<T> type) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (type.isInstance(current)) {
+        return type.cast(current);
+      }
+      current = current.getCause() == current ? null : current.getCause();
+    }
+    return null;
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/TimeoutAwareA2AHttpClient.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/TimeoutAwareA2AHttpClient.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+import org.a2aproject.sdk.client.http.A2AHttpResponse;
+import org.a2aproject.sdk.client.http.ServerSentEvent;
+
+/**
+ * An {@link A2AHttpClient} that puts a read timeout on every request.
+ *
+ * <p>
+ * The SDK's own {@code JdkA2AHttpClient} never calls {@code HttpRequest.Builder.timeout(...)}, and neither the
+ * {@link A2AHttpClient} interface nor its builders expose a way to set one. Without this class an unresponsive
+ * agent would hold a job executor thread until the OS gave up on the socket, which breaks the rule that
+ * nothing in a process engine may block without a bound.
+ * </p>
+ */
+public class TimeoutAwareA2AHttpClient implements A2AHttpClient {
+
+  private final HttpClient httpClient;
+  private final Duration readTimeout;
+
+  public TimeoutAwareA2AHttpClient(int connectTimeoutMs, int readTimeoutMs) {
+    this(HttpClient.newBuilder()
+        .connectTimeout(Duration.ofMillis(connectTimeoutMs))
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .build(), readTimeoutMs);
+  }
+
+  public TimeoutAwareA2AHttpClient(HttpClient httpClient, int readTimeoutMs) {
+    this.httpClient = httpClient;
+    this.readTimeout = Duration.ofMillis(readTimeoutMs);
+  }
+
+  @Override
+  public GetBuilder createGet() {
+    return new TimeoutAwareGetBuilder();
+  }
+
+  @Override
+  public PostBuilder createPost() {
+    return new TimeoutAwarePostBuilder();
+  }
+
+  @Override
+  public DeleteBuilder createDelete() {
+    return new TimeoutAwareDeleteBuilder();
+  }
+
+  private A2AHttpResponse send(HttpRequest request) throws IOException, InterruptedException {
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    return new StringResponse(response.statusCode(), response.body());
+  }
+
+  /**
+   * The connector never enables streaming, so no server-sent-event support is needed here. If streaming is ever
+   * turned on, this is the one place that has to grow an implementation.
+   */
+  private static CompletableFuture<Void> streamingNotSupported() {
+    // ponytail: SSE deliberately unimplemented because the connector polls instead of holding a stream open
+    // on a job executor thread. Implement here if a streaming operation is ever added.
+    throw new UnsupportedOperationException(
+        "The A2A connector does not use server-sent events; it polls with the 'sendSync' operation instead");
+  }
+
+  private record StringResponse(int status, String body) implements A2AHttpResponse {
+
+    @Override
+    public boolean success() {
+      return status >= 200 && status < 300;
+    }
+  }
+
+  private abstract class TimeoutAwareBuilder<T extends Builder<T>> implements Builder<T> {
+
+    protected String url;
+    protected final Map<String, String> headers = new LinkedHashMap<>();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T url(String url) {
+      this.url = url;
+      return (T) this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T addHeaders(Map<String, String> additionalHeaders) {
+      if (additionalHeaders != null) {
+        headers.putAll(additionalHeaders);
+      }
+      return (T) this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T addHeader(String name, String value) {
+      if (name != null && value != null) {
+        headers.put(name, value);
+      }
+      return (T) this;
+    }
+
+    protected HttpRequest.Builder request() {
+      HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url)).timeout(readTimeout);
+      headers.forEach(builder::header);
+      return builder;
+    }
+  }
+
+  private final class TimeoutAwareGetBuilder extends TimeoutAwareBuilder<GetBuilder> implements GetBuilder {
+
+    @Override
+    public A2AHttpResponse get() throws IOException, InterruptedException {
+      return send(request().GET().build());
+    }
+
+    @Override
+    public CompletableFuture<Void> getAsyncSSE(Consumer<ServerSentEvent> eventConsumer,
+                                               Consumer<Throwable> errorConsumer,
+                                               Runnable completeRunnable) {
+      return streamingNotSupported();
+    }
+  }
+
+  private final class TimeoutAwarePostBuilder extends TimeoutAwareBuilder<PostBuilder> implements PostBuilder {
+
+    private String body = "";
+
+    @Override
+    public PostBuilder body(String body) {
+      this.body = body;
+      return this;
+    }
+
+    @Override
+    public A2AHttpResponse post() throws IOException, InterruptedException {
+      return send(request().POST(HttpRequest.BodyPublishers.ofString(body)).build());
+    }
+
+    @Override
+    public CompletableFuture<Void> postAsyncSSE(Consumer<ServerSentEvent> eventConsumer,
+                                                Consumer<Throwable> errorConsumer,
+                                                Runnable completeRunnable) {
+      return streamingNotSupported();
+    }
+  }
+
+  private final class TimeoutAwareDeleteBuilder extends TimeoutAwareBuilder<DeleteBuilder> implements DeleteBuilder {
+
+    @Override
+    public A2AHttpResponse delete() throws IOException, InterruptedException {
+      return send(request().DELETE().build());
+    }
+  }
+
+}

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/package-info.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/impl/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation of the A2A connector.
+ *
+ * <p>
+ * All use of the A2A Java SDK is confined to {@link org.operaton.connect.a2a.impl.SdkA2aAgent} and
+ * {@link org.operaton.connect.a2a.impl.TimeoutAwareA2AHttpClient}, behind the
+ * {@link org.operaton.connect.a2a.impl.A2aAgent} interface, so that a protocol or SDK version bump touches
+ * as few files as possible.
+ * </p>
+ */
+package org.operaton.connect.a2a.impl;

--- a/connect/a2a/src/main/java/org/operaton/connect/a2a/package-info.java
+++ b/connect/a2a/src/main/java/org/operaton/connect/a2a/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Public API of the A2A connector: the {@link org.operaton.connect.a2a.A2aConnector} itself and the input
+ * ({@link org.operaton.connect.a2a.A2aRequest}) and output ({@link org.operaton.connect.a2a.A2aResponse})
+ * parameter names to use from BPMN.
+ */
+package org.operaton.connect.a2a;

--- a/connect/a2a/src/main/resources/META-INF/services/org.operaton.connect.spi.ConnectorProvider
+++ b/connect/a2a/src/main/resources/META-INF/services/org.operaton.connect.spi.ConnectorProvider
@@ -1,0 +1,1 @@
+org.operaton.connect.a2a.impl.A2aConnectorProviderImpl

--- a/connect/a2a/src/main/resources/element-templates/operaton-a2a-connector.json
+++ b/connect/a2a/src/main/resources/element-templates/operaton-a2a-connector.json
@@ -1,0 +1,502 @@
+{
+  "$schema": "https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json",
+  "name": "A2A agent call",
+  "id": "org.operaton.connect.a2a",
+  "description": "Delegates work to an AI agent over the Agent2Agent (A2A) protocol",
+  "documentationRef": "https://github.com/operaton/operaton/blob/main/connect/a2a/README.md",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "properties": [],
+  "groups": [
+    {
+      "id": "agent",
+      "label": "Agent"
+    },
+    {
+      "id": "message",
+      "label": "Message"
+    },
+    {
+      "id": "conversation",
+      "label": "Conversation"
+    },
+    {
+      "id": "callback",
+      "label": "Push notification (sendAsync only)"
+    },
+    {
+      "id": "timeouts",
+      "label": "Timeouts"
+    },
+    {
+      "id": "reliability",
+      "label": "Reliability"
+    },
+    {
+      "id": "output",
+      "label": "Result variables"
+    }
+  ],
+  "scopes": [
+    {
+      "type": "camunda:Connector",
+      "properties": [
+        {
+          "type": "Hidden",
+          "value": "a2a",
+          "binding": {
+            "type": "property",
+            "name": "connectorId"
+          }
+        },
+        {
+          "id": "operation",
+          "label": "Operation",
+          "description": "sendSync waits for the agent to finish. sendAsync returns straight away and the agent calls your webhook. getTask reads a task you already know about.",
+          "group": "agent",
+          "type": "Dropdown",
+          "value": "sendSync",
+          "choices": [
+            {
+              "name": "Send and wait (sendSync)",
+              "value": "sendSync"
+            },
+            {
+              "name": "Send and continue (sendAsync)",
+              "value": "sendAsync"
+            },
+            {
+              "name": "Read a task (getTask)",
+              "value": "getTask"
+            }
+          ],
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "operation"
+          }
+        },
+        {
+          "id": "url",
+          "label": "Agent URL",
+          "description": "The agent base URL, for example https://agent.example.com, or a full agent card URL ending in .json",
+          "group": "agent",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "url"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "id": "headers",
+          "label": "HTTP headers",
+          "description": "A map of headers, for example ${ {'Authorization': 'Bearer ' + agentToken} }. Keep secrets in process variables or engine configuration, never in the diagram.",
+          "group": "agent",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "headers"
+          }
+        },
+        {
+          "id": "message",
+          "label": "Message",
+          "description": "The plain text to send to the agent",
+          "group": "message",
+          "type": "Text",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "message"
+          }
+        },
+        {
+          "id": "parts",
+          "label": "Additional parts",
+          "description": "A list of maps for file and structured data parts, for example ${ [ {'type':'file','uri':invoiceUrl,'mimeType':'application/pdf'} ] }",
+          "group": "message",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "parts"
+          }
+        },
+        {
+          "id": "metadata",
+          "label": "Message metadata",
+          "description": "A map of metadata to attach to the outgoing message",
+          "group": "message",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "metadata"
+          }
+        },
+        {
+          "id": "extensions",
+          "label": "Extensions",
+          "description": "A2A extension URIs to activate, as a list or a comma-separated string",
+          "group": "message",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "extensions"
+          }
+        },
+        {
+          "id": "acceptedOutputModes",
+          "label": "Accepted output modes",
+          "description": "MIME types you can handle back, for example text/plain, application/json",
+          "group": "message",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "acceptedOutputModes"
+          }
+        },
+        {
+          "id": "requestMetadata",
+          "label": "Request metadata",
+          "description": "A map of metadata attached to the send request rather than to the message",
+          "group": "message",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "requestMetadata"
+          }
+        },
+        {
+          "id": "contextId",
+          "label": "Context id",
+          "description": "Set this to continue an earlier conversation, usually ${a2aContextId} from a previous agent task",
+          "group": "conversation",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "contextId"
+          }
+        },
+        {
+          "id": "taskId",
+          "label": "Task id",
+          "description": "Required for getTask. On a send operation it appends the message to an existing task.",
+          "group": "conversation",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "taskId"
+          }
+        },
+        {
+          "id": "referenceTaskIds",
+          "label": "Reference task ids",
+          "description": "Earlier tasks the agent should treat as context",
+          "group": "conversation",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "referenceTaskIds"
+          }
+        },
+        {
+          "id": "historyLength",
+          "label": "History length",
+          "description": "How many earlier messages the agent should return",
+          "group": "conversation",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "historyLength"
+          }
+        },
+        {
+          "id": "tenant",
+          "label": "Tenant",
+          "description": "The A2A tenant to scope the call to",
+          "group": "conversation",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "tenant"
+          }
+        },
+        {
+          "id": "callbackUrl",
+          "label": "Callback URL",
+          "description": "Where the agent POSTs the push notification. Required for sendAsync, ignored otherwise.",
+          "group": "callback",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "callbackUrl"
+          }
+        },
+        {
+          "id": "callbackToken",
+          "label": "Callback token",
+          "description": "A token the agent echoes back, so your webhook can tell a real notification from a forged one",
+          "group": "callback",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "callbackToken"
+          }
+        },
+        {
+          "id": "callbackAuthScheme",
+          "label": "Callback auth scheme",
+          "description": "For example Bearer",
+          "group": "callback",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "callbackAuthScheme"
+          }
+        },
+        {
+          "id": "callbackAuthCredentials",
+          "label": "Callback auth credentials",
+          "description": "Read this from a process variable, not from the diagram",
+          "group": "callback",
+          "type": "String",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "callbackAuthCredentials"
+          }
+        },
+        {
+          "id": "connectTimeout",
+          "label": "Connect timeout (ms)",
+          "group": "timeouts",
+          "type": "String",
+          "value": "10000",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "connectTimeout"
+          }
+        },
+        {
+          "id": "readTimeout",
+          "label": "Read timeout (ms)",
+          "description": "Applies to each individual HTTP call",
+          "group": "timeouts",
+          "type": "String",
+          "value": "30000",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "readTimeout"
+          }
+        },
+        {
+          "id": "waitTimeout",
+          "label": "Total wait (ms)",
+          "description": "How long sendSync waits for the agent to finish before raising a2a-timeout",
+          "group": "timeouts",
+          "type": "String",
+          "value": "120000",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "waitTimeout"
+          }
+        },
+        {
+          "id": "pollInterval",
+          "label": "Poll interval (ms)",
+          "group": "timeouts",
+          "type": "String",
+          "value": "2000",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "pollInterval"
+          }
+        },
+        {
+          "id": "idempotencyKey",
+          "label": "Idempotency key",
+          "description": "Must be stable across job retries and unique per activity instance. Leave the default unless you have a business key that is a better fit.",
+          "group": "reliability",
+          "type": "String",
+          "value": "${execution.getProcessInstanceId()}-${execution.getActivityInstanceId()}",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "idempotencyKey"
+          }
+        },
+        {
+          "id": "reattachOnRetry",
+          "label": "Reattach on retry",
+          "description": "Before sending, look for a task an earlier failed attempt already created, so a retry does not pay the agent twice",
+          "group": "reliability",
+          "type": "Dropdown",
+          "value": "true",
+          "choices": [
+            {
+              "name": "Yes",
+              "value": "true"
+            },
+            {
+              "name": "No",
+              "value": "false"
+            }
+          ],
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "reattachOnRetry"
+          }
+        },
+        {
+          "id": "maxVariableSize",
+          "label": "Max variable size (bytes)",
+          "description": "Larger returned files are replaced by a reference and larger texts are cut short, to keep the database healthy",
+          "group": "reliability",
+          "type": "String",
+          "value": "65536",
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "maxVariableSize"
+          }
+        },
+        {
+          "id": "includeHistory",
+          "label": "Include history",
+          "group": "reliability",
+          "type": "Dropdown",
+          "value": "false",
+          "choices": [
+            {
+              "name": "No",
+              "value": "false"
+            },
+            {
+              "name": "Yes",
+              "value": "true"
+            }
+          ],
+          "binding": {
+            "type": "camunda:inputParameter",
+            "name": "includeHistory"
+          }
+        },
+        {
+          "id": "outputText",
+          "label": "Answer text into",
+          "description": "Process variable that receives the agent's answer as plain text",
+          "group": "output",
+          "type": "String",
+          "value": "a2aText",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${text}"
+          }
+        },
+        {
+          "id": "outputArtifacts",
+          "label": "Artifacts into",
+          "description": "Process variable that receives every artifact, with all their parts",
+          "group": "output",
+          "type": "String",
+          "value": "a2aArtifacts",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${artifacts}"
+          }
+        },
+        {
+          "id": "outputArtifactText",
+          "label": "Artifact text into",
+          "group": "output",
+          "type": "String",
+          "value": "a2aArtifactText",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${artifactText}"
+          }
+        },
+        {
+          "id": "outputTaskId",
+          "label": "Task id into",
+          "description": "Needed to correlate a push notification back to this process instance",
+          "group": "output",
+          "type": "String",
+          "value": "a2aTaskId",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${taskId}"
+          }
+        },
+        {
+          "id": "outputContextId",
+          "label": "Context id into",
+          "group": "output",
+          "type": "String",
+          "value": "a2aContextId",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${contextId}"
+          }
+        },
+        {
+          "id": "outputState",
+          "label": "State into",
+          "group": "output",
+          "type": "String",
+          "value": "a2aState",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${state}"
+          }
+        },
+        {
+          "id": "outputStatusMessage",
+          "label": "Status message into",
+          "group": "output",
+          "type": "String",
+          "value": "a2aStatusMessage",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${statusMessage}"
+          }
+        },
+        {
+          "id": "outputTaskMetadata",
+          "label": "Task metadata into",
+          "group": "output",
+          "type": "String",
+          "value": "a2aTaskMetadata",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${taskMetadata}"
+          }
+        },
+        {
+          "id": "outputMessageMetadata",
+          "label": "Message metadata into",
+          "group": "output",
+          "type": "String",
+          "value": "a2aMessageMetadata",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${messageMetadata}"
+          }
+        },
+        {
+          "id": "outputTruncated",
+          "label": "Truncated flag into",
+          "description": "True when a value was too large for a process variable",
+          "group": "output",
+          "type": "String",
+          "value": "a2aTruncated",
+          "binding": {
+            "type": "camunda:outputParameter",
+            "source": "${truncated}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/connect/a2a/src/main/resources/element-templates/operaton-a2a-connector.json
+++ b/connect/a2a/src/main/resources/element-templates/operaton-a2a-connector.json
@@ -385,7 +385,7 @@
         {
           "id": "outputText",
           "label": "Answer text into",
-          "description": "Process variable that receives the agent's answer as plain text",
+          "description": "Process variable that receives the agent's answer as plain text. Falls back to the artifact text when the agent answers with artifacts only.",
           "group": "output",
           "type": "String",
           "value": "a2aText",

--- a/connect/a2a/src/main/resources/element-templates/operaton-a2a-connector.json
+++ b/connect/a2a/src/main/resources/element-templates/operaton-a2a-connector.json
@@ -5,11 +5,10 @@
   "description": "Delegates work to an AI agent over the Agent2Agent (A2A) protocol",
   "documentationRef": "https://github.com/operaton/operaton/blob/main/connect/a2a/README.md",
   "appliesTo": [
-    "bpmn:ServiceTask"
+    "bpmn:ServiceTask",
+    "bpmn:SendTask",
+    "bpmn:BusinessRuleTask"
   ],
-  "elementType": {
-    "value": "bpmn:ServiceTask"
-  },
   "properties": [],
   "groups": [
     {

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/A2aConnectorProcessTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/A2aConnectorProcessTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.ManagementService;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.connect.Connectors;
+import org.operaton.connect.a2a.impl.A2aConnectorImpl;
+import org.operaton.connect.a2a.impl.FakeA2aAgentFactory;
+import org.operaton.connect.spi.Connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Runs the example processes on a real engine, with a scripted agent behind the connector.
+ *
+ * <p>
+ * These tests exist to prove the parts that only the engine can prove: that a {@code BpmnError} actually reaches
+ * an error boundary event, that outputs land in process variables, and that the async and polling shapes work as
+ * modelled. Nothing here touches the network.
+ * </p>
+ */
+class A2aConnectorProcessTest {
+
+  private static final String SEND_SYNC = "org/operaton/connect/a2a/examples/a2a-send-sync.bpmn";
+  private static final String SEND_ASYNC = "org/operaton/connect/a2a/examples/a2a-send-async.bpmn";
+  private static final String POLL_FALLBACK = "org/operaton/connect/a2a/examples/a2a-poll-fallback.bpmn";
+
+  @RegisterExtension
+  static ProcessEngineExtension engineExtension = ProcessEngineExtension.builder().build();
+
+  private RuntimeService runtimeService;
+  private HistoryService historyService;
+  private ManagementService managementService;
+  private FakeA2aAgentFactory agents;
+
+  @BeforeEach
+  void setUp() {
+    runtimeService = engineExtension.getRuntimeService();
+    historyService = engineExtension.getHistoryService();
+    managementService = engineExtension.getManagementService();
+
+    agents = new FakeA2aAgentFactory();
+    a2aConnector().setAgentFactory(agents);
+  }
+
+  @Test
+  void theConnectorIsDiscoveredByTheServiceLoader() {
+    Connector<?> connector = Connectors.getConnector(A2aConnector.ID);
+
+    assertThat(connector).isNotNull();
+    assertThat(connector.getId()).isEqualTo(A2aConnector.ID);
+  }
+
+  @Test
+  @Deployment(resources = SEND_SYNC)
+  void sendSyncPutsTheAnswerIntoProcessVariables() {
+    agents.completesWith("task-1", "ctx-1", "The answer is 42");
+
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("a2aSendSync", variables());
+
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId()).singleResult()).isNull();
+    assertThat(historicVariable(instance.getId(), "answer")).isEqualTo("The answer is 42");
+    assertThat(historicVariable(instance.getId(), "a2aTaskId")).isEqualTo("task-1");
+    assertThat(historicVariable(instance.getId(), "a2aContextId")).isEqualTo("ctx-1");
+    assertThat(historicVariable(instance.getId(), "a2aState")).isEqualTo("TASK_STATE_COMPLETED");
+    assertThat(historicVariable(instance.getId(), "a2aTruncated")).isEqualTo(false);
+  }
+
+  @Test
+  @Deployment(resources = SEND_SYNC)
+  void anAgentFailureIsCaughtByTheErrorBoundaryEvent() {
+    agents.failsWith("task-1", "ctx-1");
+
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("a2aSendSync", variables());
+
+    assertThat(activityCompleted(instance.getId(), "failed")).isTrue();
+    assertThat(activityCompleted(instance.getId(), "done")).isFalse();
+  }
+
+  @Test
+  @Deployment(resources = SEND_SYNC)
+  void theHeaderValueIsSentButNeverPutIntoAVariable() {
+    agents.completesWith("task-1", "ctx-1", "ok");
+
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("a2aSendSync", variables());
+
+    assertThat(agents.lastConfig().headers()).containsEntry("Authorization", "Bearer secret-token");
+    assertThat(historicVariable(instance.getId(), "headers")).isNull();
+  }
+
+  @Test
+  @Deployment(resources = SEND_ASYNC)
+  void sendAsyncWaitsAtTheReceiveTaskUntilTheCallbackIsCorrelated() {
+    agents.submitsAs("task-1", "ctx-1");
+
+    Map<String, Object> variables = variables();
+    variables.put("documentUrl", "https://files.example.com/document.pdf");
+    variables.put("callbackUrl", "https://my-engine.example.com/a2a/callback");
+    variables.put("callbackToken", "shared-secret");
+    variables.put("callbackCredentials", "callback-secret");
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("a2aSendAsync", variables);
+
+    // The push notification config travelled with the send, and the ids needed to correlate are already stored.
+    assertThat(agents.lastSend().callbackUrl()).isEqualTo("https://my-engine.example.com/a2a/callback");
+    assertThat(agents.lastSend().returnImmediately()).isTrue();
+    assertThat(runtimeService.getVariable(instance.getId(), "a2aTaskId")).isEqualTo("task-1");
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId()).singleResult())
+        .isNotNull();
+
+    // This is what a webhook endpoint does when the agent calls it.
+    runtimeService.createMessageCorrelation("a2aCallback")
+        .processInstanceVariableEquals("a2aTaskId", "task-1")
+        .correlateWithResult();
+
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId()).singleResult()).isNull();
+    assertThat(activityCompleted(instance.getId(), "done")).isTrue();
+  }
+
+  @Test
+  @Deployment(resources = SEND_ASYNC)
+  void aCallbackThatNeverArrivesIsHandledByTheTimerBoundaryEvent() {
+    agents.submitsAs("task-1", "ctx-1");
+
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("a2aSendAsync", variables());
+
+    Job timer = managementService.createJobQuery().processInstanceId(instance.getId()).timers().singleResult();
+    assertThat(timer).isNotNull();
+    managementService.executeJob(timer.getId());
+
+    assertThat(activityCompleted(instance.getId(), "gaveUp")).isTrue();
+  }
+
+  @Test
+  @Deployment(resources = POLL_FALLBACK)
+  void thePollingFallbackReadsTheTaskOnATimer() {
+    agents.submitsAs("task-1", "ctx-1");
+
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("a2aPollFallback", variables());
+    assertThat(runtimeService.getVariable(instance.getId(), "a2aTaskId")).isEqualTo("task-1");
+
+    // Still working: the process loops back to the timer rather than finishing.
+    agents.getTaskReturns("task-1", "ctx-1", "TASK_STATE_WORKING", null);
+    managementService.executeJob(firstTimer(instance.getId()));
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId()).singleResult())
+        .isNotNull();
+
+    // Now finished: the next poll ends the process with the answer.
+    agents.getTaskReturns("task-1", "ctx-1", "TASK_STATE_COMPLETED", "42");
+    managementService.executeJob(firstTimer(instance.getId()));
+
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId()).singleResult()).isNull();
+    assertThat(historicVariable(instance.getId(), "answer")).isEqualTo("42");
+  }
+
+  private String firstTimer(String processInstanceId) {
+    Job timer = managementService.createJobQuery().processInstanceId(processInstanceId).timers().list().get(0);
+    return timer.getId();
+  }
+
+  private static Map<String, Object> variables() {
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("agentUrl", "https://agent.example.com");
+    variables.put("agentToken", "secret-token");
+    variables.put("question", "What is the answer?");
+    return variables;
+  }
+
+  private Object historicVariable(String processInstanceId, String name) {
+    var variable = historyService.createHistoricVariableInstanceQuery()
+        .processInstanceId(processInstanceId)
+        .variableName(name)
+        .singleResult();
+    return variable == null ? null : variable.getValue();
+  }
+
+  private boolean activityCompleted(String processInstanceId, String activityId) {
+    return historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId)
+        .activityId(activityId)
+        .count() > 0;
+  }
+
+  private static A2aConnectorImpl a2aConnector() {
+    return Connectors.getConnector(A2aConnector.ID);
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aConnectorImplTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aConnectorImplTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.delegate.BpmnError;
+import org.operaton.connect.ConnectorRequestException;
+import org.operaton.connect.a2a.A2aRequest;
+import org.operaton.connect.a2a.A2aResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers what the connector does with a request and with whatever the agent answers, using a scripted agent so
+ * that timing and failure modes are exact.
+ */
+class A2aConnectorImplTest {
+
+  private static final String URL = "https://agent.example.com";
+  private static final String KEY = "process-instance-1-activity-instance-1";
+
+  private FakeA2aAgent agent;
+  private A2aConnectorImpl connector;
+
+  @BeforeEach
+  void setUp() {
+    agent = new FakeA2aAgent();
+    connector = new A2aConnectorImpl();
+    connector.setAgentFactory(config -> agent);
+  }
+
+  @Test
+  void sendSyncMapsTheAnswerToOutputs() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    A2aResponse response = connector.execute(sendSync());
+
+    assertThat(response.getText()).isEqualTo("42");
+    assertThat(response.getTaskId()).isEqualTo("task-1");
+    assertThat(response.getState()).isEqualTo(A2aErrors.STATE_COMPLETED);
+    assertThat(agent.sends).hasSize(1);
+  }
+
+  @Test
+  void theMessageIdIsTheSameAcrossRetriesOfTheSameActivity() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    connector.execute(sendSync());
+    connector.execute(sendSync());
+
+    assertThat(agent.sends.get(0).messageId()).isEqualTo(agent.sends.get(1).messageId());
+  }
+
+  @Test
+  void aDerivedContextIdIsUsedWhenTheModellerDoesNotSupplyOne() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    connector.execute(sendSync());
+
+    assertThat(agent.sends.get(0).contextId()).isEqualTo(A2aIds.contextId(KEY));
+  }
+
+  @Test
+  void aRetryReattachesInsteadOfDispatchingASecondTask() {
+    agent.reattachableTaskId = java.util.Optional.of("task-1");
+    agent.getTaskResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    A2aResponse response = connector.execute(sendSync());
+
+    assertThat(agent.sends).isEmpty();
+    assertThat(agent.getTaskCalls).containsExactly("task-1");
+    assertThat(response.getText()).isEqualTo("42");
+  }
+
+  @Test
+  void reattachCanBeTurnedOff() {
+    agent.reattachableTaskId = java.util.Optional.of("task-1");
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-2", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    A2aRequest request = sendSync();
+    request.setRequestParameter(A2aRequest.PARAM_REATTACH_ON_RETRY, "false");
+    connector.execute(request);
+
+    assertThat(agent.sends).hasSize(1);
+  }
+
+  @Test
+  void anExplicitContextIdIsNeverProbedForReattachment() {
+    // A modeller-supplied context belongs to a longer conversation, so an earlier task in it is not ours.
+    agent.reattachableTaskId = java.util.Optional.of("task-from-earlier-turn");
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-2", "my-conversation", A2aErrors.STATE_COMPLETED, "42"));
+
+    A2aRequest request = sendSync();
+    request.setRequestParameter(A2aRequest.PARAM_CONTEXT_ID, "my-conversation");
+    connector.execute(request);
+
+    assertThat(agent.sends).hasSize(1);
+    assertThat(agent.sends.get(0).contextId()).isEqualTo("my-conversation");
+  }
+
+  @Test
+  void sendSyncPollsUntilTheTaskSettles() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_SUBMITTED, null));
+    agent.getTaskResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_WORKING, null));
+    agent.getTaskResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    A2aRequest request = sendSync();
+    request.setRequestParameter(A2aRequest.PARAM_POLL_INTERVAL, "1");
+    A2aResponse response = connector.execute(request);
+
+    assertThat(agent.getTaskCalls).hasSize(2);
+    assertThat(response.getText()).isEqualTo("42");
+  }
+
+  @Test
+  void anAgentThatNeverFinishesRaisesTheTimeoutError() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_WORKING, null));
+    agent.getTaskResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_WORKING, null));
+
+    A2aRequest request = sendSync();
+    request.setRequestParameter(A2aRequest.PARAM_WAIT_TIMEOUT, "30");
+    request.setRequestParameter(A2aRequest.PARAM_POLL_INTERVAL, "1");
+
+    assertThatThrownBy(() -> connector.execute(request))
+        .isInstanceOf(BpmnError.class)
+        .hasFieldOrPropertyWithValue("errorCode", A2aErrors.CODE_TIMEOUT);
+  }
+
+  @Test
+  void aFailedTaskBecomesACatchableBpmnError() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_FAILED, "I could not do it"));
+
+    assertThatThrownBy(() -> connector.execute(sendSync()))
+        .isInstanceOf(BpmnError.class)
+        .hasFieldOrPropertyWithValue("errorCode", A2aErrors.CODE_TASK_FAILED)
+        // Outputs are not mapped on the error path, so the ids have to travel in the message.
+        .hasMessageContaining("task-1");
+  }
+
+  @Test
+  void aRejectedTaskAndACanceledTaskHaveTheirOwnErrorCodes() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_REJECTED, null));
+    assertThatThrownBy(() -> connector.execute(sendSync()))
+        .isInstanceOf(BpmnError.class)
+        .hasFieldOrPropertyWithValue("errorCode", A2aErrors.CODE_TASK_REJECTED);
+
+    setUp();
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_CANCELED, null));
+    assertThatThrownBy(() -> connector.execute(sendSync()))
+        .isInstanceOf(BpmnError.class)
+        .hasFieldOrPropertyWithValue("errorCode", A2aErrors.CODE_TASK_CANCELED);
+  }
+
+  @Test
+  void aTaskWaitingForInputIsNotAnErrorAndKeepsItsIds() {
+    agent.sendResults.add(
+        FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_INPUT_REQUIRED, "Which invoice do you mean?"));
+
+    A2aResponse response = connector.execute(sendSync());
+
+    assertThat(response.getState()).isEqualTo(A2aErrors.STATE_INPUT_REQUIRED);
+    assertThat(response.getTaskId()).isEqualTo("task-1");
+    assertThat(response.getContextId()).isEqualTo("ctx-1");
+    assertThat(response.getText()).isEqualTo("Which invoice do you mean?");
+  }
+
+  @Test
+  void aTransportFailureIsLeftForTheJobExecutorToRetry() {
+    agent.sendFailure = new A2aCallException("connection reset", null, true);
+
+    assertThatThrownBy(() -> connector.execute(sendSync()))
+        .isInstanceOf(ConnectorRequestException.class)
+        .isNotInstanceOf(BpmnError.class);
+  }
+
+  @Test
+  void aPermanentProtocolFailureBecomesABpmnError() {
+    agent.sendFailure = new A2aCallException("method not found", null, false);
+
+    assertThatThrownBy(() -> connector.execute(sendSync()))
+        .isInstanceOf(BpmnError.class)
+        .hasFieldOrPropertyWithValue("errorCode", A2aErrors.CODE_PROTOCOL_ERROR);
+  }
+
+  @Test
+  void sendAsyncReturnsWithoutWaiting() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_SUBMITTED, null));
+
+    A2aRequest request = connector.createRequest()
+        .operation(A2aRequest.OPERATION_SEND_ASYNC)
+        .url(URL)
+        .message("do the thing");
+    request.setRequestParameter(A2aRequest.PARAM_CALLBACK_URL, "https://my-engine.example.com/a2a/callback");
+    request.setRequestParameter(A2aRequest.PARAM_CALLBACK_TOKEN, "shared-secret");
+
+    A2aResponse response = connector.execute(request);
+
+    assertThat(agent.getTaskCalls).isEmpty();
+    assertThat(response.getState()).isEqualTo(A2aErrors.STATE_SUBMITTED);
+    assertThat(response.getTaskId()).isEqualTo("task-1");
+    A2aAgent.SendCommand sent = agent.sends.get(0);
+    assertThat(sent.returnImmediately()).isTrue();
+    assertThat(sent.callbackUrl()).isEqualTo("https://my-engine.example.com/a2a/callback");
+    assertThat(sent.callbackToken()).isEqualTo("shared-secret");
+  }
+
+  @Test
+  void getTaskReadsAKnownTaskWithoutSending() {
+    agent.getTaskResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "42"));
+
+    A2aRequest request = connector.createRequest()
+        .operation(A2aRequest.OPERATION_GET_TASK)
+        .url(URL)
+        .taskId("task-1");
+
+    assertThat(connector.execute(request).getText()).isEqualTo("42");
+    assertThat(agent.sends).isEmpty();
+  }
+
+  @Test
+  void everyPartTypeAndAllMessageFieldsReachTheAgent() {
+    agent.sendResults.add(FakeA2aAgent.snapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED, "ok"));
+
+    A2aRequest request = sendSync();
+    request.setRequestParameter(A2aRequest.PARAM_PARTS, List.of(
+        Map.of("type", "text", "text", "extra text"),
+        Map.of("type", "file", "uri", "https://files.example.com/a.pdf", "mimeType", "application/pdf"),
+        Map.of("type", "data", "data", Map.of("invoiceNumber", "2026-1"))));
+    request.setRequestParameter(A2aRequest.PARAM_METADATA, Map.of("caller", "operaton"));
+    request.setRequestParameter(A2aRequest.PARAM_EXTENSIONS, "https://example.com/ext/v1");
+    request.setRequestParameter(A2aRequest.PARAM_REFERENCE_TASK_IDS, List.of("earlier-task"));
+    request.setRequestParameter(A2aRequest.PARAM_REQUEST_METADATA, Map.of("priority", "high"));
+    request.setRequestParameter(A2aRequest.PARAM_TENANT, "tenant-a");
+    request.setRequestParameter(A2aRequest.PARAM_ACCEPTED_OUTPUT_MODES, "text/plain,application/json");
+    request.setRequestParameter(A2aRequest.PARAM_HISTORY_LENGTH, "5");
+
+    connector.execute(request);
+
+    A2aAgent.SendCommand sent = agent.sends.get(0);
+    assertThat(sent.text()).isEqualTo("What is the answer?");
+    assertThat(sent.parts()).hasSize(3);
+    assertThat(sent.metadata()).containsEntry("caller", "operaton");
+    assertThat(sent.extensions()).containsExactly("https://example.com/ext/v1");
+    assertThat(sent.referenceTaskIds()).containsExactly("earlier-task");
+    assertThat(sent.requestMetadata()).containsEntry("priority", "high");
+    assertThat(sent.tenant()).isEqualTo("tenant-a");
+    assertThat(sent.acceptedOutputModes()).containsExactly("text/plain", "application/json");
+    assertThat(sent.historyLength()).isEqualTo(5);
+  }
+
+  @Test
+  void missingRequiredInputsAreRejectedWithAUsefulMessage() {
+    assertThatThrownBy(() -> connector.execute(connector.createRequest().url(URL).message("hi")))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("operation");
+
+    assertThatThrownBy(() -> connector.execute(
+        connector.createRequest().operation(A2aRequest.OPERATION_SEND_SYNC).message("hi")))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("url");
+
+    assertThatThrownBy(() -> connector.execute(
+        connector.createRequest().operation(A2aRequest.OPERATION_GET_TASK).url(URL)))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("taskId");
+
+    assertThatThrownBy(() -> connector.execute(
+        connector.createRequest().operation(A2aRequest.OPERATION_SEND_SYNC).url(URL)))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("parts");
+
+    assertThatThrownBy(() -> connector.execute(
+        connector.createRequest().operation("teleport").url(URL).message("hi")))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("teleport");
+  }
+
+  @Test
+  void theConnectorIsRegisteredUnderTheDocumentedId() {
+    assertThat(connector.getId()).isEqualTo("a2a");
+  }
+
+  private A2aRequest sendSync() {
+    A2aRequest request = connector.createRequest()
+        .operation(A2aRequest.OPERATION_SEND_SYNC)
+        .url(URL)
+        .message("What is the answer?");
+    request.setRequestParameter(A2aRequest.PARAM_IDEMPOTENCY_KEY, KEY);
+    return request;
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aIdsTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aIdsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The whole point of these ids is that a retried job produces the same ones, so that is what is asserted here.
+ */
+class A2aIdsTest {
+
+  private static final String KEY = "process-instance-1-activity-instance-1";
+
+  @Test
+  void messageIdIsStableForTheSameKey() {
+    assertThat(A2aIds.messageId(KEY)).isEqualTo(A2aIds.messageId(KEY));
+  }
+
+  @Test
+  void contextIdIsStableForTheSameKey() {
+    assertThat(A2aIds.contextId(KEY)).isEqualTo(A2aIds.contextId(KEY));
+  }
+
+  @Test
+  void differentKeysProduceDifferentIds() {
+    assertThat(A2aIds.messageId(KEY)).isNotEqualTo(A2aIds.messageId(KEY + "-other"));
+  }
+
+  @Test
+  void messageAndContextIdDifferForTheSameKey() {
+    assertThat(A2aIds.messageId(KEY)).isNotEqualTo(A2aIds.contextId(KEY));
+  }
+
+  @Test
+  void idsArePrefixedAndBounded() {
+    assertThat(A2aIds.messageId(KEY)).startsWith("msg-").hasSize(36);
+    assertThat(A2aIds.contextId(KEY)).startsWith("ctx-").hasSize(36);
+  }
+
+  @Test
+  void withoutAKeyIdsAreRandomSoNothingIsAccidentallyDeduplicated() {
+    assertThat(A2aIds.messageId(null)).isNotEqualTo(A2aIds.messageId(null));
+    assertThat(A2aIds.contextId(null)).isNotEqualTo(A2aIds.contextId(null));
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aParamsTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aParamsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.connect.ConnectorRequestException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A literal input parameter in a diagram is always a string, while the same parameter written as an expression
+ * can be any type. Both have to work, so both are covered here, together with the null, empty and blank cases.
+ */
+class A2aParamsTest {
+
+  private final A2aRequestImpl request = new A2aRequestImpl(null);
+
+  @Test
+  void stringIsTrimmedAndBlankCountsAsAbsent() {
+    request.setRequestParameter("a", "  hello  ");
+    request.setRequestParameter("b", "   ");
+    request.setRequestParameter("c", "");
+
+    assertThat(A2aParams.string(request, "a")).isEqualTo("hello");
+    assertThat(A2aParams.string(request, "b")).isNull();
+    assertThat(A2aParams.string(request, "c")).isNull();
+    assertThat(A2aParams.string(request, "missing")).isNull();
+  }
+
+  @Test
+  void integerAcceptsBothLiteralsAndExpressionResults() {
+    request.setRequestParameter("literal", "3000");
+    request.setRequestParameter("expression", 4000);
+    request.setRequestParameter("padded", " 5000 ");
+
+    assertThat(A2aParams.integer(request, "literal", 1)).isEqualTo(3000);
+    assertThat(A2aParams.integer(request, "expression", 1)).isEqualTo(4000);
+    assertThat(A2aParams.integer(request, "padded", 1)).isEqualTo(5000);
+    assertThat(A2aParams.integer(request, "missing", 42)).isEqualTo(42);
+    assertThat(A2aParams.integerOrNull(request, "missing")).isNull();
+  }
+
+  @Test
+  void aNonNumericNumberIsRejectedWithTheParameterName() {
+    request.setRequestParameter("waitTimeout", "soon");
+
+    assertThatThrownBy(() -> A2aParams.integer(request, "waitTimeout", 1))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("waitTimeout");
+  }
+
+  @Test
+  void booleanAcceptsBothLiteralsAndExpressionResults() {
+    request.setRequestParameter("literal", "true");
+    request.setRequestParameter("expression", Boolean.TRUE);
+    request.setRequestParameter("nonsense", "yes");
+
+    assertThat(A2aParams.bool(request, "literal", false)).isTrue();
+    assertThat(A2aParams.bool(request, "expression", false)).isTrue();
+    assertThat(A2aParams.bool(request, "nonsense", true)).isFalse();
+    assertThat(A2aParams.bool(request, "missing", true)).isTrue();
+  }
+
+  @Test
+  void headerMapDropsEntriesWithoutAValue() {
+    Map<String, Object> headers = new LinkedHashMap<>();
+    headers.put("Authorization", "Bearer token");
+    headers.put("X-Empty", null);
+    request.setRequestParameter("headers", headers);
+
+    assertThat(A2aParams.stringMap(request, "headers"))
+        .containsExactly(Map.entry("Authorization", "Bearer token"));
+  }
+
+  @Test
+  void stringListSplitsACommaSeparatedLiteral() {
+    request.setRequestParameter("modes", "text/plain, application/json ,");
+
+    assertThat(A2aParams.stringList(request, "modes")).containsExactly("text/plain", "application/json");
+  }
+
+  @Test
+  void stringListAlsoAcceptsARealList() {
+    request.setRequestParameter("modes", List.of("text/plain", "application/json"));
+
+    assertThat(A2aParams.stringList(request, "modes")).containsExactly("text/plain", "application/json");
+  }
+
+  @Test
+  void absentCollectionsAreEmptyRatherThanNull() {
+    assertThat(A2aParams.stringMap(request, "missing")).isEmpty();
+    assertThat(A2aParams.objectMap(request, "missing")).isEmpty();
+    assertThat(A2aParams.stringList(request, "missing")).isEmpty();
+    assertThat(A2aParams.mapList(request, "missing")).isEmpty();
+  }
+
+  @Test
+  void aMapWhereAListWasExpectedIsRejected() {
+    request.setRequestParameter("parts", Map.of("type", "text"));
+
+    assertThatThrownBy(() -> A2aParams.mapList(request, "parts"))
+        .isInstanceOf(ConnectorRequestException.class)
+        .hasMessageContaining("parts");
+  }
+
+  @Test
+  void partsMustBeAListOfMaps() {
+    request.setRequestParameter("parts", List.of("not a map"));
+
+    assertThatThrownBy(() -> A2aParams.mapList(request, "parts"))
+        .isInstanceOf(ConnectorRequestException.class);
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aResponseImplTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aResponseImplTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.connect.a2a.A2aResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Output mapping: what a modeller can actually reference from an {@code operaton:outputParameter}.
+ */
+class A2aResponseImplTest {
+
+  private static final int MAX = 64 * 1024;
+
+  @Test
+  void textIsTheTextOfTheFinalMessage() {
+    A2aResponse response = response(FakeA2aAgent.snapshot("t1", "c1", A2aErrors.STATE_COMPLETED, "The answer is 42"));
+
+    assertThat(response.getText()).isEqualTo("The answer is 42");
+    assertThat(response.getTaskId()).isEqualTo("t1");
+    assertThat(response.getContextId()).isEqualTo("c1");
+    assertThat(response.getState()).isEqualTo(A2aErrors.STATE_COMPLETED);
+    assertThat(response.isTruncated()).isFalse();
+  }
+
+  @Test
+  void multipleTextPartsAreJoinedByNewlines() {
+    Map<String, Object> message = Map.of("parts", List.of(
+        Map.of("type", "text", "text", "first"),
+        Map.of("type", "data", "data", Map.of("ignored", true)),
+        Map.of("type", "text", "text", "second")));
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        message, List.of(), Map.of(), List.of(), false);
+
+    assertThat(response(snapshot).getText()).isEqualTo("first\nsecond");
+  }
+
+  @Test
+  void everyArtifactIsReachableNotJustTheFirst() {
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        FakeA2aAgent.message("done"),
+        List.of(FakeA2aAgent.artifact("summary", "a summary"), FakeA2aAgent.artifact("detail", "the detail")),
+        Map.of(), List.of(), false);
+
+    A2aResponse response = response(snapshot);
+    assertThat(response.getArtifacts()).hasSize(2);
+    Map<String, Object> parameters = response.getResponseParameters();
+    assertThat(parameters.get(A2aResponse.PARAM_ARTIFACT_TEXT)).isEqualTo("a summary\nthe detail");
+  }
+
+  @Test
+  void allDocumentedOutputsArePresent() {
+    Map<String, Object> parameters =
+        response(FakeA2aAgent.snapshot("t1", "c1", A2aErrors.STATE_COMPLETED, "hi")).getResponseParameters();
+
+    assertThat(parameters).containsKeys(A2aResponse.PARAM_TEXT, A2aResponse.PARAM_ARTIFACT_TEXT,
+        A2aResponse.PARAM_STATUS_MESSAGE, A2aResponse.PARAM_ARTIFACTS, A2aResponse.PARAM_TASK,
+        A2aResponse.PARAM_TASK_ID, A2aResponse.PARAM_CONTEXT_ID, A2aResponse.PARAM_STATE,
+        A2aResponse.PARAM_TASK_METADATA, A2aResponse.PARAM_MESSAGE_METADATA, A2aResponse.PARAM_TRUNCATED);
+  }
+
+  @Test
+  void historyIsOnlyExposedWhenAskedFor() {
+    A2aAgent.TaskSnapshot snapshot = FakeA2aAgent.snapshot("t1", "c1", A2aErrors.STATE_COMPLETED, "hi");
+
+    assertThat(new A2aResponseImpl(snapshot, false, MAX).getResponseParameters())
+        .doesNotContainKey(A2aResponse.PARAM_HISTORY);
+    assertThat(new A2aResponseImpl(snapshot, true, MAX).getResponseParameters())
+        .containsKey(A2aResponse.PARAM_HISTORY);
+  }
+
+  @Test
+  void theTaskOutputCarriesTheWholeTask() {
+    Map<String, Object> parameters =
+        response(FakeA2aAgent.snapshot("t1", "c1", A2aErrors.STATE_COMPLETED, "hi")).getResponseParameters();
+
+    assertThat(parameters.get(A2aResponse.PARAM_TASK)).isInstanceOf(Map.class);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> task = (Map<String, Object>) parameters.get(A2aResponse.PARAM_TASK);
+    assertThat(task).containsEntry("id", "t1").containsEntry("contextId", "c1").containsKeys("status", "artifacts");
+  }
+
+  @Test
+  void metadataOfTheFinalMessageIsExposedSeparately() {
+    Map<String, Object> parameters =
+        response(FakeA2aAgent.snapshot("t1", "c1", A2aErrors.STATE_COMPLETED, "hi")).getResponseParameters();
+
+    assertThat(parameters.get(A2aResponse.PARAM_MESSAGE_METADATA)).isEqualTo(Map.of("model", "test-model"));
+  }
+
+  @Test
+  void anAnswerWithoutATaskStillMapsItsText() {
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot(null, "c1", null,
+        FakeA2aAgent.message("just a message"), List.of(), Map.of(), List.of(), false);
+
+    A2aResponse response = response(snapshot);
+    assertThat(response.getText()).isEqualTo("just a message");
+    assertThat(response.getTaskId()).isNull();
+    assertThat(response.getResponseParameters().get(A2aResponse.PARAM_TASK)).isNull();
+  }
+
+  @Test
+  void anEmptyStatusMessageDoesNotBlowUp() {
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        null, List.of(), Map.of(), List.of(), false);
+
+    A2aResponse response = response(snapshot);
+    assertThat(response.getText()).isEmpty();
+    assertThat(response.getResponseParameters().get(A2aResponse.PARAM_MESSAGE_METADATA)).isEqualTo(Map.of());
+  }
+
+  @Test
+  void tooMuchTextIsCutShortAndFlagged() {
+    String tooLong = "x".repeat(120);
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        FakeA2aAgent.message(tooLong), List.of(), Map.of(), List.of(), false);
+
+    A2aResponseImpl response = new A2aResponseImpl(snapshot, false, 100);
+    Map<String, Object> parameters = response.getResponseParameters();
+
+    assertThat((String) parameters.get(A2aResponse.PARAM_TEXT)).startsWith("x".repeat(100)).contains("truncated");
+    assertThat(parameters.get(A2aResponse.PARAM_TRUNCATED)).isEqualTo(true);
+  }
+
+  @Test
+  void truncationFlaggedByTheAgentReaderIsPassedThrough() {
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        FakeA2aAgent.message("small"), List.of(), Map.of(), List.of(), true);
+
+    assertThat(response(snapshot).isTruncated()).isTrue();
+  }
+
+  private static A2aResponse response(A2aAgent.TaskSnapshot snapshot) {
+    return new A2aResponseImpl(snapshot, false, MAX);
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aResponseImplTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/A2aResponseImplTest.java
@@ -107,6 +107,30 @@ class A2aResponseImplTest {
     assertThat(parameters.get(A2aResponse.PARAM_MESSAGE_METADATA)).isEqualTo(Map.of("model", "test-model"));
   }
 
+  /**
+   * Regression test. Agents split into two camps, and a google-adk agent closes its task with no status message
+   * at all, putting the answer in an artifact. Reading only the status message left {@code ${text}} empty against
+   * every such agent, which is the output the examples and the element template lead with.
+   */
+  @Test
+  void textFallsBackToArtifactsWhenTheAgentAnswersWithArtifactsOnly() {
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        null, List.of(FakeA2aAgent.artifact("reply", "4")), Map.of(), List.of(), false);
+
+    assertThat(response(snapshot).getText()).isEqualTo("4");
+  }
+
+  @Test
+  void aClosingMessageStillWinsOverTheArtifactText() {
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("t1", "c1", A2aErrors.STATE_COMPLETED,
+        FakeA2aAgent.message("the summary"),
+        List.of(FakeA2aAgent.artifact("reply", "raw artifact text")), Map.of(), List.of(), false);
+
+    A2aResponse response = response(snapshot);
+    assertThat(response.getText()).isEqualTo("the summary");
+    assertThat(response.getResponseParameters().get(A2aResponse.PARAM_ARTIFACT_TEXT)).isEqualTo("raw artifact text");
+  }
+
   @Test
   void anAnswerWithoutATaskStillMapsItsText() {
     A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot(null, "c1", null,

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/FakeA2aAgent.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/FakeA2aAgent.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A scripted stand-in for a real agent.
+ *
+ * <p>
+ * Tests use this instead of stubbing the A2A wire protocol, so that what is under test is the connector's own
+ * behaviour: which operation it runs, what it sends, how long it waits, and what it turns a task state into.
+ * The last scripted result repeats, which is what makes a "still working forever" agent easy to express.
+ * </p>
+ */
+class FakeA2aAgent implements A2aAgent {
+
+  final List<SendCommand> sends = new ArrayList<>();
+  final List<String> getTaskCalls = new ArrayList<>();
+  final Deque<TaskSnapshot> sendResults = new ArrayDeque<>();
+  final Deque<TaskSnapshot> getTaskResults = new ArrayDeque<>();
+
+  Optional<String> reattachableTaskId = Optional.empty();
+  RuntimeException sendFailure;
+  boolean closed;
+
+  @Override
+  public TaskSnapshot send(SendCommand command) {
+    sends.add(command);
+    if (sendFailure != null) {
+      throw sendFailure;
+    }
+    return next(sendResults);
+  }
+
+  @Override
+  public TaskSnapshot getTask(String taskId, Integer historyLength) {
+    getTaskCalls.add(taskId);
+    return next(getTaskResults);
+  }
+
+  @Override
+  public Optional<String> findLatestTaskId(String contextId) {
+    return reattachableTaskId;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+
+  /** Consumes the queue until one result is left, then keeps returning that one. */
+  private static TaskSnapshot next(Deque<TaskSnapshot> results) {
+    if (results.isEmpty()) {
+      throw new IllegalStateException("The test did not script a result for this call");
+    }
+    return results.size() > 1 ? results.poll() : results.peek();
+  }
+
+  static TaskSnapshot snapshot(String taskId, String contextId, String state, String text) {
+    return new TaskSnapshot(taskId, contextId, state, message(text), List.of(), Map.of(), List.of(), false);
+  }
+
+  static Map<String, Object> message(String text) {
+    if (text == null) {
+      return null;
+    }
+    Map<String, Object> part = new LinkedHashMap<>();
+    part.put("type", "text");
+    part.put("text", text);
+
+    Map<String, Object> message = new LinkedHashMap<>();
+    message.put("messageId", "agent-message");
+    message.put("role", "ROLE_AGENT");
+    message.put("parts", List.of(part));
+    message.put("metadata", Map.of("model", "test-model"));
+    return message;
+  }
+
+  static Map<String, Object> artifact(String name, String text) {
+    Map<String, Object> part = new LinkedHashMap<>();
+    part.put("type", "text");
+    part.put("text", text);
+
+    Map<String, Object> artifact = new LinkedHashMap<>();
+    artifact.put("artifactId", "artifact-" + name);
+    artifact.put("name", name);
+    artifact.put("parts", List.of(part));
+    artifact.put("metadata", Map.of());
+    return artifact;
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/FakeA2aAgentFactory.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/FakeA2aAgentFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Hands the connector a scripted agent and records what it was asked to do.
+ *
+ * <p>
+ * Lives in this package so that the engine-level tests, which sit in the public package, can script an agent
+ * without the internals leaking into the connector's public API.
+ * </p>
+ */
+public class FakeA2aAgentFactory implements Function<A2aAgent.Config, A2aAgent> {
+
+  private final FakeA2aAgent agent = new FakeA2aAgent();
+
+  private A2aAgent.Config lastConfig;
+
+  @Override
+  public A2aAgent apply(A2aAgent.Config config) {
+    this.lastConfig = config;
+    return agent;
+  }
+
+  /** The agent answers straight away, with everything a process would want to read. */
+  public void completesWith(String taskId, String contextId, String text) {
+    agent.sendResults.clear();
+    agent.sendResults.add(new A2aAgent.TaskSnapshot(taskId, contextId, A2aErrors.STATE_COMPLETED,
+        FakeA2aAgent.message(text),
+        List.of(FakeA2aAgent.artifact("summary", text)),
+        Map.of("model", "test-model"), List.of(), false));
+  }
+
+  /** The agent gives up on the task, which the connector turns into the {@code a2a-task-failed} BPMN error. */
+  public void failsWith(String taskId, String contextId) {
+    agent.sendResults.clear();
+    agent.sendResults.add(FakeA2aAgent.snapshot(taskId, contextId, A2aErrors.STATE_FAILED,
+        "I could not complete this"));
+  }
+
+  /** The agent accepts the work and will finish later, which is what sendAsync expects. */
+  public void submitsAs(String taskId, String contextId) {
+    agent.sendResults.clear();
+    agent.sendResults.add(FakeA2aAgent.snapshot(taskId, contextId, A2aErrors.STATE_SUBMITTED, null));
+  }
+
+  /** Sets what the next {@code getTask} calls return, replacing anything scripted before. */
+  public void getTaskReturns(String taskId, String contextId, String state, String text) {
+    agent.getTaskResults.clear();
+    agent.getTaskResults.add(new A2aAgent.TaskSnapshot(taskId, contextId, state,
+        FakeA2aAgent.message(text),
+        text == null ? List.of() : List.of(FakeA2aAgent.artifact("summary", text)),
+        Map.of(), List.of(), false));
+  }
+
+  public A2aAgent.Config lastConfig() {
+    return lastConfig;
+  }
+
+  public A2aAgent.SendCommand lastSend() {
+    return agent.sends.get(agent.sends.size() - 1);
+  }
+
+  public List<A2aAgent.SendCommand> sends() {
+    return agent.sends;
+  }
+
+  public List<String> getTaskCalls() {
+    return agent.getTaskCalls;
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/SdkA2aAgentTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/SdkA2aAgentTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The reattach probe calls {@code ListTasks}, which A2A makes optional. Agents that do not implement it answer
+ * with JSON-RPC {@code -32601}, and that must never be allowed to fail the send it was only trying to optimise.
+ *
+ * <p>
+ * This is a regression test for exactly that: an earlier version treated any unrecognised probe failure as
+ * retryable, which turned a missing optional method into a permanently failing service task against every agent
+ * without {@code ListTasks}, which is most of them.
+ * </p>
+ */
+class SdkA2aAgentTest {
+
+  @Test
+  void aMissingOptionalMethodDoesNotCountAsATransportFailure() {
+    // What an agent without ListTasks actually produces, once the SDK is done with it.
+    assertThat(SdkA2aAgent.isTransportFailure(new RuntimeException("Method not found"))).isFalse();
+    assertThat(SdkA2aAgent.isTransportFailure(new NullPointerException())).isFalse();
+    assertThat(SdkA2aAgent.isTransportFailure(httpError(404))).isFalse();
+    assertThat(SdkA2aAgent.isTransportFailure(httpError(400))).isFalse();
+  }
+
+  @Test
+  void aRealTransportProblemDoesCount() {
+    assertThat(SdkA2aAgent.isTransportFailure(new IOException("connection reset"))).isTrue();
+    assertThat(SdkA2aAgent.isTransportFailure(httpError(500))).isTrue();
+    assertThat(SdkA2aAgent.isTransportFailure(httpError(503))).isTrue();
+    assertThat(SdkA2aAgent.isTransportFailure(httpError(429))).isTrue();
+    assertThat(SdkA2aAgent.isTransportFailure(httpError(408))).isTrue();
+  }
+
+  @Test
+  void theCauseChainIsSearchedNotJustTheTopException() {
+    assertThat(SdkA2aAgent.isTransportFailure(new IllegalStateException(new IOException("reset")))).isTrue();
+    assertThat(SdkA2aAgent.isTransportFailure(new IllegalStateException(httpError(503)))).isTrue();
+    assertThat(SdkA2aAgent.isTransportFailure(new IllegalStateException(new RuntimeException("nope")))).isFalse();
+  }
+
+  @Test
+  void aSelfReferencingCauseChainTerminates() {
+    RuntimeException looping = new RuntimeException("loop") {
+      @Override
+      public synchronized Throwable getCause() {
+        return this;
+      }
+    };
+
+    assertThat(SdkA2aAgent.isTransportFailure(looping)).isFalse();
+  }
+
+  private static A2AClientHTTPError httpError(int code) {
+    return new A2AClientHTTPError(code, "failed", "", Map.of());
+  }
+
+}

--- a/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/SdkA2aAgentWireTest.java
+++ b/connect/a2a/src/test/java/org/operaton/connect/a2a/impl/SdkA2aAgentWireTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.a2a.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.connect.a2a.A2aResponse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the real A2A wire protocol, rather than a scripted agent.
+ *
+ * <p>
+ * The card and the JSON-RPC payloads here are copies of what a real A2A v1.0 agent (google-adk with
+ * {@code a2a-sdk} 1.1.2) actually put on the wire, down to the details that matter: the result is wrapped in a
+ * {@code task} envelope, parts carry a bare {@code text} field with no kind discriminator, and the answer comes
+ * back as an artifact rather than as a closing status message.
+ * </p>
+ */
+@WireMockTest
+class SdkA2aAgentWireTest {
+
+  private static final String AGENT_CARD_PATH = "/.well-known/agent-card.json";
+
+  /** As returned by the agent: the answer is an artifact and there is no closing status message. */
+  private static final String COMPLETED_TASK = """
+      {"jsonrpc":"2.0","id":"1","result":{"task":{
+        "id":"task-1",
+        "contextId":"ctx-1",
+        "status":{"state":"TASK_STATE_COMPLETED"},
+        "artifacts":[{"artifactId":"reply","parts":[{"text":"ping"}],"extensions":[]}],
+        "history":[]
+      }}}""";
+
+  private static final String WORKING_TASK = """
+      {"jsonrpc":"2.0","id":"1","result":{"task":{
+        "id":"task-1",
+        "contextId":"ctx-1",
+        "status":{"state":"TASK_STATE_WORKING"},
+        "artifacts":[],
+        "history":[]
+      }}}""";
+
+  private static final String FAILED_TASK = """
+      {"jsonrpc":"2.0","id":"1","result":{"task":{
+        "id":"task-1",
+        "contextId":"ctx-1",
+        "status":{"state":"TASK_STATE_FAILED","message":{"messageId":"m1",
+          "role":"ROLE_AGENT","parts":[{"text":"I could not do that"}]}},
+        "artifacts":[],
+        "history":[]
+      }}}""";
+
+  /**
+   * GetTask returns the task directly, without the {@code task} envelope that SendMessage uses. SendMessage can
+   * answer with either a task or a bare message, so it needs the discriminator; GetTask cannot.
+   */
+  private static final String COMPLETED_TASK_UNWRAPPED = """
+      {"jsonrpc":"2.0","id":"1","result":{
+        "id":"task-1",
+        "contextId":"ctx-1",
+        "status":{"state":"TASK_STATE_COMPLETED"},
+        "artifacts":[{"artifactId":"reply","parts":[{"text":"ping"}],"extensions":[]}],
+        "history":[]
+      }}""";
+
+  /** What an agent without the optional ListTasks method answers. */
+  private static final String METHOD_NOT_FOUND = """
+      {"jsonrpc":"2.0","id":"1","error":{"code":-32601,"message":"Method not found"}}""";
+
+  @Test
+  void sendsAMessageAndMapsTheTaskThatComesBack(WireMockRuntimeInfo wireMock) {
+    stubCard(wireMock);
+    stubMethod("SendMessage", COMPLETED_TASK);
+
+    A2aAgent.TaskSnapshot snapshot = agent(wireMock).send(command("Say ping"));
+
+    assertThat(snapshot.taskId()).isEqualTo("task-1");
+    assertThat(snapshot.contextId()).isEqualTo("ctx-1");
+    assertThat(snapshot.state()).isEqualTo(A2aErrors.STATE_COMPLETED);
+    assertThat(snapshot.artifacts()).hasSize(1);
+    assertThat(snapshot.truncated()).isFalse();
+  }
+
+  @Test
+  void theAnswerIsReadableAsPlainTextEvenThoughItArrivedAsAnArtifact() {
+    // The whole point of the text fallback: this agent shape returns no closing status message at all.
+    A2aAgent.TaskSnapshot snapshot = new A2aAgent.TaskSnapshot("task-1", "ctx-1", A2aErrors.STATE_COMPLETED,
+        null, List.of(FakeA2aAgent.artifact("reply", "ping")), Map.of(), List.of(), false);
+
+    assertThat(new A2aResponseImpl(snapshot, false, 65536).getText()).isEqualTo("ping");
+  }
+
+  @Test
+  void theOutgoingRequestCarriesTheDeterministicMessageIdAndTheText(WireMockRuntimeInfo wireMock) {
+    stubCard(wireMock);
+    stubMethod("SendMessage", COMPLETED_TASK);
+
+    agent(wireMock).send(command("Say ping"));
+
+    verify(postRequestedFor(urlPathEqualTo("/"))
+        .withRequestBody(matchingJsonPath("$.method", equalTo("SendMessage")))
+        .withRequestBody(matchingJsonPath("$.params.message.messageId", equalTo("msg-deterministic")))
+        .withRequestBody(matchingJsonPath("$.params.message.parts[0].text", equalTo("Say ping"))));
+  }
+
+  /**
+   * Regression test at the wire level. {@code ListTasks} is optional and this is the exact response a real agent
+   * gives when it does not implement it. It must not be allowed to fail the send.
+   */
+  @Test
+  void anAgentWithoutListTasksDegradesInsteadOfFailing(WireMockRuntimeInfo wireMock) {
+    stubCard(wireMock);
+    stubMethod("ListTasks", METHOD_NOT_FOUND);
+
+    Optional<String> found = agent(wireMock).findLatestTaskId("ctx-1");
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  void readsAKnownTask(WireMockRuntimeInfo wireMock) {
+    stubCard(wireMock);
+    stubMethod("GetTask", COMPLETED_TASK_UNWRAPPED);
+
+    A2aAgent.TaskSnapshot snapshot = agent(wireMock).getTask("task-1", null);
+
+    assertThat(snapshot.taskId()).isEqualTo("task-1");
+    assertThat(snapshot.state()).isEqualTo(A2aErrors.STATE_COMPLETED);
+  }
+
+  @Test
+  void aTaskStillWorkingIsReportedAsSuchRatherThanWaitedOnHere(WireMockRuntimeInfo wireMock) {
+    stubCard(wireMock);
+    stubMethod("SendMessage", WORKING_TASK);
+
+    A2aAgent.TaskSnapshot snapshot = agent(wireMock).send(command("take your time"));
+
+    assertThat(snapshot.state()).isEqualTo(A2aErrors.STATE_WORKING);
+    assertThat(A2aErrors.isSettled(snapshot.state())).isFalse();
+  }
+
+  @Test
+  void aFailedTaskKeepsTheAgentsExplanation(WireMockRuntimeInfo wireMock) {
+    stubCard(wireMock);
+    stubMethod("SendMessage", FAILED_TASK);
+
+    A2aAgent.TaskSnapshot snapshot = agent(wireMock).send(command("do the impossible"));
+
+    assertThat(snapshot.state()).isEqualTo(A2aErrors.STATE_FAILED);
+    assertThat(new A2aResponseImpl(snapshot, false, 65536).getText()).isEqualTo("I could not do that");
+  }
+
+  private static void stubCard(WireMockRuntimeInfo wireMock) {
+    String base = wireMock.getHttpBaseUrl();
+    stubFor(get(urlEqualTo(AGENT_CARD_PATH)).willReturn(okJson("""
+        {
+          "name":"stub-agent",
+          "description":"A2A v1.0 stub",
+          "version":"1",
+          "capabilities":{"streaming":false,"pushNotifications":true,"extendedAgentCard":false},
+          "defaultInputModes":["text/plain"],
+          "defaultOutputModes":["text/plain"],
+          "skills":[],
+          "url":"%s",
+          "preferredTransport":"JSONRPC",
+          "supportedInterfaces":[{"url":"%s","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]
+        }""".formatted(base, base))));
+  }
+
+  private static void stubMethod(String method, String response) {
+    stubFor(post(urlPathEqualTo("/"))
+        .withRequestBody(matchingJsonPath("$.method", equalTo(method)))
+        .willReturn(okJson(response)));
+  }
+
+  private static A2aAgent agent(WireMockRuntimeInfo wireMock) {
+    return new SdkA2aAgent(new A2aAgent.Config(wireMock.getHttpBaseUrl(), Map.of(), 5_000, 10_000, 65_536));
+  }
+
+  private static A2aAgent.SendCommand command(String text) {
+    return new A2aAgent.SendCommand("msg-deterministic", null, null, text, List.of(), Map.of(), List.of(),
+        List.of(), Map.of(), null, List.of(), null, null, null, null, null, false);
+  }
+
+}

--- a/connect/a2a/src/test/resources/logback-test.xml
+++ b/connect/a2a/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.operaton.bpm.connect.a2a" level="DEBUG" />
+  <logger name="org.operaton.bpm.engine" level="WARN" />
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/connect/a2a/src/test/resources/operaton.cfg.xml
+++ b/connect/a2a/src/test/resources/operaton.cfg.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <property name="jdbcUrl" value="jdbc:h2:mem:operaton-connect-a2a;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcDriver" value="org.h2.Driver" />
+    <property name="jdbcUsername" value="sa" />
+    <property name="jdbcPassword" value="" />
+
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="enforceHistoryTimeToLive" value="false" />
+
+    <!-- Jobs are executed by the tests themselves, so that timers fire when the test says so. -->
+    <property name="jobExecutorActivate" value="false" />
+
+    <property name="processEnginePlugins">
+      <list>
+        <bean class="org.operaton.connect.plugin.impl.ConnectProcessEnginePlugin" />
+      </list>
+    </property>
+
+  </bean>
+
+</beans>

--- a/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-poll-fallback.bpmn
+++ b/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-poll-fallback.bpmn
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+             id="a2aPollFallbackDefinitions"
+             targetNamespace="http://operaton.org/schema/1.0/bpmn">
+
+  <!--
+    For an agent whose card does not advertise capabilities.pushNotifications.
+
+    Send without a callback URL, then poll with 'getTask' on a timer until the task settles. Each poll is a
+    short-lived job, so nothing holds a job executor thread while the agent thinks. This is the polling
+    fallback for the same work the sendAsync example does with a push notification.
+  -->
+  <process id="a2aPollFallback" name="Delegate to an agent and poll" isExecutable="true">
+
+    <startEvent id="start" name="Work arrived">
+      <outgoing>flowToDelegate</outgoing>
+    </startEvent>
+    <sequenceFlow id="flowToDelegate" sourceRef="start" targetRef="delegateToAgent" />
+
+    <serviceTask id="delegateToAgent" name="Delegate to the agent">
+      <extensionElements>
+        <operaton:connector>
+          <operaton:connectorId>a2a</operaton:connectorId>
+          <operaton:inputOutput>
+            <operaton:inputParameter name="operation">sendAsync</operaton:inputParameter>
+            <operaton:inputParameter name="url">${agentUrl}</operaton:inputParameter>
+            <operaton:inputParameter name="message">${question}</operaton:inputParameter>
+            <operaton:inputParameter name="idempotencyKey">${execution.getProcessInstanceId()}-${execution.getActivityInstanceId()}</operaton:inputParameter>
+            <operaton:outputParameter name="a2aTaskId">${taskId}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aContextId">${contextId}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aState">${state}</operaton:outputParameter>
+          </operaton:inputOutput>
+        </operaton:connector>
+      </extensionElements>
+      <incoming>flowToDelegate</incoming>
+      <outgoing>flowToTimer</outgoing>
+    </serviceTask>
+    <sequenceFlow id="flowToTimer" sourceRef="delegateToAgent" targetRef="waitBeforePoll" />
+
+    <intermediateCatchEvent id="waitBeforePoll" name="Wait 10s">
+      <incoming>flowToTimer</incoming>
+      <incoming>flowKeepPolling</incoming>
+      <outgoing>flowToPoll</outgoing>
+      <timerEventDefinition>
+        <timeDuration>PT10S</timeDuration>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <sequenceFlow id="flowToPoll" sourceRef="waitBeforePoll" targetRef="pollAgent" />
+
+    <serviceTask id="pollAgent" name="Read the task">
+      <extensionElements>
+        <operaton:connector>
+          <operaton:connectorId>a2a</operaton:connectorId>
+          <operaton:inputOutput>
+            <operaton:inputParameter name="operation">getTask</operaton:inputParameter>
+            <operaton:inputParameter name="url">${agentUrl}</operaton:inputParameter>
+            <operaton:inputParameter name="taskId">${a2aTaskId}</operaton:inputParameter>
+            <operaton:outputParameter name="a2aState">${state}</operaton:outputParameter>
+            <operaton:outputParameter name="answer">${text}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aArtifacts">${artifacts}</operaton:outputParameter>
+          </operaton:inputOutput>
+        </operaton:connector>
+      </extensionElements>
+      <incoming>flowToPoll</incoming>
+      <outgoing>flowToDecision</outgoing>
+    </serviceTask>
+    <sequenceFlow id="flowToDecision" sourceRef="pollAgent" targetRef="settled" />
+
+    <exclusiveGateway id="settled" name="Settled?" default="flowKeepPolling">
+      <incoming>flowToDecision</incoming>
+      <outgoing>flowToDone</outgoing>
+      <outgoing>flowKeepPolling</outgoing>
+    </exclusiveGateway>
+    <sequenceFlow id="flowToDone" sourceRef="settled" targetRef="done">
+      <conditionExpression xsi:type="tFormalExpression">${a2aState == 'TASK_STATE_COMPLETED'}</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="flowKeepPolling" sourceRef="settled" targetRef="waitBeforePoll" />
+
+    <endEvent id="done" name="Agent answered">
+      <incoming>flowToDone</incoming>
+    </endEvent>
+  </process>
+
+  <bpmndi:BPMNDiagram id="a2aPollFallbackDiagram">
+    <bpmndi:BPMNPlane id="a2aPollFallbackPlane" bpmnElement="a2aPollFallback">
+      <bpmndi:BPMNShape id="startShape" bpmnElement="start">
+        <dc:Bounds x="160" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="delegateShape" bpmnElement="delegateToAgent">
+        <dc:Bounds x="250" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="waitShape" bpmnElement="waitBeforePoll">
+        <dc:Bounds x="410" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="pollShape" bpmnElement="pollAgent">
+        <dc:Bounds x="500" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="settledShape" bpmnElement="settled">
+        <dc:Bounds x="655" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="doneShape" bpmnElement="done">
+        <dc:Bounds x="770" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flowToDelegateEdge" bpmnElement="flowToDelegate">
+        <di:waypoint x="196" y="200" />
+        <di:waypoint x="250" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToTimerEdge" bpmnElement="flowToTimer">
+        <di:waypoint x="350" y="200" />
+        <di:waypoint x="410" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToPollEdge" bpmnElement="flowToPoll">
+        <di:waypoint x="446" y="200" />
+        <di:waypoint x="500" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToDecisionEdge" bpmnElement="flowToDecision">
+        <di:waypoint x="600" y="200" />
+        <di:waypoint x="655" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToDoneEdge" bpmnElement="flowToDone">
+        <di:waypoint x="705" y="200" />
+        <di:waypoint x="770" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowKeepPollingEdge" bpmnElement="flowKeepPolling">
+        <di:waypoint x="680" y="175" />
+        <di:waypoint x="680" y="110" />
+        <di:waypoint x="428" y="110" />
+        <di:waypoint x="428" y="182" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-poll-fallback.bpmn
+++ b/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-poll-fallback.bpmn
@@ -15,7 +15,7 @@
     short-lived job, so nothing holds a job executor thread while the agent thinks. This is the polling
     fallback for the same work the sendAsync example does with a push notification.
   -->
-  <process id="a2aPollFallback" name="Delegate to an agent and poll" isExecutable="true">
+  <process id="a2aPollFallback" name="Delegate to an agent and poll" isExecutable="true" operaton:historyTimeToLive="P30D">
 
     <startEvent id="start" name="Work arrived">
       <outgoing>flowToDelegate</outgoing>

--- a/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-async.bpmn
+++ b/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-async.bpmn
@@ -24,7 +24,7 @@
   -->
   <message id="a2aCallbackMessage" name="a2aCallback" />
 
-  <process id="a2aSendAsync" name="Delegate to an agent and continue" isExecutable="true">
+  <process id="a2aSendAsync" name="Delegate to an agent and continue" isExecutable="true" operaton:historyTimeToLive="P30D">
 
     <startEvent id="start" name="Work arrived">
       <outgoing>flowToDelegate</outgoing>

--- a/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-async.bpmn
+++ b/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-async.bpmn
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+             id="a2aSendAsyncDefinitions"
+             targetNamespace="http://operaton.org/schema/1.0/bpmn">
+
+  <!--
+    Hand work to a long-running agent and carry on.
+
+    The connector registers a push notification config with the agent and returns immediately with the task id,
+    context id and state. The process then waits at a receive task. Your own webhook endpoint receives the
+    agent's callback and correlates it back in:
+
+      runtimeService.createMessageCorrelation("a2aCallback")
+                    .processInstanceVariableEquals("a2aTaskId", taskIdFromCallback)
+                    .correlateWithResult();
+
+    The webhook must tolerate arriving before the process instance has reached the receive task, and retry with
+    a short backoff. The timer boundary event below is the backstop for a notification that never comes at all.
+  -->
+  <message id="a2aCallbackMessage" name="a2aCallback" />
+
+  <process id="a2aSendAsync" name="Delegate to an agent and continue" isExecutable="true">
+
+    <startEvent id="start" name="Work arrived">
+      <outgoing>flowToDelegate</outgoing>
+    </startEvent>
+    <sequenceFlow id="flowToDelegate" sourceRef="start" targetRef="delegateToAgent" />
+
+    <serviceTask id="delegateToAgent" name="Delegate to the agent">
+      <extensionElements>
+        <operaton:connector>
+          <operaton:connectorId>a2a</operaton:connectorId>
+          <operaton:inputOutput>
+            <operaton:inputParameter name="operation">sendAsync</operaton:inputParameter>
+            <operaton:inputParameter name="url">${agentUrl}</operaton:inputParameter>
+            <operaton:inputParameter name="headers">
+              <operaton:map>
+                <operaton:entry key="Authorization">Bearer ${agentToken}</operaton:entry>
+              </operaton:map>
+            </operaton:inputParameter>
+            <operaton:inputParameter name="message">${question}</operaton:inputParameter>
+
+            <!-- A file the agent should work on, sent by reference rather than inline. -->
+            <operaton:inputParameter name="parts">
+              <operaton:list>
+                <operaton:map>
+                  <operaton:entry key="type">file</operaton:entry>
+                  <operaton:entry key="uri">${documentUrl}</operaton:entry>
+                  <operaton:entry key="mimeType">application/pdf</operaton:entry>
+                  <operaton:entry key="name">document.pdf</operaton:entry>
+                </operaton:map>
+              </operaton:list>
+            </operaton:inputParameter>
+
+            <operaton:inputParameter name="callbackUrl">${callbackUrl}</operaton:inputParameter>
+            <operaton:inputParameter name="callbackToken">${callbackToken}</operaton:inputParameter>
+            <operaton:inputParameter name="callbackAuthScheme">Bearer</operaton:inputParameter>
+            <operaton:inputParameter name="callbackAuthCredentials">${callbackCredentials}</operaton:inputParameter>
+
+            <operaton:inputParameter name="idempotencyKey">${execution.getProcessInstanceId()}-${execution.getActivityInstanceId()}</operaton:inputParameter>
+
+            <!-- These three are what makes the callback correlatable. -->
+            <operaton:outputParameter name="a2aTaskId">${taskId}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aContextId">${contextId}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aState">${state}</operaton:outputParameter>
+          </operaton:inputOutput>
+        </operaton:connector>
+      </extensionElements>
+      <incoming>flowToDelegate</incoming>
+      <outgoing>flowToWait</outgoing>
+    </serviceTask>
+    <sequenceFlow id="flowToWait" sourceRef="delegateToAgent" targetRef="waitForAgent" />
+
+    <receiveTask id="waitForAgent" name="Wait for the agent" messageRef="a2aCallbackMessage">
+      <incoming>flowToWait</incoming>
+      <outgoing>flowToDone</outgoing>
+    </receiveTask>
+    <sequenceFlow id="flowToDone" sourceRef="waitForAgent" targetRef="done" />
+
+    <boundaryEvent id="agentTookTooLong" name="30 minutes" attachedToRef="waitForAgent">
+      <outgoing>flowToGaveUp</outgoing>
+      <timerEventDefinition>
+        <timeDuration>PT30M</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="flowToGaveUp" sourceRef="agentTookTooLong" targetRef="gaveUp" />
+
+    <endEvent id="done" name="Agent answered">
+      <incoming>flowToDone</incoming>
+    </endEvent>
+    <endEvent id="gaveUp" name="Gave up waiting">
+      <incoming>flowToGaveUp</incoming>
+    </endEvent>
+  </process>
+
+  <bpmndi:BPMNDiagram id="a2aSendAsyncDiagram">
+    <bpmndi:BPMNPlane id="a2aSendAsyncPlane" bpmnElement="a2aSendAsync">
+      <bpmndi:BPMNShape id="startShape" bpmnElement="start">
+        <dc:Bounds x="160" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="delegateShape" bpmnElement="delegateToAgent">
+        <dc:Bounds x="250" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="waitShape" bpmnElement="waitForAgent">
+        <dc:Bounds x="410" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="tookTooLongShape" bpmnElement="agentTookTooLong">
+        <dc:Bounds x="442" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="doneShape" bpmnElement="done">
+        <dc:Bounds x="580" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="gaveUpShape" bpmnElement="gaveUp">
+        <dc:Bounds x="580" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flowToDelegateEdge" bpmnElement="flowToDelegate">
+        <di:waypoint x="196" y="100" />
+        <di:waypoint x="250" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToWaitEdge" bpmnElement="flowToWait">
+        <di:waypoint x="350" y="100" />
+        <di:waypoint x="410" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToDoneEdge" bpmnElement="flowToDone">
+        <di:waypoint x="510" y="100" />
+        <di:waypoint x="580" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToGaveUpEdge" bpmnElement="flowToGaveUp">
+        <di:waypoint x="460" y="158" />
+        <di:waypoint x="460" y="240" />
+        <di:waypoint x="580" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-sync.bpmn
+++ b/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-sync.bpmn
@@ -16,7 +16,7 @@
   -->
   <error id="a2aTaskFailedError" name="A2A task failed" errorCode="a2a-task-failed" />
 
-  <process id="a2aSendSync" name="Ask an agent and wait" isExecutable="true">
+  <process id="a2aSendSync" name="Ask an agent and wait" isExecutable="true" operaton:historyTimeToLive="P30D">
 
     <startEvent id="start" name="Question asked">
       <outgoing>flowToAskAgent</outgoing>

--- a/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-sync.bpmn
+++ b/connect/a2a/src/test/resources/org/operaton/connect/a2a/examples/a2a-send-sync.bpmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+             id="a2aSendSyncDefinitions"
+             targetNamespace="http://operaton.org/schema/1.0/bpmn">
+
+  <!--
+    Ask an agent a question and wait for the answer.
+
+    The agent is expected to be quick. If it is not, 'waitTimeout' expires and the connector raises the
+    'a2a-timeout' BPMN error, which is why a real process would usually also attach a boundary event for it.
+  -->
+  <error id="a2aTaskFailedError" name="A2A task failed" errorCode="a2a-task-failed" />
+
+  <process id="a2aSendSync" name="Ask an agent and wait" isExecutable="true">
+
+    <startEvent id="start" name="Question asked">
+      <outgoing>flowToAskAgent</outgoing>
+    </startEvent>
+    <sequenceFlow id="flowToAskAgent" sourceRef="start" targetRef="askAgent" />
+
+    <serviceTask id="askAgent" name="Ask the agent">
+      <extensionElements>
+        <operaton:connector>
+          <operaton:connectorId>a2a</operaton:connectorId>
+          <operaton:inputOutput>
+            <operaton:inputParameter name="operation">sendSync</operaton:inputParameter>
+            <operaton:inputParameter name="url">${agentUrl}</operaton:inputParameter>
+
+            <!-- Secrets come from process variables, never from the diagram. -->
+            <operaton:inputParameter name="headers">
+              <operaton:map>
+                <operaton:entry key="Authorization">Bearer ${agentToken}</operaton:entry>
+              </operaton:map>
+            </operaton:inputParameter>
+
+            <operaton:inputParameter name="message">${question}</operaton:inputParameter>
+            <operaton:inputParameter name="metadata">
+              <operaton:map>
+                <operaton:entry key="processInstanceId">${execution.getProcessInstanceId()}</operaton:entry>
+              </operaton:map>
+            </operaton:inputParameter>
+            <operaton:inputParameter name="acceptedOutputModes">text/plain</operaton:inputParameter>
+
+            <!-- Stable across job retries, unique per activity instance: this is what lets a retry reattach
+                 to a task an earlier attempt already started instead of paying for it twice. -->
+            <operaton:inputParameter name="idempotencyKey">${execution.getProcessInstanceId()}-${execution.getActivityInstanceId()}</operaton:inputParameter>
+
+            <operaton:inputParameter name="connectTimeout">5000</operaton:inputParameter>
+            <operaton:inputParameter name="readTimeout">10000</operaton:inputParameter>
+            <operaton:inputParameter name="waitTimeout">30000</operaton:inputParameter>
+            <operaton:inputParameter name="pollInterval">1000</operaton:inputParameter>
+
+            <operaton:outputParameter name="answer">${text}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aArtifacts">${artifacts}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aArtifactText">${artifactText}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aTaskId">${taskId}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aContextId">${contextId}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aState">${state}</operaton:outputParameter>
+            <operaton:outputParameter name="a2aTruncated">${truncated}</operaton:outputParameter>
+          </operaton:inputOutput>
+        </operaton:connector>
+      </extensionElements>
+      <incoming>flowToAskAgent</incoming>
+      <outgoing>flowToDone</outgoing>
+    </serviceTask>
+    <sequenceFlow id="flowToDone" sourceRef="askAgent" targetRef="done" />
+
+    <boundaryEvent id="agentFailed" name="Agent failed" attachedToRef="askAgent">
+      <outgoing>flowToFailed</outgoing>
+      <errorEventDefinition errorRef="a2aTaskFailedError" />
+    </boundaryEvent>
+    <sequenceFlow id="flowToFailed" sourceRef="agentFailed" targetRef="failed" />
+
+    <endEvent id="done" name="Answered">
+      <incoming>flowToDone</incoming>
+    </endEvent>
+    <endEvent id="failed" name="Handled failure">
+      <incoming>flowToFailed</incoming>
+    </endEvent>
+  </process>
+
+  <bpmndi:BPMNDiagram id="a2aSendSyncDiagram">
+    <bpmndi:BPMNPlane id="a2aSendSyncPlane" bpmnElement="a2aSendSync">
+      <bpmndi:BPMNShape id="startShape" bpmnElement="start">
+        <dc:Bounds x="160" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="askAgentShape" bpmnElement="askAgent">
+        <dc:Bounds x="250" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="agentFailedShape" bpmnElement="agentFailed">
+        <dc:Bounds x="282" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="doneShape" bpmnElement="done">
+        <dc:Bounds x="430" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="failedShape" bpmnElement="failed">
+        <dc:Bounds x="430" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flowToAskAgentEdge" bpmnElement="flowToAskAgent">
+        <di:waypoint x="196" y="100" />
+        <di:waypoint x="250" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToDoneEdge" bpmnElement="flowToDone">
+        <di:waypoint x="350" y="100" />
+        <di:waypoint x="430" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flowToFailedEdge" bpmnElement="flowToFailed">
+        <di:waypoint x="300" y="158" />
+        <di:waypoint x="300" y="240" />
+        <di:waypoint x="430" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -32,6 +32,7 @@
     <module>core</module>
     <module>http-client</module>
     <module>soap-http-client</module>
+    <module>a2a</module>
     <module>connectors-all</module>
   </modules>
   <build>

--- a/docs/decisions/0002-a2a-connector-uses-the-a2a-java-sdk.md
+++ b/docs/decisions/0002-a2a-connector-uses-the-a2a-java-sdk.md
@@ -1,0 +1,117 @@
+---
+status: "proposed"
+date: 2026-08-13
+decision-makers: Operaton maintainers
+consulted: —
+informed: Operaton contributors
+---
+
+# A2A connector is a Connect SPI connector built on the A2A Java SDK
+
+## Context and Problem Statement
+
+Processes increasingly need to delegate a step to an AI agent. The
+[Agent2Agent (A2A) protocol](https://a2a-protocol.org/) v1.0 is the emerging open standard for that, and Operaton
+has no way to call an A2A agent today.
+
+Two questions have to be answered together. Where does such a call live in Operaton, and do we implement the
+protocol ourselves or take a dependency on the official
+[A2A Java SDK](https://github.com/a2aproject/a2a-java)? The second question matters because the SDK's transitive
+closure lands new third-party jars on the engine classpath, and AGENTS.md requires an ADR for major dependencies.
+
+## Decision Drivers
+
+* A modeller who is not a Java developer must be able to add an agent call by dragging a task and filling in
+  fields.
+* The BPMN must stay valid and portable; the activity should remain a plain `bpmn:serviceTask`.
+* A2A is more than a request/response call: it has task lifecycle states, artifact streaming with chunk
+  reassembly, push-notification configuration, stream resubscription, and transport negotiation off the agent
+  card.
+* The engine classpath is shared by every process application, so new dependencies are expensive.
+* A protocol version bump should touch as few files as possible; A2A is young and still moving.
+* Nothing running on a job executor thread may block without a bound.
+
+## Considered Options
+
+* Connect SPI connector using the A2A Java SDK
+* Connect SPI connector implementing the A2A JSON-RPC calls directly on `httpclient5` and Jackson
+* An external task worker shipped outside the engine
+* A new BPMN element type with a custom `ActivityBehavior`
+
+## Decision Outcome
+
+Chosen option: **Connect SPI connector using the A2A Java SDK**, as a new opt-in module `connect/a2a`
+(`org.operaton.connect:operaton-connect-a2a`) registered under connector id `a2a`.
+
+A Connect connector gets declarative input/output mapping in the properties panel for free, runs inside the
+engine so there is no extra service to operate, and leaves the diagram portable.
+
+The SDK is used because the protocol surface that has to be right is much larger than the four JSON-RPC calls it
+looks like from the outside. In particular `ClientConfig` owns the streaming-versus-polling decision,
+`ClientTaskManager` reassembles `TaskArtifactUpdateEvent` chunks (`append` / `lastChunk`), `Client.subscribeToTask`
+handles resubscription after a dropped stream, and `ClientBuilder.findBestClientTransport()` negotiates transport
+from the card's `supportedInterfaces` and `preferredTransport`. Reimplementing that would be reimplementing a
+moving specification.
+
+To contain the dependency, all SDK usage sits behind `A2aAgent`, an interface whose methods take and return only
+strings, maps and lists. `SdkA2aAgent` is the only class importing `org.a2aproject.sdk`.
+
+### Consequences
+
+* Good, because a new agent call needs no Java at all: an element template plus input/output parameters.
+* Good, because task lifecycle, artifact assembly and push-notification configuration are handled by the
+  reference implementation rather than by us.
+* Good, because HTTP goes through the SDK's `JdkA2AHttpClient` abstraction over `java.net.http.HttpClient`, so
+  there is **no Netty and no Jackson conflict, and no shading was needed**.
+* Good, because a protocol bump touches two files.
+* Bad, because the transitive closure adds `protobuf-java`, `protobuf-java-util` (and with it Guava) and
+  `proto-google-common-protos` to the classpath of anyone using the connector. `a2a-java-sdk-client-transport-jsonrpc`
+  compile-depends on `a2a-java-sdk-spec-grpc` even when only JSON-RPC is used, so these cannot be excluded without
+  patching the SDK. `gson` is already managed by Operaton, and `jakarta.enterprise.cdi-api` and
+  `jakarta.inject-api` already come from the Jakarta EE BOM.
+* Bad, because the module needs `operaton-engine` at `provided` scope in order to throw `BpmnError`, which is a
+  layering wrinkle for a `connect/*` module. It creates no reactor cycle: `engine` only reaches `connect` through
+  `operaton-connect-connectors-all` under the non-default `check-plugins` profile, and this module is deliberately
+  not part of `connectors-all`.
+* Bad, because 1.2.0.Final's own release notes mention resolving split packages across modules, i.e. the SDK's
+  module layout is not settled yet.
+* Neutral, because the connector is opt-in. It is not in `connectors-all` (which shades and relocates
+  `org.apache`, unsafe for protobuf) and has no WildFly distro module yet, so nobody pays for these dependencies
+  unless they add the module.
+
+### Confirmation
+
+* Unit tests cover request building, response mapping, error classification and the reattach and timeout paths
+  against a scripted `A2aAgent`.
+* Engine-level tests run the three example processes on an in-memory engine and assert that a `BpmnError` reaches
+  an error boundary event, that outputs land in process variables, and that the async and polling shapes behave as
+  modelled.
+* `A2aAgent` having no SDK types in its signatures is what keeps the seam honest, and is visible in review.
+
+## Pros and Cons of the Options
+
+### Connect SPI connector implementing JSON-RPC directly
+
+Four calls (`SendMessage`, `GetTask`, `ListTasks`, `CreateTaskPushNotificationConfig`) over `httpclient5` and
+Jackson, both already managed by Operaton.
+
+* Good, because zero new dependencies and no shading question at all.
+* Good, because full control over timeouts and logging.
+* Bad, because it reimplements artifact chunk reassembly, streaming and resubscription, task lifecycle handling
+  and transport negotiation, all of which the SDK already does.
+* Bad, because every A2A revision becomes our maintenance problem, and v1.0 already renamed the JSON-RPC methods
+  from the `message/send` style to `SendMessage`.
+
+### External task worker outside the engine
+
+* Good, because the engine classpath stays untouched.
+* Bad, because it is another service to deploy, monitor and secure.
+* Bad, because the modeller loses the properties-panel input/output mapping and needs a worker deployment for
+  every new agent call, which defeats the main requirement.
+
+### New BPMN element type with a custom ActivityBehavior
+
+* Good, because agent calls could be first-class in the palette.
+* Bad, because it makes the BPMN non-portable and commits the engine to a modelling concept while A2A is still
+  changing.
+* Bad, because it is a far larger change than a connector for the same user-visible result.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -30,6 +30,7 @@
     <version.accessors-smart>2.6.0</version.accessors-smart>
     <version.commons-codec>1.22.1</version.commons-codec>
     <version.gson>2.14.0</version.gson>
+    <version.a2a-sdk>1.2.0.Final</version.a2a-sdk>
     <version.hibernate>6.6.10.Final</version.hibernate>
     <version.jackson>2.21.5</version.jackson>
     <version.jackson3>3.1.5</version.jackson3>


### PR DESCRIPTION
Opened as a **draft**: this adds a new engine-side module and new third-party jars, which is a maintainer-level
call. I would rather get a verdict on the dependencies and the layering before polishing. See
#3480 for the full proposal and the open questions.

## What this adds

A Connect SPI connector, id **`a2a`**, in a new opt-in module `connect/a2a`, so a modeller can call an
[A2A v1.0](https://a2a-protocol.org/) agent from a plain `bpmn:serviceTask` without writing Java.

```xml
<operaton:connector>
  <operaton:connectorId>a2a</operaton:connectorId>
  <operaton:inputOutput>
    <operaton:inputParameter name="operation">sendSync</operaton:inputParameter>
    <operaton:inputParameter name="url">${agentUrl}</operaton:inputParameter>
    <operaton:inputParameter name="message">${question}</operaton:inputParameter>
    <operaton:outputParameter name="answer">${text}</operaton:outputParameter>
  </operaton:inputOutput>
</operaton:connector>
```

Three operations: `sendSync` (send, then poll until the task settles, bounded by `waitTimeout`), `sendAsync`
(send with a push-notification config, return the ids immediately) and `getTask` (for a timer-driven polling
fallback). Full input/output/error reference in [`connect/a2a/README.md`](connect/a2a/README.md).

## Design notes for review

- **All SDK usage sits behind `A2aAgent`**, an interface whose methods take and return only strings, maps and
  lists. `SdkA2aAgent` is the only class importing `org.a2aproject.sdk`, so an SDK or protocol bump touches it and
  `TimeoutAwareA2AHttpClient` and nothing else.
- **`TimeoutAwareA2AHttpClient` exists out of necessity.** The SDK's `JdkA2AHttpClient` never calls
  `HttpRequest.Builder.timeout(...)`, and neither `A2AHttpClient` nor its builders expose a way to set one.
  Without it an unresponsive agent would hold a job executor thread until the OS gave up on the socket.
- **Streaming is deliberately off.** `sendSync` polls instead, so no job executor thread is pinned to an open SSE
  connection for the duration of the agent's work.
- **Not in `connectors-all`, no WildFly module.** `connectors-all` shades and relocates `org.apache`, which is not
  safe for protobuf, and shipping protobuf/Guava as JBoss modules is a distribution decision. Both are called out
  as open questions in the issue.
- **Header values and request bodies are never logged**; header names are logged at debug so a missing
  `Authorization` is still diagnosable.

## Dependencies added

`org.a2aproject.sdk:a2a-java-sdk-client:1.2.0.Final` (BOM imported in `bom/internal-dependencies`, version
property in `parent/pom.xml`). Its closure adds `protobuf-java`, `protobuf-java-util` (→ Guava) and
`proto-google-common-protos`; `gson` was already managed, and the two Jakarta APIs come from the Jakarta EE BOM.
**No Netty, no Jackson conflict, no shading.** ADR: `docs/decisions/0002-a2a-connector-uses-the-a2a-java-sdk.md`.

## Verified against a live agent and inside a real engine

This has been run end to end against a real A2A v1.0 agent (google-adk with `a2a-sdk` 1.1.2), first directly and
then from a BPMN process inside an `operaton/operaton:2.1.2` Run container with the connector dropped into
`configuration/userlib`. A service task calling the agent produced:

```
answer          = 4
a2aState        = TASK_STATE_COMPLETED
a2aTaskId       = f0b204bdc8d3477a97cc14c67dddd12f
a2aContextId    = ctx-c729d7ecd9210450e0c332c4ba353288
a2aArtifactText = 4
```

A second process asks for a task id that does not exist. Its activity history is
`readMissingTask → caughtProtocolError (boundaryError) → handledError`, which is direct evidence that a terminal
A2A failure becomes a `BpmnError` an error boundary event catches, in a real engine rather than a mock.
`ConnectProcessEnginePlugin` is active by default in Operaton Run, so no extra configuration was needed.

Getting there found four real defects, all fixed here with regression tests:

1. **The reattach probe took down every send to an agent without `ListTasks`.** `ListTasks` is optional and many
   agents answer `-32601 Method not found`. That failure was classified as retryable and rethrown, so with
   `reattachOnRetry` defaulting to `true` every `sendSync` to such an agent failed permanently. The probe is now
   best-effort: only a proven transport failure (`IOException`, or HTTP 408/425/429/5xx) fails the job.
2. **`text` was empty for agents that answer with artifacts.** Some agents close a task with a status message,
   others return only artifacts and no message. `text` read only the status message, so it was blank against the
   second kind, which is the output the examples and the element template lead with. It now falls back to the
   artifact text.
3. **The example processes could not be deployed.** None set `historyTimeToLive`, so any engine with `enforceTTL`
   on, the default, rejects them. All now set it.
4. **A transport failure named the wrong URL.** The `url` input locates the agent *card*; the endpoint actually
   called is the one the card advertises in `supportedInterfaces[].url`. The message now says so and includes the
   cause, so a card advertising an unreachable address is not mistaken for an agent being down.

Also confirmed empirically: `protobuf-java` and `a2a-java-sdk-spec-grpc` are required **at runtime** on the pure
JSON-RPC path, exactly as the ADR states. The client will not construct without them.

## Verification, stated precisely

- ✅ **58 unit tests pass**, run on the JUnit console launcher against published Operaton artifacts.
- ✅ **Wire-level tests** (`SdkA2aAgentWireTest`) drive the real JSON-RPC protocol over WireMock, using payloads
  copied from a real agent: `SendMessage` wraps its result in a `task` envelope while `GetTask` does not, parts
  carry a bare `text` field with no kind discriminator, and `-32601` on `ListTasks` is covered explicitly.
- ✅ **End-to-end in an Operaton Run 2.1.2 container** against a live agent, including the error-boundary path.
- ✅ Compiles on Java 17 against both `2.2.0-M2` and `2.1.2` Operaton artifacts.
- ✅ The element template validates against `@camunda/element-templates-json-schema` with 0 errors.
- ❌ **`mvn clean install` has not been run**, and neither has `.devenv/scripts/maintenance/code-cleanup.sh`
  (OpenRewrite). There is no Maven on the machine I authored this on. Style was matched by hand to
  `connect/http-client`. Please treat CI as the first signal on the full reactor build.
- ❌ **`A2aConnectorProcessTest` has not been executed** in-process; it compiles, and the behaviour it asserts was
  instead demonstrated in the real container as described above.

## Tests included

`A2aIdsTest`, `A2aParamsTest` (literal-vs-expression coercion, plus null/empty/blank cases), `A2aResponseImplTest`
(output mapping, multi-artifact reachability, truncation, the artifact-text fallback), `SdkA2aAgentTest` (the
reattach-probe classification), `SdkA2aAgentWireTest` (the real protocol over WireMock), `A2aConnectorImplTest`
(operation dispatch, retry reattachment, polling, timeout, and each error code), and `A2aConnectorProcessTest`,
which runs the three example processes on an in-memory engine.

## Checklist

- [x] New files carry the Apache 2.0 license header
- [x] Public API has Javadoc and `@since 2.2`
- [x] Unit tests written (JUnit 5 + AssertJ)
- [x] ADR added for the new major dependency
- [x] Conventional Commits, footer references #3480
- [ ] `mvn clean install` green — needs CI, see above
- [ ] `code-cleanup.sh` run — needs a Maven environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
