### PR TITLE
chore(ci): make build.yml the single m2-cache producer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,8 +86,9 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        id: m2-cache
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"
@@ -180,6 +181,22 @@ jobs:
             distro/**/target/operaton-*.gz
             distro/webjar/target/operaton-webapp-webjar-*.jar
           key: ${{ github.run_id }}-build-artifacts
+      # This job is the only m2-cache producer: cache entries written from PR
+      # branches are readable only by that same PR, so PR-side writes just fill
+      # the shared 10 GB pool (the LRU evictions behind the recurring nightly
+      # failures). All other jobs restore-only. The freshly installed
+      # org/operaton artifacts are purged before saving — restoring them into
+      # later builds would make them accidentally incremental and can mask
+      # stale-artifact bugs.
+      - name: Purge Operaton artifacts before cache save
+        if: steps.m2-cache.outputs.cache-hit != 'true'
+        run: rm -rf ~/.m2/repository/org/operaton
+      - name: Save Maven packages
+        if: steps.m2-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ~/.m2
+          key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"
 
   publish:
     name: Publish

--- a/.github/workflows/code-cleanup.yml
+++ b/.github/workflows/code-cleanup.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -239,8 +239,8 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"
@@ -371,8 +371,8 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"
@@ -448,8 +448,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7.0.1
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"
@@ -528,6 +528,12 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2
+          key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: ${{ runner.os }}-m2
       - name: Import GPG key
         shell: bash
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -154,8 +154,8 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"

--- a/.github/workflows/reports-and-docs.yml
+++ b/.github/workflows/reports-and-docs.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache@v6.1.0
+      - name: Restore Maven packages
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ~/.m2
           key: "${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}"


### PR DESCRIPTION
The shared 10 GB Actions cache pool is chronically over quota, driven by Linux-m2-* entries written from many jobs: any job missing its pom-hash key saved its entire ~/.m2 back, including the freshly installed org/operaton artifacts (observed 1.7-3.2 GiB vs ~0.7 GiB clean). PR-side writes are PR-scoped and unreadable elsewhere, so they only consumed pool space and accelerated LRU eviction of run-scoped handoffs.

Changes:
- build.yml build job is now the only producer: restore with id, purge ~/.m2/repository/org/operaton before an explicit cache/save, both guarded on cache miss (save only for a new pom-hash, only on green builds).
- All other consumers switch to actions/cache/restore: pr-build build job, integration-build build/IT/side-by-side jobs, code-cleanup.yml and reports-and-docs.yml (both previously competed as writers on the same key).
- deploy-snapshots gains an m2 restore; it was the only job rebuilding with a cold repository (~22 min).