### PR TITLE
Extract markdown linting to job

### DIFF
--- a/.github/markdownlint-cli2.yml
+++ b/.github/markdownlint-cli2.yml
@@ -1,0 +1,5 @@
+---
+# see https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+config:
+  MD013:
+    line_length: 160

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,23 +56,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-adr:
-    name: Lint ADRs
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Set up Git repository
-        uses: actions/checkout@v7.0.1
-        with:
-          sparse-checkout: |
-            docs/decisions
-      - name: Lint ADR files
-        # version: v20.0.0 - pinned to specific commit for security
-        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff
-        with:
-          globs: |
-            docs/decisions/*.md
 
   build:
     name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Linting
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  lint-markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-slim
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v7.0.1
+      - name: Lint ADR files
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
+        continue-on-error: true
+        with:
+          globs: |
+            docs/decisions/**/*.md
+          config: '.github/markdownlint-cli2.yml'
+

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,14 +39,14 @@ Common examples include:
 
 ![image](adr-decision-process.png)
 
-* Open a new discussion on a shared editor (Etherpad, etc.)
-* Create a new issue, link the shared editor in it
-* Discuss options, weigh pros & cons until the proposal is deemed ready by participants
-* If no agreement is reached, withdraw the proposal
-* If an agreement is reached, assign an ADR number, open a PR with the ADR in this folder
-* Core contributors review, approve and request changes
-* If two core contributors (the author excluded) agree on the ADR and no veto is present by others, it is approved
-* Merge the PR, close the issue
+- Open a new discussion on a shared editor (Etherpad, etc.)
+- Create a new issue, link the shared editor in it
+- Discuss options, weigh pros & cons until the proposal is deemed ready by participants
+- If no agreement is reached, withdraw the proposal
+- If an agreement is reached, assign an ADR number, open a PR with the ADR in this folder
+- Core contributors review, approve and request changes
+- If two core contributors (the author excluded) agree on the ADR and no veto is present by others, it is approved
+- Merge the PR, close the issue
 
 ## File Naming Convention
 


### PR DESCRIPTION
Moves the "Lint ADR" job to a separate workflow. This allows finer control to execute the job only when relevant changes are done.

Also adds a configuration file for the markdown linter.