### PR TITLE
test(webapps-neo): Stop the date formatter test failing after midnight

### DIFF
--- a/webapps-neo/frontend/src/helper/date_formatter.test.js
+++ b/webapps-neo/frontend/src/helper/date_formatter.test.js
@@ -7,6 +7,12 @@ describe('date_formatter', () => {
   beforeEach(() => {
     // Save original navigator
     originalNavigator = global.navigator;
+
+    // Freeze the clock at local midday. Tests that shift "now" by a couple of
+    // hours would otherwise cross midnight and flip the expected relative day
+    // whenever CI happens to run shortly after midnight.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
   });
 
   afterEach(() => {


### PR DESCRIPTION
Fixes the flaky frontend test reported in #3521.

## Problem

The `Webapps Neo Frontend` job fails on any PR built between midnight and 02:00 runner-local time, most recently on [run 32318803176](https://github.com/operaton/operaton/actions/runs/32318803176/job/96276620870?pr=3518) (an unrelated dependabot bump):

```
FAIL  src/helper/date_formatter.test.js > date_formatter > formatRelativeDateTime > should ignore time when ignoreTime is true
AssertionError: expected 'yesterday' to be 'today'
```

This is not a defect in `date_formatter.js`. The test builds its input by subtracting two hours from the *current* time and expects `"today"`. That job started at 00:50 UTC, so "two hours ago" landed on the previous calendar day and the formatter correctly returned `"yesterday"`.

## Solution

Freeze the clock at *local* midday for the suite in `beforeEach` — the file already restored real timers in `afterEach`. Building the fixed date from local components rather than a UTC instant keeps it away from midnight in every runner time zone.

## Verification

* Reproduced the exact CI failure locally with `TZ=America/Anchorage` (01:28 local at the time).
* After the fix, the file passes under `America/Anchorage`, `UTC`, `Europe/Berlin`, `Pacific/Auckland` and `Asia/Kolkata`.
* Full frontend suite: 63 files, 588 tests passed.
* `npm run lint`: 0 errors (only the 6 pre-existing warnings).

related to #3521