### PR TITLE
fix(build): backport prepare-deploy.sh hardening to release/2.1.x

### DIFF
--- a/.github/scripts/prepare-deploy.sh
+++ b/.github/scripts/prepare-deploy.sh
@@ -3,12 +3,20 @@
 # this activates a profile that skips the deployment of sql scripts in the release workflow
 set -e
 
-# Find the last release tag that contains the last commit that modified the db directory
-LAST_RELEASE_TAG=$(git tag --contains $(git log --pretty=format:%H -- engine/src/main/resources/org/operaton/bpm/engine/db | tail -1) | grep '^v' | sort -V | tail -1)
+DB_DIR=engine/src/main/resources/org/operaton/bpm/engine/db
+
+# Last release tag reachable from HEAD (i.e. the previous release on this branch)
+LAST_RELEASE_TAG=$(git tag --merged HEAD | grep '^v' | sort -V | tail -1)
+
+if [ -z "$LAST_RELEASE_TAG" ]; then
+    echo "⚠️ No release tag found; sql scripts will be deployed."
+    exit 0
+fi
 
 # Check if there are any changes in the db directory since the last release tag
-git diff --quiet $LAST_RELEASE_TAG -- engine/src/main/resources/org/operaton/bpm/engine/db
-if [ $? -eq 0 ]; then
+if git diff --quiet "$LAST_RELEASE_TAG" -- "$DB_DIR"; then
     echo "No database changes detected since last release tag $LAST_RELEASE_TAG."
     touch distro/sql-script/.skip-deploy
+else
+    echo "Database changes detected since last release tag $LAST_RELEASE_TAG; sql scripts will be deployed."
 fi


### PR DESCRIPTION
## Summary
- Backports #3406 (merged to `main` on 2026-07-24, never backported) to `release/2.1.x`.
- Without this, `release.yml`'s Maven Build step crashes on this branch. The old script's `LAST_RELEASE_TAG` was computed via `git tag --contains <historical db commit>` across **all** branches, which now resolves to `v2.2.0-M2` (higher version, also descends from that commit) instead of `v2.1.3`. It then ran `git diff --quiet $LAST_RELEASE_TAG -- <db dir>` as a bare statement under `set -e`; since that diff is non-empty, the nonzero exit aborted the script before the `if [ $? -eq 0 ]` check ever ran.
- The fixed script scopes the tag lookup to `git tag --merged HEAD` (ancestors of the current branch only → correctly resolves to `v2.1.3`) and wraps the diff directly in an `if` so `set -e` doesn't short-circuit it.

Found via the dry-run (`dry_run=true`) release.yml run for **2.1.4**: https://github.com/operaton/operaton/actions/runs/32453987314

## Test plan
- [ ] Re-run `release.yml` with `dry_run=true` on `release/2.1.x` after merge and confirm the Maven Build step completes