### PR TITLE
chore(ci): don't fail or poison the build cache on a skip_tests dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       checks: write
       actions: write
     env:
-      # Build cache, but never for a max-profile run.
+      # Build cache, but never for a max-profile or a skip_tests run.
       #
       # Restoring a module skips its Surefire and JaCoCo executions and replays
       # the stored surefire-reports instead. For an ordinary push that is the
@@ -82,9 +82,18 @@ jobs:
       # would make that reproduction behave differently from the run it is meant
       # to reproduce.
       #
-      # Consequence: pushes (profile=normal) produce the cache that pr-build.yml
-      # restores; max runs neither read nor write it.
-      USE_BUILD_CACHE: ${{ (github.event.inputs.profile || 'normal') != 'max' }}
+      # The skip_tests opt-out is about what such a run leaves behind: module
+      # artifacts with no surefire-reports beside them. Saving those would
+      # hand pr-build.yml modules it restores instead of tests, leaving the
+      # Publish Test Report gate below with no results for them - a red PR whose
+      # cause sits in an unrelated dispatch from days earlier. Restoring is
+      # disabled along with saving: a restored module contributes reports the
+      # run was explicitly asked not to produce.
+      #
+      # Consequence: pushes (profile=normal, skip_tests unset) produce the cache
+      # that pr-build.yml restores; max and skip_tests runs neither read nor
+      # write it.
+      USE_BUILD_CACHE: ${{ (github.event.inputs.profile || 'normal') != 'max' && github.event.inputs.skip_tests != 'true' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7.0.1
@@ -157,10 +166,11 @@ jobs:
           # caches surefire-reports, site/jacoco and classes alongside the
           # artifact, so this job stays the authoritative source of test and
           # coverage data even when most of the reactor is restored.
-          # See USE_BUILD_CACHE at the job level for why max runs opt out.
+          # See USE_BUILD_CACHE at the job level for why max and skip_tests runs
+          # opt out.
           BUILD_CMD="$BUILD_CMD -Dmaven.build.cache.enabled=${USE_BUILD_CACHE}"
           if [ "$USE_BUILD_CACHE" != "true" ]; then
-            echo "ℹ️ profile=max — build cache off, every module is rebuilt and retested"
+            echo "ℹ️ profile=$PROFILE, skip_tests=$SKIP_TESTS — build cache off, nothing is restored or saved"
           fi
 
           echo "ℹ️ Executing: $BUILD_CMD"
@@ -182,8 +192,12 @@ jobs:
         with:
           path: ~/.m2/build-cache
           key: "${{ runner.os }}-build-cache-${{ github.sha }}"
+      # require_passed_tests turns an empty report set into a failure, which is
+      # what we want for a normal build - see the build cache notes above, a
+      # restored module has to bring its reports with it. A skip_tests dispatch
+      # legitimately produces none, so it skips the gate rather than failing it.
       - name: Publish Test Report
-        if: always()
+        if: always() && github.event.inputs.skip_tests != 'true'
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 #v6.4.2
         with:
           report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml


### PR DESCRIPTION
Follow-up to #3491. A `workflow_dispatch` of `build.yml` with `skip_tests=true` fails since the build cache PoC landed, and would poison the shared cache if it did not.

[Run 32487931222](https://github.com/operaton/operaton/actions/runs/32487931222) (`profile=normal`, `skip_tests=true`) ended with:

```
ℹ️ Executing: .devenv/scripts/build/build.sh --profile=normal --runner=mvnd --skip-tests -Dmaven.build.cache.enabled=true
...
##[error]❌ No passed test results found for JUnit Test Report
```

Two separate problems behind that line:

- **The gate.** `Publish Test Report` lost its `continue-on-error: true` in #3491 while keeping `require_passed_tests: true`. That combination is right for a normal build — a restored module has to bring its surefire-reports with it, and an empty report set should be red. A `skip_tests` run legitimately produces none, so it now skips the step instead of failing it.
- **The cache.** That same run saved a 171 MB / 103-module cache *before* it failed, built entirely without surefire-reports. Here it was pruned away by the next default-branch build, but a `skip_tests` dispatch on `main` would have handed `pr-build.yml` modules it restores instead of tests — a red PR whose cause sits in an unrelated dispatch from days earlier. `USE_BUILD_CACHE` now covers `skip_tests` alongside `profile=max`, so such a run neither reads nor writes the cache.

Also fixes the info line in the Maven build step, which hardcoded `profile=max` and so reported the wrong reason on a `skip_tests` run.

## Verification status of the PoC itself

- **Write side** — confirmed on [32492577880](https://github.com/operaton/operaton/actions/runs/32492577880): `build cache size: 203M`, `cached module builds: 104`, saved as `Linux-build-cache-a29b9f86…` on `refs/heads/main`. 33m49s against a 32–34m baseline for recent `main` pushes, so the save costs nothing measurable.
- **Pruning** — confirmed: `deleting superseded build cache 6862399243`, one `Linux-build-cache-*` entry left in the pool.
- **`max` opt-out** — confirmed on [32488670050](https://github.com/operaton/operaton/actions/runs/32488670050): cache off, `cached module builds: 0`, no save.
- **Read side** — not yet measured. The only PR build on the PoC branch ran at 13:38, before the first save, and reported `Cache not found for input keys: Linux-build-cache-…`. This PR is the first one to run against an existing `main` entry; it touches only `build.yml`, so most of the reactor should restore. Compare against 52m38s from [32487874176](https://github.com/operaton/operaton/actions/runs/32487874176).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3i6var6eAtozWvzrPoWYd
