### PR TITLE
Annotate nullability for engine commands and related services

### DIFF
--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/FileValueImpl.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/FileValueImpl.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Serial;
 import java.nio.charset.Charset;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.variable.type.FileValueType;
 import org.operaton.bpm.engine.variable.type.ValueType;
@@ -62,7 +61,7 @@ public class FileValueImpl implements FileValue {
     return mimeType;
   }
 
-  public void setMimeType(@NonNull String mimeType) {
+  public void setMimeType(@Nullable String mimeType) {
     this.mimeType = mimeType;
   }
 
@@ -83,7 +82,7 @@ public class FileValueImpl implements FileValue {
     return type;
   }
 
-  public void setEncoding(@NonNull String encoding) {
+  public void setEncoding(@Nullable String encoding) {
     this.encoding = encoding;
   }
 

--- a/commons/utils/src/main/java/org/operaton/commons/utils/IoUtil.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/IoUtil.java
@@ -176,10 +176,6 @@ public class IoUtil {
    * @return the file object
    */
   public static File getClasspathFile(@NonNull String filename) {
-    if(filename == null) {
-      throw LOG.nullParameter("filename");
-    }
-
     return getClasspathFile(filename, null);
   }
 
@@ -192,6 +188,9 @@ public class IoUtil {
    * @throws IoUtilException if the file cannot be loaded
    */
   public static File getClasspathFile(@NonNull String filename, @Nullable ClassLoader classLoader) {
+    if(filename == null) {
+      throw LOG.nullParameter("filename");
+    }
 
     URL fileUrl = null;
 

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
@@ -31,7 +31,6 @@ import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.cdi.annotation.BusinessProcessScoped;
 import org.operaton.bpm.engine.cdi.impl.context.ContextAssociationManager;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
@@ -39,6 +39,8 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
+import static org.operaton.bpm.engine.impl.context.Context.hasActiveCommandContext;
+
 /**
  * Bean supporting contextual business process management. This allows us to
  * implement a unit of work, in which a particular CDI scope (Conversation /
@@ -742,7 +744,7 @@ public class BusinessProcess implements Serializable {
   }
 
   protected void assertCommandContextNotActive() {
-    if(Context.getCommandContext() != null) {
+    if(hasActiveCommandContext()) {
       throw new ProcessEngineCdiException("Cannot use this method of the BusinessProcess bean from an active command context.");
     }
   }

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/CdiArtifactFactory.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/CdiArtifactFactory.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.cdi;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ArtifactFactory;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.engine.impl.DefaultArtifactFactory;
@@ -24,6 +25,7 @@ import org.operaton.bpm.engine.impl.DefaultArtifactFactory;
  *
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
+@NullMarked
 public class CdiArtifactFactory implements ArtifactFactory {
 
   private final ArtifactFactory defaultArtifactFactory = new DefaultArtifactFactory();

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessEngineServicesProducer.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessEngineServicesProducer.java
@@ -49,19 +49,17 @@ public class ProcessEngineServicesProducer {
   @Named
   @ApplicationScoped
   public ProcessEngine processEngine() {
-
     ProcessEngine processEngine =  BpmPlatform.getProcessEngineService().getDefaultProcessEngine();
     if(processEngine != null) {
       return processEngine;
-    } else {
-      List<ProcessEngine> processEngines = BpmPlatform.getProcessEngineService().getProcessEngines();
-      if (processEngines != null && processEngines.size() == 1) {
-        return processEngines.get(0);
-      } else {
-        return ProcessEngines.getDefaultProcessEngine(false);
-      }
     }
 
+    List<ProcessEngine> processEngines = BpmPlatform.getProcessEngineService().getProcessEngines();
+    if (processEngines.size() == 1) {
+      return processEngines.get(0);
+    } else {
+      return ProcessEngines.getDefaultProcessEngine(false);
+    }
   }
 
   @Produces @Named @ApplicationScoped public RuntimeService runtimeService() { return processEngine().getRuntimeService(); }

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/context/DefaultContextAssociationManager.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/context/DefaultContextAssociationManager.java
@@ -188,7 +188,7 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
   }
 
   protected ExecutionEntity getExecutionFromContext() {
-    if(Context.getCommandContext() != null) {
+    if(Context.hasActiveCommandContext()) {
       BpmnExecutionContext executionContext = Context.getBpmnExecutionContext();
       if(executionContext != null) {
         return executionContext.getExecution();
@@ -228,7 +228,7 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
   }
 
   protected void ensureCommandContextNotActive() {
-    if(Context.getCommandContext() != null) {
+    if(Context.hasActiveCommandContext()) {
       throw new ProcessEngineCdiException("Cannot work with scoped associations inside command context.");
     }
   }

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/util/ProgrammaticBeanLookup.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/util/ProgrammaticBeanLookup.java
@@ -127,8 +127,8 @@ public final class ProgrammaticBeanLookup {
   }
 
   private static void releaseOnContextClose(CreationalContext<?> creationalContext, Bean<?> bean) {
-    CommandContext commandContext = Context.getCommandContext();
-    if(commandContext != null) {
+    if(Context.hasActiveCommandContext()) {
+      CommandContext commandContext = Context.getCommandContext();
       commandContext.registerCommandContextListener(new CreationalContextReleaseListener(creationalContext));
 
     } else {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/FilterResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/FilterResourceImpl.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.core.Response.Status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.FilterService;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -140,7 +141,7 @@ public class FilterResourceImpl extends AbstractAuthorizedRestResource implement
   }
 
   @Override
-  public Object querySingleResult(Request request, String extendingQuery) {
+  public @Nullable Object querySingleResult(Request request, String extendingQuery) {
     Variant variant = request.selectVariant(VARIANTS);
     if (variant != null) {
       if (MediaType.APPLICATION_JSON_TYPE.equals(variant.getMediaType())) {
@@ -337,7 +338,7 @@ public class FilterResourceImpl extends AbstractAuthorizedRestResource implement
     return dto;
   }
 
-  protected Query<?,?> convertQuery(String queryString) {
+  protected @Nullable Query<?,?> convertQuery(String queryString) {
     if (isEmptyJson(queryString)) {
       return null;
     }

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/SpringArtifactFactory.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/SpringArtifactFactory.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.spring;
 
+import org.jspecify.annotations.NullMarked;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 
@@ -26,6 +27,7 @@ import org.operaton.bpm.engine.impl.DefaultArtifactFactory;
  *
  * @author Svetlana Dorokhova
  */
+@NullMarked
 public class SpringArtifactFactory implements ArtifactFactory {
 
   private final ArtifactFactory defaultArtifactFactory = new DefaultArtifactFactory();

--- a/engine/src/main/java/org/operaton/bpm/engine/ArtifactFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/ArtifactFactory.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Create and destroy artifacts of a given class in a container specific way.
  * This SPI hides differences between CDI, Spring, etc.
@@ -35,6 +37,7 @@ package org.operaton.bpm.engine;
  *
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
+@NullMarked
 public interface ArtifactFactory {
   /**
    *

--- a/engine/src/main/java/org/operaton/bpm/engine/AuthenticationException.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/AuthenticationException.java
@@ -18,7 +18,9 @@ package org.operaton.bpm.engine;
 
 import java.io.Serial;
 import java.util.Date;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class AuthenticationException extends ProcessEngineException {
 
   @Serial private static final long serialVersionUID = 1L;

--- a/engine/src/main/java/org/operaton/bpm/engine/AuthorizationException.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/AuthorizationException.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.authorization.MissingAuthorization;
 
 import org.jspecify.annotations.Nullable;
@@ -35,10 +36,11 @@ import org.jspecify.annotations.Nullable;
  * @author Daniel Meyer
  *
  */
+@NullMarked
 @SuppressWarnings("java:S5738")
 public class AuthorizationException extends ProcessEngineException {
 
-  protected final String userId;
+  protected final @Nullable String userId;
   protected final transient List<MissingAuthorization> missingAuthorizations;
 
   // These properties have been replaced by the list of missingAuthorizations
@@ -49,19 +51,19 @@ public class AuthorizationException extends ProcessEngineException {
    * of the {@link MissingAuthorization}(s).
    */
   @Deprecated(since = "1.0", forRemoval = true)
-  protected String resourceType;
+  protected @Nullable String resourceType;
   /**
    * @deprecated Use {@link #getMissingAuthorizations()} instead to get the type of the resource
    * of the {@link MissingAuthorization}(s).
    */
   @Deprecated(since = "1.0", forRemoval = true)
-  protected String permissionName;
+  protected @Nullable String permissionName;
   /**
    * @deprecated Use {@link #getMissingAuthorizations()} instead to get the type of the resource
    * of the {@link MissingAuthorization}(s).
    */
   @Deprecated(since = "1.0", forRemoval = true)
-  protected String resourceId;
+  protected @Nullable String resourceId;
 
   public AuthorizationException(String message) {
     super(message);
@@ -98,7 +100,7 @@ public class AuthorizationException extends ProcessEngineException {
    * of the {@link MissingAuthorization}(s).
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  public String getResourceType() {
+  public @Nullable String getResourceType() {
     String result = null;
     if (missingAuthorizations.size() == 1) {
       result = missingAuthorizations.get(0).getResourceType();
@@ -125,7 +127,7 @@ public class AuthorizationException extends ProcessEngineException {
    * @return id of the user in which context the request was made and who misses authorizations
    *  to perform it successfully.
    */
-  public String getUserId() {
+  public @Nullable String getUserId() {
     return userId;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/ExternalTaskService.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/ExternalTaskService.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.BatchPermissions;
 import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.Resources;
@@ -176,7 +177,7 @@ public interface ExternalTaskService {
    *     <li>{@link Permissions#UPDATE_INSTANCE} on {@link Resources#PROCESS_DEFINITION}</li>
    *   </ul>
    */
-  void complete(String externalTaskId, String workerId, Map<String, Object> variables, Map<String, Object> localVariables);
+  void complete(String externalTaskId, String workerId, @Nullable Map<String, Object> variables, @Nullable Map<String, Object> localVariables);
 
   /**
    * <p>Extends a lock of an external task on behalf of a worker.

--- a/engine/src/main/java/org/operaton/bpm/engine/FilterService.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/FilterService.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.filter.Filter;
@@ -129,7 +130,7 @@ public interface FilterService {
    *  {@link Integer#MAX_VALUE}).
    *  Please use {@link #listPage(String, Query, int, int)} instead.
    */
-  <T, Q extends Query<?, T>> List<T> list(String filterId, Q extendingQuery);
+  <T, Q extends Query<?, T>> List<T> list(String filterId, @Nullable Q extendingQuery);
 
   /**
    * Executes the query of the filter and returns the result in the given boundaries as list.
@@ -169,7 +170,7 @@ public interface FilterService {
    *  be specified with the process engine configuration property <code>queryMaxResultsLimit</code>
    *  (default {@link Integer#MAX_VALUE}).
    */
-  <T, Q extends Query<?, T>> List<T> listPage(String filterId, Q extendingQuery, int firstResult, int maxResults);
+  <T, Q extends Query<?, T>> List<T> listPage(String filterId, @Nullable Q extendingQuery, int firstResult, int maxResults);
 
   /**
    * Executes the query of the filter and returns the a single result.
@@ -199,7 +200,7 @@ public interface FilterService {
    *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
    *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
-  <T, Q extends Query<?, T>> T singleResult(String filterId, Q extendingQuery);
+  <T, Q extends Query<?, T>> T singleResult(String filterId, @Nullable Q extendingQuery);
 
   /**
    * Executes the query of the filter and returns the result count.
@@ -229,6 +230,6 @@ public interface FilterService {
    *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
    *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
-  Long count(String filterId, Query<?, ?> extendingQuery);
+  Long count(String filterId, @Nullable Query<?, ?> extendingQuery);
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/TaskService.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/TaskService.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.operaton.bpm.engine.authorization.Resources;
@@ -1265,7 +1266,7 @@ public interface TaskService {
   void deleteAttachment(String attachmentId);
 
   /** Delete an attachment to the given task id and attachment id */
-  void deleteTaskAttachment(String taskId, String attachmentId);
+  void deleteTaskAttachment(@Nullable String taskId, String attachmentId);
 
   /** The list of subtasks for this parent task */
   List<Task> getSubTasks(String parentTaskId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractQuery.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.*;
 
 import org.joda.time.DateTime;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -156,7 +157,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
 
     if (commandExecutor != null) {
       if (!maxResultsLimitEnabled) {
-        maxResultsLimitEnabled = Context.getCommandContext() == null;
+        maxResultsLimitEnabled = Context.getCommandContextWhenAvailable().isEmpty();
       }
 
       return commandExecutor.execute(this);
@@ -189,7 +190,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   }
 
   @Override
-  public @Nullable Object execute(CommandContext commandContext) {
+  public @Nullable Object execute(@NonNull CommandContext commandContext) {
     if (resultType==ResultType.LIST) {
       return evaluateExpressionsAndExecuteList(commandContext, null);
     } else if (resultType==ResultType.SINGLE_RESULT) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractQuery.java
@@ -157,7 +157,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
 
     if (commandExecutor != null) {
       if (!maxResultsLimitEnabled) {
-        maxResultsLimitEnabled = Context.getCommandContextWhenAvailable().isEmpty();
+        maxResultsLimitEnabled = Context.findCommandContext().isEmpty();
       }
 
       return commandExecutor.execute(this);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/DefaultArtifactFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/DefaultArtifactFactory.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ArtifactFactory;
 import org.operaton.bpm.engine.ProcessEngineException;
 
@@ -28,6 +29,7 @@ import org.operaton.bpm.engine.ProcessEngineException;
  *
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
+@NullMarked
 public class DefaultArtifactFactory implements ArtifactFactory {
   @Override
   public <T> T getArtifact(Class<T> clazz) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskServiceImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskServiceImpl.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
@@ -77,7 +78,7 @@ public class ExternalTaskServiceImpl extends ServiceImpl implements ExternalTask
   }
 
   @Override
-  public void complete(String externalTaskId, String workerId, Map<String, Object> variables, Map<String, Object> localVariables) {
+  public void complete(String externalTaskId, String workerId, @Nullable Map<String, Object> variables, @Nullable Map<String, Object> localVariables) {
     commandExecutor.execute(new CompleteExternalTaskCmd(externalTaskId, workerId, variables, localVariables));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/FilterServiceImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/FilterServiceImpl.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl;
 
 import java.util.List;
 
+import org.jspecify.annotations.NonNull;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.FilterService;
 import org.operaton.bpm.engine.filter.Filter;
@@ -40,7 +41,7 @@ import org.operaton.bpm.engine.query.Query;
 public class FilterServiceImpl extends ServiceImpl implements FilterService {
 
   @Override
-  public Filter newTaskFilter() {
+  public @NonNull Filter newTaskFilter() {
     return commandExecutor.execute(new CreateFilterCmd(EntityTypes.TASK));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/GetDeployedTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/GetDeployedTaskFormCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.FormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -29,6 +31,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  * @author Anna Pazola
  *
  */
+@NullMarked
 public class GetDeployedTaskFormCmd extends AbstractGetDeployedFormCmd {
 
   protected String taskId;
@@ -39,14 +42,18 @@ public class GetDeployedTaskFormCmd extends AbstractGetDeployedFormCmd {
   }
 
   @Override
-  protected FormData getFormData() {
-    return commandContext.runWithoutAuthorization(new GetTaskFormCmd(taskId));
+  protected @Nullable FormData getFormData() {
+    return getCommandContext().runWithoutAuthorization(new GetTaskFormCmd(taskId));
   }
 
   @Override
   protected void checkAuthorization() {
-    TaskEntity taskEntity = commandContext.getTaskManager().findTaskById(taskId);
-    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    TaskEntity taskEntity = getCommandContext().getTaskManager().findTaskById(taskId);
+    if (taskEntity == null) {
+      return;
+    }
+
+    for (CommandChecker checker : getCommandContext().getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkReadTask(taskEntity);
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceReportImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceReportImpl.java
@@ -95,12 +95,10 @@ public class HistoricProcessInstanceReportImpl implements HistoricProcessInstanc
     ensureNotNull(NotValidException.class, "periodUnit", periodUnit);
     this.durationPeriodUnit = periodUnit;
 
-    CommandContext commandContext = Context.getCommandContext();
-
-    if (commandContext == null) {
+    if (!Context.hasActiveCommandContext()) {
       return commandExecutor.execute(new ExecuteDurationReportCmd());
     } else {
-      return executeDurationReport(commandContext);
+      return executeDurationReport(Context.getCommandContext());
     }
 
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricTaskInstanceReportImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricTaskInstanceReportImpl.java
@@ -52,13 +52,11 @@ public class HistoricTaskInstanceReportImpl implements HistoricTaskInstanceRepor
 
   @Override
   public List<HistoricTaskInstanceReportResult> countByProcessDefinitionKey() {
-    CommandContext commandContext = Context.getCommandContext();
-
-    if(commandContext == null) {
+    if(!Context.hasActiveCommandContext()) {
       return commandExecutor.execute(new HistoricTaskInstanceCountByProcessDefinitionKey());
     }
     else {
-      return executeCountByProcessDefinitionKey(commandContext);
+      return executeCountByProcessDefinitionKey(Context.getCommandContext());
     }
   }
 
@@ -69,13 +67,11 @@ public class HistoricTaskInstanceReportImpl implements HistoricTaskInstanceRepor
 
   @Override
   public List<HistoricTaskInstanceReportResult> countByTaskName() {
-    CommandContext commandContext = Context.getCommandContext();
-
-    if(commandContext == null) {
+    if(!Context.hasActiveCommandContext()) {
       return commandExecutor.execute(new HistoricTaskInstanceCountByNameCmd());
     }
     else {
-      return executeCountByTaskName(commandContext);
+      return executeCountByTaskName(Context.getCommandContext());
     }
   }
 
@@ -89,13 +85,11 @@ public class HistoricTaskInstanceReportImpl implements HistoricTaskInstanceRepor
     ensureNotNull(NotValidException.class, "periodUnit", periodUnit);
     this.durationPeriodUnit = periodUnit;
 
-    CommandContext commandContext = Context.getCommandContext();
-
-    if(commandContext == null) {
+    if(!Context.hasActiveCommandContext()) {
       return commandExecutor.execute(new ExecuteDurationCmd());
     }
     else {
-      return executeDuration(commandContext);
+      return executeDuration(Context.getCommandContext());
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/SetJobsRetriesByProcessBatchCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/SetJobsRetriesByProcessBatchCmd.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.operaton.bpm.engine.impl.batch.BatchElementConfiguration;
 import org.operaton.bpm.engine.impl.cmd.AbstractSetJobsRetriesBatchCmd;
@@ -31,17 +33,18 @@ import org.operaton.commons.utils.CollectionUtil;
 /**
  * @author Askar Akhmerov
  */
+@NullMarked
 public class SetJobsRetriesByProcessBatchCmd extends AbstractSetJobsRetriesBatchCmd {
 
   protected final List<String> processInstanceIds;
   protected final ProcessInstanceQuery query;
-  protected HistoricProcessInstanceQuery historicProcessInstanceQuery;
+  protected final @Nullable HistoricProcessInstanceQuery historicProcessInstanceQuery;
 
   public SetJobsRetriesByProcessBatchCmd(List<String> processInstanceIds,
                                          ProcessInstanceQuery query,
-                                         HistoricProcessInstanceQuery historicProcessInstanceQuery,
+                                         @Nullable HistoricProcessInstanceQuery historicProcessInstanceQuery,
                                          int retries,
-                                         Date dueDate,
+                                         @Nullable Date dueDate,
                                          boolean isDueDateSet) {
     this.processInstanceIds = processInstanceIds;
     this.query = query;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskServiceImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.TaskService;
@@ -472,7 +473,7 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
   }
 
   @Override
-  public void deleteTaskAttachment(String taskId, String attachmentId) {
+  public void deleteTaskAttachment(@Nullable String taskId, String attachmentId) {
     commandExecutor.execute(new DeleteAttachmentCmd(taskId, attachmentId));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CommandChecker.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CommandChecker.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cfg;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.history.HistoricCaseInstance;
@@ -44,6 +46,7 @@ import org.operaton.bpm.engine.runtime.CaseExecution;
  * allowed on the entity. If it is not allowed, the checker throws a
  * {@link ProcessEngineException}.
  */
+@NullMarked
 public interface CommandChecker {
 
   /**
@@ -294,7 +297,7 @@ public interface CommandChecker {
   /**
    * Checks if it is allowed to delete the given historic task instance.
    */
-  void checkDeleteHistoricTaskInstance(HistoricTaskInstanceEntity task);
+  void checkDeleteHistoricTaskInstance(@Nullable HistoricTaskInstanceEntity task);
 
   /**
    * Checks if it is allowed to delete the given historic process instance.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CommandChecker.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CommandChecker.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.cfg;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.history.HistoricCaseInstance;
@@ -297,7 +296,7 @@ public interface CommandChecker {
   /**
    * Checks if it is allowed to delete the given historic task instance.
    */
-  void checkDeleteHistoricTaskInstance(@Nullable HistoricTaskInstanceEntity task);
+  void checkDeleteHistoricTaskInstance(HistoricTaskInstanceEntity task);
 
   /**
    * Checks if it is allowed to delete the given historic process instance.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cfg.auth;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.authorization.Permission;
@@ -38,6 +39,7 @@ import org.operaton.bpm.engine.impl.db.PermissionCheckBuilder;
 import org.operaton.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionEntity;
 import org.operaton.bpm.engine.impl.dmn.entity.repository.DecisionRequirementsDefinitionEntity;
 import org.operaton.bpm.engine.impl.history.event.HistoricExternalTaskLogEntity;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.AuthorizationManager;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricJobLogEventEntity;
@@ -52,6 +54,7 @@ import org.operaton.bpm.engine.repository.DecisionDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.*;
 import static org.operaton.bpm.engine.authorization.Resources.BATCH;
@@ -66,7 +69,7 @@ import static org.operaton.bpm.engine.authorization.Resources.TASK;
  * {@link CommandChecker} that uses the {@link AuthorizationManager} to perform
  * authorization checks.
  */
-public class AuthorizationCommandChecker implements CommandChecker {
+public @NullMarked class AuthorizationCommandChecker implements CommandChecker {
 
   @Override
   public void checkEvaluateDecision(DecisionDefinition decisionDefinition) {
@@ -599,7 +602,7 @@ public class AuthorizationCommandChecker implements CommandChecker {
   // delete permission ////////////////////////////////////////
 
   @Override
-  public void checkDeleteHistoricTaskInstance(HistoricTaskInstanceEntity task) {
+  public void checkDeleteHistoricTaskInstance(@Nullable HistoricTaskInstanceEntity task) {
     // deleting unexisting historic task instance should be silently ignored
     // see javaDoc HistoryService.deleteHistoricTaskInstance
     if (task != null && task.getProcessDefinitionKey() != null) {
@@ -667,12 +670,13 @@ public class AuthorizationCommandChecker implements CommandChecker {
     if (executionId != null) {
 
       // Permissions to task actions is based on the order in which PermissioncheckBuilder is built
+      ProcessDefinitionEntity processDefinition = requireNonNull(task.getProcessDefinition());
       CompositePermissionCheck taskWorkPermission = new PermissionCheckBuilder()
         .disjunctive()
           .atomicCheckForResourceId(TASK, taskId, TASK_ASSIGN)
-          .atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinition().getKey(), TASK_ASSIGN)
+          .atomicCheckForResourceId(PROCESS_DEFINITION, processDefinition.getKey(), TASK_ASSIGN)
           .atomicCheckForResourceId(TASK, taskId, UPDATE)
-          .atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinition().getKey(), UPDATE_TASK)
+          .atomicCheckForResourceId(PROCESS_DEFINITION, processDefinition.getKey(), UPDATE_TASK)
         .build();
 
       getAuthorizationManager().checkAuthorization(taskWorkPermission);
@@ -725,12 +729,13 @@ public class AuthorizationCommandChecker implements CommandChecker {
     if (executionId != null) {
 
       // Permissions to task actions is based on the order in which PermissioncheckBuilder is built
+      ProcessDefinitionEntity processDefinition = requireNonNull(task.getProcessDefinition());
       CompositePermissionCheck taskWorkPermission = new PermissionCheckBuilder()
           .disjunctive()
           .atomicCheckForResourceId(TASK, taskId, TASK_WORK)
-          .atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinition().getKey(), TASK_WORK)
+          .atomicCheckForResourceId(PROCESS_DEFINITION, processDefinition.getKey(), TASK_WORK)
           .atomicCheckForResourceId(TASK, taskId, UPDATE)
-          .atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinition().getKey(), UPDATE_TASK)
+          .atomicCheckForResourceId(PROCESS_DEFINITION, processDefinition.getKey(), UPDATE_TASK)
         .build();
 
       getAuthorizationManager().checkAuthorization(taskWorkPermission);
@@ -850,7 +855,7 @@ public class AuthorizationCommandChecker implements CommandChecker {
   }
 
   @Override
-  public void checkDeleteHistoricVariableInstance(HistoricVariableInstanceEntity variable) {
+  public void checkDeleteHistoricVariableInstance(@Nullable HistoricVariableInstanceEntity variable) {
     if (variable != null && variable.getProcessDefinitionKey() != null) {
       getAuthorizationManager().checkAuthorization(DELETE_HISTORY, PROCESS_DEFINITION, variable.getProcessDefinitionKey());
     }
@@ -950,19 +955,23 @@ public class AuthorizationCommandChecker implements CommandChecker {
   // helper ////////////////////////////////////////
 
   protected AuthorizationManager getAuthorizationManager() {
-    return Context.getCommandContext().getAuthorizationManager();
+    CommandContext commandContext = requireNonNull(Context.getCommandContext());
+    return commandContext.getAuthorizationManager();
   }
 
-  protected ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
-    return Context.getCommandContext().getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
+  protected @Nullable ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
+    CommandContext commandContext = requireNonNull(Context.getCommandContext());
+    return commandContext.getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
   }
 
-  protected DecisionDefinitionEntity findLatestDecisionDefinitionById(String decisionDefinitionId) {
-    return Context.getCommandContext().getDecisionDefinitionManager().findDecisionDefinitionById(decisionDefinitionId);
+  protected @Nullable DecisionDefinitionEntity findLatestDecisionDefinitionById(String decisionDefinitionId) {
+    CommandContext commandContext = requireNonNull(Context.getCommandContext());
+    return commandContext.getDecisionDefinitionManager().findDecisionDefinitionById(decisionDefinitionId);
   }
 
-  protected ExecutionEntity findExecutionById(String processInstanceId) {
-    return Context.getCommandContext().getExecutionManager().findExecutionById(processInstanceId);
+  protected @Nullable ExecutionEntity findExecutionById(String processInstanceId) {
+    CommandContext commandContext = requireNonNull(Context.getCommandContext());
+    return commandContext.getExecutionManager().findExecutionById(processInstanceId);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/DefaultPermissionProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/DefaultPermissionProvider.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cfg.auth;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.authorization.Permission;
@@ -29,6 +30,7 @@ import org.operaton.bpm.engine.impl.util.ResourceTypeUtil;
  * @author Tobias Metzke
  *
  */
+@NullMarked
 public class DefaultPermissionProvider implements PermissionProvider {
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/PermissionProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/PermissionProvider.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cfg.auth;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Resource;
 
@@ -27,6 +29,7 @@ import org.operaton.bpm.engine.authorization.Resource;
  * @author Tobias Metzke
  *
  */
+@NullMarked
 public interface PermissionProvider {
 
   /**
@@ -43,5 +46,5 @@ public interface PermissionProvider {
   /**
    * Gets the name of the resource with the resource type
    */
-  String getNameForResource(int resourceType);
+  @Nullable String getNameForResource(int resourceType);
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
@@ -615,23 +615,23 @@ public @NullMarked class TenantCommandChecker implements CommandChecker {
   // helper //////////////////////////////////////////////////
 
   protected TenantManager getTenantManager() {
-    return Context.getRequiredCommandContext().getTenantManager();
+    return Context.getCommandContext().getTenantManager();
   }
 
   protected @Nullable ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
-    return Context.getRequiredCommandContext().getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
+    return Context.getCommandContext().getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
   }
 
   protected @Nullable DecisionDefinitionEntity findLatestDecisionDefinitionById(String decisionDefinitionId) {
-    return Context.getRequiredCommandContext().getDecisionDefinitionManager().findDecisionDefinitionById(decisionDefinitionId);
+    return Context.getCommandContext().getDecisionDefinitionManager().findDecisionDefinitionById(decisionDefinitionId);
   }
 
   protected @Nullable ExecutionEntity findExecutionById(String processInstanceId) {
-    return Context.getRequiredCommandContext().getExecutionManager().findExecutionById(processInstanceId);
+    return Context.getCommandContext().getExecutionManager().findExecutionById(processInstanceId);
   }
 
   protected @Nullable DeploymentEntity findDeploymentById(String deploymentId) {
-    return Context.getRequiredCommandContext().getDeploymentManager().findDeploymentById(deploymentId);
+    return Context.getCommandContext().getDeploymentManager().findDeploymentById(deploymentId);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cfg.multitenancy;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.history.HistoricCaseInstance;
 import org.operaton.bpm.engine.history.HistoricDecisionInstance;
@@ -49,7 +51,7 @@ import org.operaton.bpm.engine.runtime.CaseExecution;
  * {@link CommandChecker} to ensure that commands are only executed for
  * entities which belongs to one of the authenticated tenants.
  */
-public class TenantCommandChecker implements CommandChecker {
+public @NullMarked class TenantCommandChecker implements CommandChecker {
 
   protected static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
@@ -143,7 +145,7 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkUpdateProcessInstance(ExecutionEntity execution) {
-    if (execution != null && !getTenantManager().isAuthenticatedTenant(execution.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(execution.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("update the process instance '%s'".formatted(execution.getId()));
     }
   }
@@ -155,7 +157,7 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkUpdateJob(JobEntity job) {
-    if (job != null && !getTenantManager().isAuthenticatedTenant(job.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(job.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("update the job '%s'".formatted(job.getId()));
     }
   }
@@ -220,14 +222,14 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkReadJob(JobEntity job) {
-    if (job != null && !getTenantManager().isAuthenticatedTenant(job.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(job.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("read the job '%s'".formatted(job.getId()));
     }
   }
 
   @Override
   public void checkReadProcessInstance(ExecutionEntity execution) {
-    if (execution != null && !getTenantManager().isAuthenticatedTenant(execution.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(execution.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("read the process instance '%s'".formatted(execution.getId()));
     }
   }
@@ -239,7 +241,7 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkDeleteProcessInstance(ExecutionEntity execution) {
-    if (execution != null && !getTenantManager().isAuthenticatedTenant(execution.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(execution.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the process instance '%s'".formatted(execution.getId()));
     }
   }
@@ -261,7 +263,7 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkReadTask(TaskEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("read the task '%s'".formatted(task.getId()));
     }
   }
@@ -273,7 +275,7 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkUpdateTaskVariable(TaskEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("update the task '%s'".formatted(task.getId()));
     }
   }
@@ -285,28 +287,28 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkDeleteBatch(BatchEntity batch) {
-    if (batch != null && !getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete batch '%s'".formatted(batch.getId()));
     }
   }
 
   @Override
   public void checkDeleteHistoricBatch(HistoricBatchEntity batch) {
-    if (batch != null && !getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete historic batch '%s'".formatted(batch.getId()));
     }
   }
 
   @Override
   public void checkSuspendBatch(BatchEntity batch) {
-    if (batch != null && !getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("suspend batch '%s'".formatted(batch.getId()));
     }
   }
 
   @Override
   public void checkActivateBatch(BatchEntity batch) {
-    if (batch != null && !getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(batch.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("activate batch '%s'".formatted(batch.getId()));
     }
   }
@@ -343,21 +345,21 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkDeleteTask(TaskEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the task '%s'".formatted(task.getId()));
     }
   }
 
   @Override
   public void checkTaskAssign(TaskEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("assign the task '%s'".formatted(task.getId()));
     }
   }
 
   @Override
   public void checkCreateTask(TaskEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("create the task '%s'".formatted(task.getId()));
     }
   }
@@ -369,14 +371,14 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkTaskWork(TaskEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("work on task '%s'".formatted(task.getId()));
     }
   }
 
   @Override
   public void checkReadDecisionDefinition(DecisionDefinitionEntity decisionDefinition) {
-    if (decisionDefinition != null && !getTenantManager().isAuthenticatedTenant(decisionDefinition.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(decisionDefinition.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("get the decision definition '%s'".formatted(decisionDefinition.getId()));
     }
   }
@@ -393,42 +395,42 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkReadDecisionRequirementsDefinition(DecisionRequirementsDefinitionEntity decisionRequirementsDefinition) {
-    if (decisionRequirementsDefinition != null && !getTenantManager().isAuthenticatedTenant(decisionRequirementsDefinition.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(decisionRequirementsDefinition.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("get the decision requirements definition '%s'".formatted(decisionRequirementsDefinition.getId()));
     }
   }
 
   @Override
   public void checkReadCaseDefinition(CaseDefinition caseDefinition) {
-    if (caseDefinition != null && !getTenantManager().isAuthenticatedTenant(caseDefinition.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(caseDefinition.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("get the case definition '%s'".formatted(caseDefinition.getId()));
     }
   }
 
   @Override
   public void checkUpdateCaseDefinition(CaseDefinition caseDefinition) {
-    if (caseDefinition != null && !getTenantManager().isAuthenticatedTenant(caseDefinition.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(caseDefinition.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("update the case definition '%s'".formatted(caseDefinition.getId()));
     }
   }
 
   @Override
   public void checkDeleteHistoricTaskInstance(HistoricTaskInstanceEntity task) {
-    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic task instance '%s'".formatted(task.getId()));
     }
   }
 
   @Override
   public void checkDeleteHistoricProcessInstance(HistoricProcessInstance instance) {
-    if (instance != null && !getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic process instance '%s'".formatted(instance.getId()));
     }
   }
 
   @Override
   public void checkDeleteHistoricCaseInstance(HistoricCaseInstance instance) {
-    if (instance != null && !getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic case instance '%s'".formatted(instance.getId()));
     }
   }
@@ -446,7 +448,7 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkDeleteHistoricDecisionInstance(HistoricDecisionInstance decisionInstance) {
-    if (decisionInstance != null && !getTenantManager().isAuthenticatedTenant(decisionInstance.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(decisionInstance.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant(
           "delete the historic decision instance '%s'".formatted(decisionInstance.getId())
       );
@@ -455,21 +457,21 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkDeleteHistoricVariableInstance(HistoricVariableInstanceEntity variable) {
-    if (variable != null && !getTenantManager().isAuthenticatedTenant(variable.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(variable.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic variable instance '%s'".formatted(variable.getId()));
     }
   }
 
   @Override
   public void checkDeleteHistoricVariableInstancesByProcessInstance(HistoricProcessInstanceEntity instance) {
-    if (instance != null && !getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic variable instances of process instance '%s'".formatted(instance.getId()));
     }
   }
 
   @Override
   public void checkReadHistoricJobLog(HistoricJobLogEventEntity historicJobLog) {
-    if (historicJobLog != null && !getTenantManager().isAuthenticatedTenant(historicJobLog.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(historicJobLog.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("get the historic job log '%s'".formatted(historicJobLog.getId()));
     }
   }
@@ -492,35 +494,35 @@ public class TenantCommandChecker implements CommandChecker {
 
   @Override
   public void checkUpdateCaseInstance(CaseExecution caseExecution) {
-    if (caseExecution != null && !getTenantManager().isAuthenticatedTenant(caseExecution.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(caseExecution.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("update the case execution '%s'".formatted(caseExecution.getId()));
     }
   }
 
   @Override
   public void checkReadCaseInstance(CaseExecution caseExecution) {
-    if (caseExecution != null && !getTenantManager().isAuthenticatedTenant(caseExecution.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(caseExecution.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("get the case execution '%s'".formatted(caseExecution.getId()));
     }
   }
 
   @Override
   public void checkDeleteUserOperationLog(UserOperationLogEntry entry) {
-    if (entry != null && !getTenantManager().isAuthenticatedTenant(entry.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(entry.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the user operation log entry '%s'".formatted(entry.getId()));
     }
   }
 
   @Override
   public void checkUpdateUserOperationLog(UserOperationLogEntry entry) {
-    if (entry != null && !getTenantManager().isAuthenticatedTenant(entry.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(entry.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("update the user operation log entry '%s'".formatted(entry.getId()));
     }
   }
 
   @Override
   public void checkReadHistoricExternalTaskLog(HistoricExternalTaskLogEntity historicExternalTaskLog) {
-    if (historicExternalTaskLog != null && !getTenantManager().isAuthenticatedTenant(historicExternalTaskLog.getTenantId())) {
+    if (!getTenantManager().isAuthenticatedTenant(historicExternalTaskLog.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("get the historic external task log '%s'".formatted(historicExternalTaskLog.getId()));
     }
   }
@@ -613,23 +615,23 @@ public class TenantCommandChecker implements CommandChecker {
   // helper //////////////////////////////////////////////////
 
   protected TenantManager getTenantManager() {
-    return Context.getCommandContext().getTenantManager();
+    return Context.getRequiredCommandContext().getTenantManager();
   }
 
-  protected ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
-    return Context.getCommandContext().getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
+  protected @Nullable ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
+    return Context.getRequiredCommandContext().getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
   }
 
-  protected DecisionDefinitionEntity findLatestDecisionDefinitionById(String decisionDefinitionId) {
-    return Context.getCommandContext().getDecisionDefinitionManager().findDecisionDefinitionById(decisionDefinitionId);
+  protected @Nullable DecisionDefinitionEntity findLatestDecisionDefinitionById(String decisionDefinitionId) {
+    return Context.getRequiredCommandContext().getDecisionDefinitionManager().findDecisionDefinitionById(decisionDefinitionId);
   }
 
-  protected ExecutionEntity findExecutionById(String processInstanceId) {
-    return Context.getCommandContext().getExecutionManager().findExecutionById(processInstanceId);
+  protected @Nullable ExecutionEntity findExecutionById(String processInstanceId) {
+    return Context.getRequiredCommandContext().getExecutionManager().findExecutionById(processInstanceId);
   }
 
-  protected DeploymentEntity findDeploymentById(String deploymentId) {
-    return Context.getCommandContext().getDeploymentManager().findDeploymentById(deploymentId);
+  protected @Nullable DeploymentEntity findDeploymentById(String deploymentId) {
+    return Context.getRequiredCommandContext().getDeploymentManager().findDeploymentById(deploymentId);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractAddIdentityLinkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractAddIdentityLinkCmd.java
@@ -17,6 +17,8 @@
 
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -27,13 +29,13 @@ import org.operaton.bpm.engine.task.IdentityLinkType;
  * Abstract class that modifies {@link AbstractSetTaskPropertyCmd} to customize validation & logging for
  * Add Identity Link related Commands.
  */
-public abstract class AbstractAddIdentityLinkCmd extends AbstractSetTaskPropertyCmd<Integer> {
+public abstract @NullMarked class AbstractAddIdentityLinkCmd extends AbstractSetTaskPropertyCmd<Integer> {
 
-  protected final String userId;
-  protected final String groupId;
+  protected final @Nullable String userId;
+  protected final @Nullable String groupId;
   protected final String type;
 
-  protected AbstractAddIdentityLinkCmd(String taskId, String userId, String groupId, String type) {
+  protected AbstractAddIdentityLinkCmd(String taskId, @Nullable String userId, @Nullable String groupId, String type) {
     super(taskId, null, true);
     validateParameters(type, userId, groupId);
 
@@ -43,7 +45,7 @@ public abstract class AbstractAddIdentityLinkCmd extends AbstractSetTaskProperty
   }
 
   @Override
-  protected void executeSetOperation(TaskEntity task, Integer value) {
+  protected void executeSetOperation(TaskEntity task, @Nullable Integer value) {
 
     if (isAssignee(type)) {
       task.setAssignee(userId);
@@ -68,11 +70,11 @@ public abstract class AbstractAddIdentityLinkCmd extends AbstractSetTaskProperty
   protected abstract void logOperation(CommandContext context, TaskEntity task);
 
   @Override
-  protected String getUserOperationLogName() {
+  protected @Nullable String getUserOperationLogName() {
     return null; // Ignored for identity commands
   }
 
-  protected void validateParameters(String type, String userId, String groupId) {
+  protected void validateParameters(String type, @Nullable String userId, @Nullable String groupId) {
 
     if (isAssignee(type) && groupId != null) {
       throw new BadUserRequestException("Incompatible usage: cannot use ASSIGNEE together with a groupId");
@@ -83,7 +85,7 @@ public abstract class AbstractAddIdentityLinkCmd extends AbstractSetTaskProperty
     }
   }
 
-  protected boolean hasNullIdentity(String userId, String groupId) {
+  protected boolean hasNullIdentity(@Nullable String userId, @Nullable String groupId) {
     return (userId == null) && (groupId == null);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractCorrelateMessageCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractCorrelateMessageCmd.java
@@ -31,6 +31,8 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Thorben Lindhauer
  * @author Daniel Meyer
@@ -97,7 +99,7 @@ public abstract class AbstractCorrelateMessageCmd {
   }
 
   protected void checkAuthorization(CorrelationHandlerResult correlation) {
-    CommandContext commandContext = Context.getCommandContext();
+    CommandContext commandContext = requireNonNull(Context.getCommandContext());
 
     for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
       if (MessageCorrelationResultType.Execution.equals(correlation.getResultType())) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractDeleteProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractDeleteProcessDefinitionCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -33,6 +34,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tassilo Weidner
  */
+@NullMarked
 public abstract class AbstractDeleteProcessDefinitionCmd implements Command<Void> {
 
   protected boolean cascade;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractDeleteProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractDeleteProcessInstanceCmd.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.exception.NotFoundException;
@@ -47,10 +49,11 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * Provide common logic for process instance deletion operations.
  * Permissions checking and single process instance removal included.
  */
+@NullMarked
 public abstract class AbstractDeleteProcessInstanceCmd {
 
   protected boolean externallyTerminated;
-  protected String deleteReason;
+  protected @Nullable String deleteReason;
   protected boolean skipCustomListeners;
   protected boolean skipSubprocesses;
   protected boolean failIfNotExists = true;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractDeleteProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractDeleteProcessInstanceCmd.java
@@ -41,6 +41,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionManager;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -82,6 +83,7 @@ public abstract class AbstractDeleteProcessInstanceCmd {
 
     ensureNotNull(NotFoundException.class, "No process instance found for id '%s'".formatted(processInstanceId),
         "processInstance", execution);
+    requireNonNull(execution);
 
     checkDeleteProcessInstance(execution, commandContext);
 
@@ -117,9 +119,6 @@ public abstract class AbstractDeleteProcessInstanceCmd {
 
   public void triggerHistoryEvent(List<ProcessInstance> subProcesslist) {
     ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
-    if(configuration == null) {
-      return;
-    }
 
     HistoryLevel historyLevel = configuration.getHistoryLevel();
     for (final ProcessInstance processInstance : subProcesslist) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractExecuteFilterCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractExecuteFilterCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.impl.AbstractQuery;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -28,15 +30,16 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Sebastian Menski
  */
+@NullMarked
 public abstract class AbstractExecuteFilterCmd {
   protected String filterId;
-  protected Query<?, ?> extendingQuery;
+  protected @Nullable Query<?, ?> extendingQuery;
 
   protected AbstractExecuteFilterCmd(String filterId) {
     this.filterId = filterId;
   }
 
-  protected AbstractExecuteFilterCmd(String filterId, Query<?, ?> extendingQuery) {
+  protected AbstractExecuteFilterCmd(String filterId, @Nullable Query<?, ?> extendingQuery) {
     this.filterId = filterId;
     this.extendingQuery = extendingQuery;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
@@ -18,6 +18,9 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.exception.DeploymentResourceNotFoundException;
 import org.operaton.bpm.engine.exception.NotFoundException;
@@ -25,14 +28,17 @@ import org.operaton.bpm.engine.form.FormData;
 import org.operaton.bpm.engine.form.OperatonFormRef;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.repository.OperatonFormDefinition;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  *
  * @author Anna Pazola
  *
  */
-public abstract class AbstractGetDeployedFormCmd implements Command<InputStream> {
+public abstract @NullMarked class AbstractGetDeployedFormCmd implements Command<InputStream> {
 
   protected static final String EMBEDDED_KEY = "embedded:";
   protected static final String OPERATON_FORMS_KEY = "operaton-forms:";
@@ -44,14 +50,14 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
   protected static final String DEPLOYMENT_KEY = "deployment:";
   protected static final int DEPLOYMENT_KEY_LENGTH = DEPLOYMENT_KEY.length();
 
-  protected CommandContext commandContext;
+  private @Nullable CommandContext commandContext;
 
   @Override
-  public InputStream execute(final CommandContext commandContext) {
+  public @Nullable InputStream execute(final CommandContext commandContext) {
     this.commandContext = commandContext;
     checkAuthorization();
 
-    final FormData formData = getFormData();
+    final FormData formData = requireNonNull(getFormData());
     String formKey = formData.getFormKey();
     OperatonFormRef operatonFormRef = formData.getOperatonFormRef();
 
@@ -64,7 +70,11 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
     }
   }
 
-  protected InputStream getResourceForFormKey(FormData formData, String formKey) {
+  protected final CommandContext getCommandContext() {
+    return EnsureUtil.ensureActiveCommandContext(commandContext);
+  }
+
+  protected @Nullable InputStream getResourceForFormKey(FormData formData, String formKey) {
     String resourceName = formKey;
 
     if (resourceName.startsWith(EMBEDDED_KEY)) {
@@ -84,9 +94,9 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
     return getDeploymentResource(formData.getDeploymentId(), resourceName);
   }
 
-  protected InputStream getResourceForOperatonFormRef(OperatonFormRef operatonFormRef,
+  protected @Nullable InputStream getResourceForOperatonFormRef(OperatonFormRef operatonFormRef,
       String deploymentId) {
-    OperatonFormDefinition definition = commandContext.runWithoutAuthorization(
+    OperatonFormDefinition definition = getCommandContext().runWithoutAuthorization(
         new GetOperatonFormDefinitionCmd(operatonFormRef, deploymentId));
 
     if (definition == null) {
@@ -96,16 +106,16 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
     return getDeploymentResource(definition.getDeploymentId(), definition.getResourceName());
   }
 
-  protected InputStream getDeploymentResource(String deploymentId, String resourceName) {
+  protected @Nullable InputStream getDeploymentResource(String deploymentId, String resourceName) {
     GetDeploymentResourceCmd getDeploymentResourceCmd = new GetDeploymentResourceCmd(deploymentId, resourceName);
     try {
-      return commandContext.runWithoutAuthorization(getDeploymentResourceCmd);
+      return getCommandContext().runWithoutAuthorization(getDeploymentResourceCmd);
     } catch (DeploymentResourceNotFoundException e) {
       throw new NotFoundException("The form with the resource name '%s' cannot be found in deployment with id %s".formatted(resourceName, deploymentId), e);
     }
   }
 
-  protected abstract FormData getFormData();
+  protected abstract @Nullable FormData getFormData();
 
   protected abstract void checkAuthorization();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetFormVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetFormVariablesCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.form.FormField;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -39,7 +41,7 @@ public abstract class AbstractGetFormVariablesCmd implements Command<VariableMap
   }
 
   @SuppressWarnings("unused")
-  protected TypedValue createVariable(FormField formField, VariableScope variableScope) {
+  protected @Nullable TypedValue createVariable(FormField formField, VariableScope variableScope) {
     TypedValue value = formField.getValue();
 
     if(value != null) {
@@ -48,7 +50,5 @@ public abstract class AbstractGetFormVariablesCmd implements Command<VariableMap
     else {
       return null;
     }
-
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetFormVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetFormVariablesCmd.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.form.FormField;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstanceCancellationCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,13 +27,14 @@ import org.operaton.bpm.engine.impl.util.ModificationUtil;
  * @author Thorben Lindhauer
  *
  */
+@NullMarked
 public abstract class AbstractInstanceCancellationCmd extends AbstractProcessInstanceModificationCommand {
 
   protected String cancellationReason;
 
   protected AbstractInstanceCancellationCmd(String processInstanceId) {
     super(processInstanceId);
-    this.cancellationReason = "Cancellation due to process instance modifcation";
+    this.cancellationReason = "Cancellation due to process instance modification";
   }
 
   protected AbstractInstanceCancellationCmd(String processInstanceId, String cancellationReason) {
@@ -73,9 +75,9 @@ public abstract class AbstractInstanceCancellationCmd extends AbstractProcessIns
     return null;
   }
 
-  protected abstract ExecutionEntity determineSourceInstanceExecution(CommandContext commandContext);
+  protected abstract @Nullable ExecutionEntity determineSourceInstanceExecution(CommandContext commandContext);
 
-  protected ExecutionEntity findSuperExecution(ExecutionEntity parentScopeExecution, ExecutionEntity topmostCancellableExecution){
+  protected @Nullable ExecutionEntity findSuperExecution(@Nullable ExecutionEntity parentScopeExecution, ExecutionEntity topmostCancellableExecution){
     ExecutionEntity superExecution = null;
     if(parentScopeExecution == null) {
       superExecution = topmostCancellableExecution.getSuperExecution();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
@@ -59,9 +59,9 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
 
   protected VariableMap variables;
   protected VariableMap variablesLocal;
-  protected String ancestorActivityInstanceId;
+  protected @Nullable String ancestorActivityInstanceId;
 
-  protected AbstractInstantiationCmd(String processInstanceId, String ancestorActivityInstanceId) {
+  protected AbstractInstantiationCmd(@Nullable String processInstanceId, @Nullable String ancestorActivityInstanceId) {
     super(processInstanceId);
     this.ancestorActivityInstanceId = ancestorActivityInstanceId;
     this.variables = new VariableMapImpl();
@@ -92,7 +92,7 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
     return variablesLocal;
   }
 
-  public String getAncestorActivityInstanceId() {
+  public @Nullable String getAncestorActivityInstanceId() {
     return ancestorActivityInstanceId;
   }
 
@@ -110,6 +110,7 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
     EnsureUtil.ensureNotNull(NotValidException.class, describeFailure(
         "Element '%s' does not exist in process '%s'".formatted(getTargetElementId(), processDefinition.getId())),
       "element", elementToInstantiate);
+    requireNonNull(elementToInstantiate);
     // rebuild the mapping because the execution tree changes with every iteration
     final ActivityExecutionTreeMapping mapping = new ActivityExecutionTreeMapping(commandContext, processInstanceId);
 
@@ -194,6 +195,7 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
     EnsureUtil.ensureNotNull(NotValidException.class,
         describeFailure("Ancestor activity instance '%s' does not exist".formatted(ancestorActivityInstanceId)),
         "ancestorInstance", ancestorInstance);
+    requireNonNull(ancestorInstance);
 
     // determine ancestor activity scope execution and activity
     final ExecutionEntity ancestorScopeExecution = getScopeExecutionForActivityInstance(processInstance, mapping,
@@ -226,9 +228,9 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
   }
 
   private @Nullable ScopeImpl determineFlowScope(List<PvmActivity> activitiesToInstantiate, CoreModelElement elementToInstantiate,
-      ActivityImpl topMostActivity) {
+      @Nullable ActivityImpl topMostActivity) {
     if (!activitiesToInstantiate.isEmpty() || ActivityImpl.class.isAssignableFrom(elementToInstantiate.getClass())) {
-      return topMostActivity.getFlowScope();
+      return topMostActivity != null ? topMostActivity.getFlowScope() : null;
     } else if (TransitionImpl.class.isAssignableFrom(elementToInstantiate.getClass())) {
       TransitionImpl transitionToInstantiate = (TransitionImpl) elementToInstantiate;
       return transitionToInstantiate.getSource().getFlowScope();
@@ -245,7 +247,7 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
   }
 
   private ActivityStartBehavior determineStartBehavior(CoreModelElement elementToInstantiate,
-      List<PvmActivity> activitiesToInstantiate, ActivityImpl topMostActivity) {
+      List<PvmActivity> activitiesToInstantiate, @Nullable ActivityImpl topMostActivity) {
     ActivityStartBehavior startBehavior = ActivityStartBehavior.CONCURRENT_IN_FLOW_SCOPE;
     if (topMostActivity != null) {
       startBehavior = topMostActivity.getActivityStartBehavior();
@@ -272,7 +274,7 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
   }
 
   private void executeInstantiation(CoreModelElement elementToInstantiate, final ActivityExecutionTreeMapping mapping,
-      ExecutionEntity scopeExecution, List<PvmActivity> activitiesToInstantiate, ActivityImpl topMostActivity,
+      ExecutionEntity scopeExecution, List<PvmActivity> activitiesToInstantiate, @Nullable ActivityImpl topMostActivity,
       ActivityStartBehavior startBehavior) {
     switch (startBehavior) {
     case CANCEL_EVENT_SCOPE: {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 
 import org.jspecify.annotations.Nullable;
@@ -32,6 +33,7 @@ import org.operaton.bpm.engine.impl.core.delegate.CoreActivityBehavior;
 import org.operaton.bpm.engine.impl.core.model.CoreModelElement;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.operaton.bpm.engine.impl.persistence.entity.ExecutionManager;
 import org.operaton.bpm.engine.impl.pvm.PvmActivity;
 import org.operaton.bpm.engine.impl.pvm.PvmScope;
 import org.operaton.bpm.engine.impl.pvm.PvmTransition;
@@ -47,11 +49,13 @@ import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Thorben Lindhauer
  *
  */
-public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceModificationCommand {
+public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProcessInstanceModificationCommand {
 
   protected VariableMap variables;
   protected VariableMap variablesLocal;
@@ -98,7 +102,8 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
 
   @Override
   public @Nullable Void execute(final CommandContext commandContext) {
-    ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
+    ExecutionManager executionManager = commandContext.getExecutionManager();
+    ExecutionEntity processInstance = requireNonNull(executionManager.findExecutionById(processInstanceId));
     final ProcessDefinitionImpl processDefinition = processInstance.getProcessDefinition();
 
     CoreModelElement elementToInstantiate = getTargetElement(processDefinition);
@@ -183,7 +188,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
   private ExecutionEntity determineScopeExecutionWithAncestorActivity(final CommandContext commandContext,
       ExecutionEntity processInstance, final ProcessDefinitionImpl processDefinition,
       CoreModelElement elementToInstantiate, final ActivityExecutionTreeMapping mapping, FlowScopeWalker walker) {
-    ActivityInstance tree = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
+    ActivityInstance tree = requireNonNull(commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId)));
 
     ActivityInstance ancestorInstance = findActivityInstance(tree, ancestorActivityInstanceId);
     EnsureUtil.ensureNotNull(NotValidException.class,
@@ -209,7 +214,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
     return ancestorScopeExecution;
   }
 
-  private ActivityImpl determineTopMostActivity(List<PvmActivity> activitiesToInstantiate,
+  private @Nullable ActivityImpl determineTopMostActivity(List<PvmActivity> activitiesToInstantiate,
       CoreModelElement elementToInstantiate) {
     if (!activitiesToInstantiate.isEmpty()) {
       return (ActivityImpl) activitiesToInstantiate.get(0);
@@ -220,7 +225,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
     return null;
   }
 
-  private ScopeImpl determineFlowScope(List<PvmActivity> activitiesToInstantiate, CoreModelElement elementToInstantiate,
+  private @Nullable ScopeImpl determineFlowScope(List<PvmActivity> activitiesToInstantiate, CoreModelElement elementToInstantiate,
       ActivityImpl topMostActivity) {
     if (!activitiesToInstantiate.isEmpty() || ActivityImpl.class.isAssignableFrom(elementToInstantiate.getClass())) {
       return topMostActivity.getFlowScope();
@@ -328,7 +333,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
     return !(behavior instanceof SequentialMultiInstanceActivityBehavior);
   }
 
-  protected ExecutionEntity getSingleExecutionForScope(ActivityExecutionTreeMapping mapping, ScopeImpl scope) {
+  protected @Nullable ExecutionEntity getSingleExecutionForScope(ActivityExecutionTreeMapping mapping, ScopeImpl scope) {
     Set<ExecutionEntity> executions = mapping.getExecutions(scope);
 
     if (!executions.isEmpty()) {
@@ -377,7 +382,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
 
   protected abstract ScopeImpl getTargetFlowScope(ProcessDefinitionImpl processDefinition);
 
-  protected abstract CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition);
+  protected abstract @Nullable CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition);
 
   protected abstract String getTargetElementId();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
@@ -150,7 +150,9 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
     // the interruption and cancellation takes place before we instantiate the
     // activity stack
     ActivityImpl topMostActivity = determineTopMostActivity(activitiesToInstantiate, elementToInstantiate);
-    ScopeImpl flowScope = determineFlowScope(activitiesToInstantiate, elementToInstantiate, topMostActivity);
+    // the element to instantiate is always either an activity or a transition, hence a flow scope exists
+    ScopeImpl flowScope = requireNonNull(
+        determineFlowScope(activitiesToInstantiate, elementToInstantiate, topMostActivity), "flowScope");
 
     throwIfNoConcurrentInstantiationPossible(flowScope);
 
@@ -191,6 +193,7 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
       CoreModelElement elementToInstantiate, final ActivityExecutionTreeMapping mapping, FlowScopeWalker walker) {
     ActivityInstance tree = requireNonNull(commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId)));
 
+    requireNonNull(ancestorActivityInstanceId);
     ActivityInstance ancestorInstance = findActivityInstance(tree, ancestorActivityInstanceId);
     EnsureUtil.ensureNotNull(NotValidException.class,
         describeFailure("Ancestor activity instance '%s' does not exist".formatted(ancestorActivityInstanceId)),
@@ -278,22 +281,26 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
       ActivityStartBehavior startBehavior) {
     switch (startBehavior) {
     case CANCEL_EVENT_SCOPE: {
-      ScopeImpl scopeToCancel = topMostActivity.getEventScope();
+      // a cancelling start behavior is only determined for a non-null top most activity
+      ActivityImpl activityToCancel = requireNonNull(topMostActivity, "topMostActivity");
+      ScopeImpl scopeToCancel = activityToCancel.getEventScope();
       ExecutionEntity executionToCancel = getSingleExecutionForScope(mapping, scopeToCancel);
       if (executionToCancel != null) {
-        executionToCancel.deleteCascade("Cancelling activity %s executed.".formatted(topMostActivity), skipCustomListeners,
+        executionToCancel.deleteCascade("Cancelling activity %s executed.".formatted(activityToCancel), skipCustomListeners,
             skipIoMappings);
-        instantiate(executionToCancel.getParent(), activitiesToInstantiate, elementToInstantiate);
+        instantiate(requireNonNull(executionToCancel.getParent()), activitiesToInstantiate, elementToInstantiate);
       } else {
-        ExecutionEntity flowScopeExecution = getSingleExecutionForScope(mapping, topMostActivity.getFlowScope());
-        instantiateConcurrent(flowScopeExecution, activitiesToInstantiate, elementToInstantiate);
+        ExecutionEntity flowScopeExecution = getSingleExecutionForScope(mapping, activityToCancel.getFlowScope());
+        instantiateConcurrent(requireNonNull(flowScopeExecution), activitiesToInstantiate, elementToInstantiate);
       }
       break;
     }
     case INTERRUPT_EVENT_SCOPE: {
-      ScopeImpl scopeToCancel = topMostActivity.getEventScope();
-      ExecutionEntity executionToCancel = getSingleExecutionForScope(mapping, scopeToCancel);
-      executionToCancel.interrupt("Interrupting activity %s executed.".formatted(topMostActivity), skipCustomListeners,
+      // an interrupting start behavior is only determined for a non-null top most activity
+      ActivityImpl activityToInterrupt = requireNonNull(topMostActivity, "topMostActivity");
+      ScopeImpl scopeToCancel = activityToInterrupt.getEventScope();
+      ExecutionEntity executionToCancel = requireNonNull(getSingleExecutionForScope(mapping, scopeToCancel), "execution to cancel");
+      executionToCancel.interrupt("Interrupting activity %s executed.".formatted(activityToInterrupt), skipCustomListeners,
           skipIoMappings, false);
       executionToCancel.setActivity(null);
       executionToCancel.leaveActivityInstance();
@@ -301,9 +308,11 @@ public abstract @NullMarked class AbstractInstantiationCmd extends AbstractProce
       break;
     }
     case INTERRUPT_FLOW_SCOPE: {
-      ScopeImpl scopeToCancel = topMostActivity.getFlowScope();
-      ExecutionEntity executionToCancel = getSingleExecutionForScope(mapping, scopeToCancel);
-      executionToCancel.interrupt("Interrupting activity %s executed.".formatted(topMostActivity), skipCustomListeners,
+      // an interrupting start behavior is only determined for a non-null top most activity
+      ActivityImpl activityToInterrupt = requireNonNull(topMostActivity, "topMostActivity");
+      ScopeImpl scopeToCancel = activityToInterrupt.getFlowScope();
+      ExecutionEntity executionToCancel = requireNonNull(getSingleExecutionForScope(mapping, scopeToCancel), "execution to cancel");
+      executionToCancel.interrupt("Interrupting activity %s executed.".formatted(activityToInterrupt), skipCustomListeners,
           skipIoMappings, false);
       executionToCancel.setActivity(null);
       executionToCancel.leaveActivityInstance();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractModificationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractModificationCmd.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.ModificationBuilderImpl;
@@ -32,6 +33,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 
+@NullMarked
 public abstract class AbstractModificationCmd <T> implements Command<T> {
 
   protected ModificationBuilderImpl builder;
@@ -41,7 +43,6 @@ public abstract class AbstractModificationCmd <T> implements Command<T> {
   }
 
   protected Collection<String> collectProcessInstanceIds() {
-
     Set<String> collectedProcessInstanceIds = new HashSet<>();
 
     List<String> processInstanceIds = builder.getProcessInstanceIds();
@@ -85,7 +86,6 @@ public abstract class AbstractModificationCmd <T> implements Command<T> {
   }
 
   protected ProcessDefinitionEntity getProcessDefinition(CommandContext commandContext, String processDefinitionId) {
-
     return commandContext
         .getProcessEngineConfiguration()
         .getDeploymentCache()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractPatchVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractPatchVariablesCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collection;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -28,6 +29,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Stefan Hentschel.
  */
+@NullMarked
 public abstract class AbstractPatchVariablesCmd implements Command<Void> {
   protected String entityId;
   protected Map<String, ? extends Object> variables;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractProcessInstanceModificationCommand.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractProcessInstanceModificationCommand.java
@@ -20,16 +20,20 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.ActivityExecutionTreeMapping;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.TransitionInstance;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -67,7 +71,7 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     return processInstanceId;
   }
 
-  protected ActivityInstance findActivityInstance(ActivityInstance tree, String activityInstanceId) {
+  protected @Nullable ActivityInstance findActivityInstance(@NonNull ActivityInstance tree, @NonNull String activityInstanceId) {
     if (activityInstanceId.equals(tree.getId())) {
       return tree;
     } else {
@@ -82,7 +86,7 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     return null;
   }
 
-  protected TransitionInstance findTransitionInstance(ActivityInstance tree, String transitionInstanceId) {
+  protected @Nullable TransitionInstance findTransitionInstance(@NonNull ActivityInstance tree, @Nullable String transitionInstanceId) {
     for (TransitionInstance childTransitionInstance : tree.getChildTransitionInstances()) {
       if (matchesRequestedTransitionInstance(childTransitionInstance, transitionInstanceId)) {
         return childTransitionInstance;
@@ -99,7 +103,7 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     return null;
   }
 
-  protected boolean matchesRequestedTransitionInstance(TransitionInstance instance, String queryInstanceId) {
+  protected boolean matchesRequestedTransitionInstance(@NonNull TransitionInstance instance, @Nullable String queryInstanceId) {
     boolean match = instance.getId().equals(queryInstanceId);
 
     // check if the execution queried for has been replaced by the given instance
@@ -107,7 +111,8 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     // this is a fix for CAM-4090 to tolerate inconsistent transition instance ids as described in CAM-4143
     if (!match) {
       // note: execution id = transition instance id
-      ExecutionEntity cachedExecution = Context.getCommandContext()
+      CommandContext commandContext = requireNonNull(Context.getCommandContext());
+      ExecutionEntity cachedExecution = commandContext
           .getDbEntityManager()
           .getCachedEntity(ExecutionEntity.class, queryInstanceId);
 
@@ -141,8 +146,8 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     return match;
   }
 
-  protected ScopeImpl getScopeForActivityInstance(ProcessDefinitionImpl processDefinition,
-      ActivityInstance activityInstance) {
+  protected ScopeImpl getScopeForActivityInstance(@NonNull ProcessDefinitionImpl processDefinition,
+      @NonNull ActivityInstance activityInstance) {
     String scopeId = activityInstance.getActivityId();
 
     if (processDefinition.getId().equals(scopeId)) {
@@ -153,8 +158,8 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     }
   }
 
-  protected ExecutionEntity getScopeExecutionForActivityInstance(ExecutionEntity processInstance,
-      ActivityExecutionTreeMapping mapping, ActivityInstance activityInstance) {
+  protected @NonNull ExecutionEntity getScopeExecutionForActivityInstance(@NonNull ExecutionEntity processInstance,
+      @NonNull ActivityExecutionTreeMapping mapping, @NonNull ActivityInstance activityInstance) {
     ensureNotNull("activityInstance", activityInstance);
 
     ProcessDefinitionImpl processDefinition = processInstance.getProcessDefinition();
@@ -164,7 +169,8 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     Set<String> activityInstanceExecutions = new HashSet<>(Arrays.asList(activityInstance.getExecutionIds()));
 
     for (String activityInstanceExecutionId : activityInstance.getExecutionIds()) {
-      ExecutionEntity execution = Context.getCommandContext()
+      CommandContext commandContext = requireNonNull(Context.getCommandContext());
+      ExecutionEntity execution = commandContext
           .getExecutionManager()
           .findExecutionById(activityInstanceExecutionId);
       if (execution.isConcurrent() && execution.hasChildren()) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractRemoveVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractRemoveVariableCmd.java
@@ -18,12 +18,14 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 
 /**
  * @author Stefan Hentschel.
  */
+@NullMarked
 public abstract class AbstractRemoveVariableCmd extends AbstractVariableCmd {
   protected final Collection<String> variableNames;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractRestartProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractRestartProcessInstanceCmd.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
@@ -34,6 +35,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 
+@NullMarked
 public abstract class AbstractRestartProcessInstanceCmd<T> implements Command<T> {
 
   protected CommandExecutor commandExecutor;
@@ -45,7 +47,6 @@ public abstract class AbstractRestartProcessInstanceCmd<T> implements Command<T>
   }
 
   protected Collection<String> collectProcessInstanceIds() {
-
     Set<String> collectedProcessInstanceIds = new HashSet<>();
 
     List<String> processInstanceIds = builder.getProcessInstanceIds();
@@ -82,7 +83,6 @@ public abstract class AbstractRestartProcessInstanceCmd<T> implements Command<T>
   }
 
   protected ProcessDefinitionEntity getProcessDefinition(CommandContext commandContext, String processDefinitionId) {
-
     return commandContext
         .getProcessEngineConfiguration()
         .getDeploymentCache()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetBatchStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetBatchStateCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.BadUserRequestException;
@@ -30,6 +31,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
+@NullMarked
 public abstract class AbstractSetBatchStateCmd implements Command<Void> {
 
   public static final String SUSPENSION_STATE_PROPERTY = "suspensionState";
@@ -87,7 +89,7 @@ public abstract class AbstractSetBatchStateCmd implements Command<Void> {
 
   protected abstract AbstractSetJobDefinitionStateCmd createSetJobDefinitionStateCommand(UpdateJobDefinitionSuspensionStateBuilderImpl builder);
 
-  protected void logUserOperation(CommandContext commandContext, String tenantId) {
+  protected void logUserOperation(CommandContext commandContext, @Nullable String tenantId) {
     PropertyChange propertyChange = new PropertyChange(SUSPENSION_STATE_PROPERTY, null, getNewSuspensionState().getName());
     commandContext.getOperationLogManager()
       .logBatchOperation(getUserOperationType(), batchId, tenantId, propertyChange);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetExternalTaskRetriesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetExternalTaskRetriesCmd.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.ExternalTaskQueryImpl;
@@ -34,6 +35,7 @@ import org.operaton.commons.utils.CollectionUtil;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotContainsNull;
 
+@NullMarked
 public abstract class AbstractSetExternalTaskRetriesCmd<T> implements Command<T> {
 
   protected UpdateExternalTaskRetriesBuilderImpl builder;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobDefinitionStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobDefinitionStateCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -30,6 +32,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.*;
  * @author Daniel Meyer
  * @author roman.smirnov
  */
+@NullMarked
 public abstract class AbstractSetJobDefinitionStateCmd extends AbstractSetStateCmd {
 
   protected String jobDefinitionId;
@@ -190,7 +193,7 @@ public abstract class AbstractSetJobDefinitionStateCmd extends AbstractSetStateC
   }
 
   @Override
-  protected String getDeploymentId(CommandContext commandContext) {
+  protected @Nullable String getDeploymentId(CommandContext commandContext) {
     if (jobDefinitionId != null) {
       return getDeploymentIdByJobDefinition(commandContext, jobDefinitionId);
     } else if (processDefinitionId != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobStateCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,6 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.*;
 /**
  * @author roman.smirnov
  */
+@NullMarked
 public abstract class AbstractSetJobStateCmd extends AbstractSetStateCmd {
 
   protected String jobId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobsRetriesBatchCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobsRetriesBatchCmd.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.authorization.BatchPermissions;
 import org.operaton.bpm.engine.batch.Batch;
@@ -37,10 +39,11 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
 /**
  * @author Askar Akhmerov
  */
+@NullMarked
 public abstract class AbstractSetJobsRetriesBatchCmd implements Command<Batch> {
 
   protected int retries;
-  protected Date dueDate;
+  protected @Nullable Date dueDate;
   protected boolean isDueDateSet;
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -38,6 +40,7 @@ import org.operaton.bpm.engine.management.JobDefinition;
  * @author Joram Barrez
  * @author roman.smirnov
  */
+@NullMarked
 public abstract class AbstractSetProcessDefinitionStateCmd extends AbstractSetStateCmd {
 
   public static final String INCLUDE_PROCESS_INSTANCES_PROPERTY = "includeProcessInstances";
@@ -203,7 +206,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd extends AbstractSetSt
   }
 
   @Override
-  protected String getDeploymentId(CommandContext commandContext) {
+  protected @Nullable String getDeploymentId(CommandContext commandContext) {
     if (processDefinitionId != null) {
       return getDeploymentIdByProcessDefinition(commandContext, processDefinitionId);
     } else if (processDefinitionKey != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetProcessInstanceStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetProcessInstanceStateCmd.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
@@ -42,14 +44,15 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
  * @author Joram Barrez
  * @author roman.smirnov
  */
+@NullMarked
 public abstract class AbstractSetProcessInstanceStateCmd extends AbstractSetStateCmd {
 
-  protected final String processInstanceId;
-  protected String processDefinitionId;
-  protected String processDefinitionKey;
+  protected final @Nullable String processInstanceId;
+  protected final @Nullable String processDefinitionId;
+  protected final @Nullable String processDefinitionKey;
 
-  protected String processDefinitionTenantId;
-  protected boolean isProcessDefinitionTenantIdSet;
+  protected final @Nullable String processDefinitionTenantId;
+  protected final boolean isProcessDefinitionTenantIdSet;
 
   protected AbstractSetProcessInstanceStateCmd(UpdateProcessInstanceSuspensionStateBuilderImpl builder) {
     super(true, null);
@@ -119,24 +122,22 @@ public abstract class AbstractSetProcessInstanceStateCmd extends AbstractSetStat
     HistoryLevel historyLevel = commandContext.getProcessEngineConfiguration().getHistoryLevel();
     List<ProcessInstance> updatedProcessInstances = obtainProcessInstances(commandContext);
     //suspension state is not updated synchronously
-    if (getNewSuspensionState() != null && updatedProcessInstances != null) {
-      for (final ProcessInstance processInstance: updatedProcessInstances) {
+    for (final ProcessInstance processInstance: updatedProcessInstances) {
 
-        if (historyLevel.isHistoryEventProduced(HistoryEventTypes.PROCESS_INSTANCE_UPDATE, processInstance)) {
-          HistoryEventProcessor.processHistoryEvents(new HistoryEventProcessor.HistoryEventCreator() {
-            @Override
-            public HistoryEvent createHistoryEvent(HistoryEventProducer producer) {
-              HistoricProcessInstanceEventEntity processInstanceUpdateEvt = (HistoricProcessInstanceEventEntity)
-                  producer.createProcessInstanceUpdateEvt((DelegateExecution) processInstance);
-              if (SuspensionState.SUSPENDED.getStateCode() == getNewSuspensionState().getStateCode()) {
-                processInstanceUpdateEvt.setState(HistoricProcessInstance.STATE_SUSPENDED);
-              } else {
-                processInstanceUpdateEvt.setState(HistoricProcessInstance.STATE_ACTIVE);
-              }
-              return processInstanceUpdateEvt;
+      if (historyLevel.isHistoryEventProduced(HistoryEventTypes.PROCESS_INSTANCE_UPDATE, processInstance)) {
+        HistoryEventProcessor.processHistoryEvents(new HistoryEventProcessor.HistoryEventCreator() {
+          @Override
+          public HistoryEvent createHistoryEvent(HistoryEventProducer producer) {
+            HistoricProcessInstanceEventEntity processInstanceUpdateEvt = (HistoricProcessInstanceEventEntity)
+                producer.createProcessInstanceUpdateEvt((DelegateExecution) processInstance);
+            if (SuspensionState.SUSPENDED.getStateCode() == getNewSuspensionState().getStateCode()) {
+              processInstanceUpdateEvt.setState(HistoricProcessInstance.STATE_SUSPENDED);
+            } else {
+              processInstanceUpdateEvt.setState(HistoricProcessInstance.STATE_ACTIVE);
             }
-          });
-        }
+            return processInstanceUpdateEvt;
+          }
+        });
       }
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetStateCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Date;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 
 import org.jspecify.annotations.Nullable;
@@ -32,17 +33,17 @@ import org.operaton.bpm.engine.impl.persistence.entity.TimerEntity;
 
 /**
  * @author Roman Smirnov
- *
  */
+@NullMarked
 public abstract class AbstractSetStateCmd implements Command<Void> {
 
   protected static final String SUSPENSION_STATE_PROPERTY = "suspensionState";
 
   protected boolean includeSubResources;
   protected boolean isLogUserOperationDisabled;
-  protected Date executionDate;
+  protected @Nullable Date executionDate;
 
-  protected AbstractSetStateCmd(boolean includeSubResources, Date executionDate) {
+  protected AbstractSetStateCmd(boolean includeSubResources, @Nullable Date executionDate) {
     this.includeSubResources = includeSubResources;
     this.executionDate = executionDate;
   }
@@ -81,7 +82,7 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
   }
 
   protected void triggerHistoryEvent(CommandContext commandContext) {
-
+    // no-op
   }
 
   public void disableLogUserOperation() {
@@ -109,15 +110,15 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
     commandContext.getJobManager().schedule(timer);
   }
 
-  protected String getDelayedExecutionJobHandlerType() {
+  protected @Nullable String getDelayedExecutionJobHandlerType() {
     return null;
   }
 
-  protected JobHandlerConfiguration getJobHandlerConfiguration() {
+  protected @Nullable JobHandlerConfiguration getJobHandlerConfiguration() {
     return null;
   }
 
-  protected AbstractSetStateCmd getNextCommand() {
+  protected @Nullable AbstractSetStateCmd getNextCommand() {
     return null;
   }
 
@@ -128,7 +129,7 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
    *         for that deployment can execute the resulting job
    */
   @SuppressWarnings("unused")
-  protected String getDeploymentId(CommandContext commandContext) {
+  protected @Nullable String getDeploymentId(CommandContext commandContext) {
     return null;
   }
 
@@ -144,7 +145,7 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
 
   protected abstract SuspensionState getNewSuspensionState();
 
-  protected String getDeploymentIdByProcessDefinition(CommandContext commandContext, String processDefinitionId) {
+  protected @Nullable String getDeploymentIdByProcessDefinition(CommandContext commandContext, String processDefinitionId) {
     ProcessDefinitionEntity definition = commandContext.getProcessDefinitionManager().getCachedResourceDefinitionEntity(processDefinitionId);
     if (definition == null) {
       definition = commandContext.getProcessDefinitionManager().findLatestDefinitionById(processDefinitionId);
@@ -155,7 +156,7 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
     return null;
   }
 
-  protected String getDeploymentIdByProcessDefinitionKey(CommandContext commandContext, String processDefinitionKey,
+  protected @Nullable String getDeploymentIdByProcessDefinitionKey(CommandContext commandContext, String processDefinitionKey,
       boolean tenantIdSet, String tenantId) {
     ProcessDefinitionEntity definition = null;
     if (tenantIdSet) {
@@ -171,7 +172,7 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
     return null;
   }
 
-  protected String getDeploymentIdByJobDefinition(CommandContext commandContext, String jobDefinitionId) {
+  protected @Nullable String getDeploymentIdByJobDefinition(CommandContext commandContext, String jobDefinitionId) {
     JobDefinitionManager jobDefinitionManager = commandContext.getJobDefinitionManager();
     JobDefinitionEntity jobDefinition = jobDefinitionManager.findById(jobDefinitionId);
     if (jobDefinition != null && jobDefinition.getProcessDefinitionId() != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetTaskPropertyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetTaskPropertyCmd.java
@@ -17,6 +17,7 @@
 
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.exception.NotFoundException;
@@ -35,10 +36,10 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @param <T> the type of the value to set by this command
  */
-public abstract class AbstractSetTaskPropertyCmd<T> implements Command<Void> {
+public abstract @NullMarked class AbstractSetTaskPropertyCmd<T> implements Command<Void> {
 
   protected final String taskId;
-  protected final T value;
+  protected final @Nullable T value;
 
   /**
    * Constructor of Commands that wish to set a property to a given task.
@@ -48,7 +49,7 @@ public abstract class AbstractSetTaskPropertyCmd<T> implements Command<Void> {
    * @throws NullValueException in case the given taskId or the given value are null
    * @throws NotFoundException  in case the referenced task does not exist
    */
-  protected AbstractSetTaskPropertyCmd(String taskId, T value) {
+  protected AbstractSetTaskPropertyCmd(String taskId, @Nullable T value) {
     this(taskId, value, false);
   }
 
@@ -60,8 +61,9 @@ public abstract class AbstractSetTaskPropertyCmd<T> implements Command<Void> {
    * @param value                  the new value to set to the referenced task
    * @param skipValueValidation if true, the validation of the value will be excluded
    */
-  protected AbstractSetTaskPropertyCmd(String taskId, T value, boolean skipValueValidation) {
-    this.taskId = ensureNotNullAndGet("taskId", taskId);
+  protected AbstractSetTaskPropertyCmd(String taskId, @Nullable T value, boolean skipValueValidation) {
+    ensureNotNullAndGet("taskId", taskId);
+    this.taskId = taskId;
     this.value = skipValueValidation ? value : ensureNotNullAndGet("value", value);
   }
 
@@ -123,15 +125,15 @@ public abstract class AbstractSetTaskPropertyCmd<T> implements Command<Void> {
    *
    * @return the user operation log name
    */
-  protected abstract String getUserOperationLogName();
+  protected abstract @Nullable String getUserOperationLogName();
 
   /**
    * Executes the set operation of the concrete command.
    *
    * @param task  the task entity on which to set a property
-   * @param value the value to se
+   * @param value the value to set
    */
-  protected abstract void executeSetOperation(TaskEntity task, T value);
+  protected abstract void executeSetOperation(TaskEntity task, @Nullable T value);
 
   /**
    * Ensures the value is not null and returns the value.
@@ -141,7 +143,7 @@ public abstract class AbstractSetTaskPropertyCmd<T> implements Command<Void> {
    * @return the value
    * @throws NullValueException in case the given value is null
    */
-  protected <S> S ensureNotNullAndGet(String variableName, S value) {
+  protected <S> @Nullable S ensureNotNullAndGet(String variableName, @Nullable S value) {
     ensureNotNull(variableName, value);
     return value;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetTaskPropertyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetTaskPropertyCmd.java
@@ -28,6 +28,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -102,6 +103,7 @@ public abstract @NullMarked class AbstractSetTaskPropertyCmd<T> implements Comma
     TaskEntity task = taskManager.findTaskById(taskId);
 
     ensureNotNull(NotFoundException.class, "Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkTaskAgainstContext(task, context);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetVariableCmd.java
@@ -18,12 +18,14 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 
 /**
  * @author Stefan Hentschel.
  */
+@NullMarked
 public abstract class AbstractSetVariableCmd extends AbstractVariableCmd {
   protected Map<String, ? extends Object> variables;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractUpdateProcessInstancesSuspendStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractUpdateProcessInstancesSuspendStateCmd.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
@@ -33,6 +34,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.commons.utils.CollectionUtil;
 
+@NullMarked
 public abstract class AbstractUpdateProcessInstancesSuspendStateCmd<T> implements Command<T> {
 
   protected UpdateProcessInstancesSuspensionStateBuilderImpl builder;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractVariableCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
@@ -25,11 +26,14 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.pvm.runtime.Callback;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Stefan Hentschel.
  */
+@NullMarked
 public abstract class AbstractVariableCmd implements Command<Void> {
-  protected CommandContext commandContext;
+  private @Nullable CommandContext commandContext;
   protected String entityId;
   protected boolean isLocal;
   protected boolean preventLogUserOperation;
@@ -61,9 +65,13 @@ public abstract class AbstractVariableCmd implements Command<Void> {
     return null;
   }
 
-  protected abstract AbstractVariableScope getEntity();
+  protected CommandContext getCommandContext() {
+    return requireNonNull(commandContext);
+  }
 
-  protected abstract ExecutionEntity getContextExecution();
+  protected abstract @Nullable AbstractVariableScope getEntity();
+
+  protected abstract @Nullable ExecutionEntity getContextExecution();
 
   protected abstract void logVariableOperation(AbstractVariableScope scope);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractWritableIdentityServiceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractWritableIdentityServiceCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -24,6 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * @author Daniel Meyer
  *
  */
+@NullMarked
 public abstract class AbstractWritableIdentityServiceCmd<T> implements Command<T> {
   @Override
   public final T execute(CommandContext commandContext) {
@@ -36,6 +39,6 @@ public abstract class AbstractWritableIdentityServiceCmd<T> implements Command<T
     return executeCmd(commandContext);
   }
 
-  protected abstract T executeCmd(CommandContext commandContext);
+  protected abstract @Nullable T executeCmd(CommandContext commandContext);
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AcquireJobsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AcquireJobsCmd.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.db.DbEntity;
 import org.operaton.bpm.engine.impl.db.entitymanager.OptimisticLockingListener;
@@ -41,7 +42,7 @@ import org.operaton.bpm.engine.impl.util.ClockUtil;
  * @author Nick Burch
  * @author Daniel Meyer
  */
-public class AcquireJobsCmd implements Command<AcquiredJobs>, OptimisticLockingListener {
+public @NullMarked class AcquireJobsCmd implements Command<AcquiredJobs>, OptimisticLockingListener {
 
   private final JobExecutor jobExecutor;
 
@@ -55,13 +56,11 @@ public class AcquireJobsCmd implements Command<AcquiredJobs>, OptimisticLockingL
   public AcquireJobsCmd(JobExecutor jobExecutor, int numJobsToAcquire) {
     this.jobExecutor = jobExecutor;
     this.numJobsToAcquire = numJobsToAcquire;
+    this.acquiredJobs = new AcquiredJobs(numJobsToAcquire);
   }
 
   @Override
   public AcquiredJobs execute(CommandContext commandContext) {
-
-    acquiredJobs = new AcquiredJobs(numJobsToAcquire);
-
     List<AcquirableJobEntity> jobs = commandContext
       .getJobManager()
       .findNextJobsToExecute(new Page(0, numJobsToAcquire));
@@ -133,9 +132,7 @@ public class AcquireJobsCmd implements Command<AcquiredJobs>, OptimisticLockingL
   }
 
   protected boolean isAcquireExclusiveOverProcessHierarchies(CommandContext context) {
-    var engineConfig = context.getProcessEngineConfiguration();
-
-    return engineConfig != null && engineConfig.isJobExecutorAcquireExclusiveOverProcessHierarchies();
+    return context.getProcessEngineConfiguration().isJobExecutorAcquireExclusiveOverProcessHierarchies();
   }
 
   protected String selectProcessInstanceId(AcquirableJobEntity job, boolean isAcquireExclusiveOverProcessHierarchies) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateBatchCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateBatchCmd.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.batch.BatchEntity;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.management.UpdateJobDefinitionSuspensionStateBuilderImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 
-public class ActivateBatchCmd extends AbstractSetBatchStateCmd {
+public @NullMarked class ActivateBatchCmd extends AbstractSetBatchStateCmd {
 
   public ActivateBatchCmd(String batchId) {
     super(batchId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateJobCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateJobCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.management.UpdateJobSuspensionStateBuilderImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 /**
  * @author roman.smirnov
  */
-public class ActivateJobCmd extends AbstractSetJobStateCmd {
+public @NullMarked class ActivateJobCmd extends AbstractSetJobStateCmd {
 
   public ActivateJobCmd(UpdateJobSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateJobDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateJobDefinitionCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerActivateJobDefinitionHandler;
 import org.operaton.bpm.engine.impl.management.UpdateJobDefinitionSuspensionStateBuilderImpl;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 /**
  * @author roman.smirnov
  */
-public class ActivateJobDefinitionCmd extends AbstractSetJobDefinitionStateCmd {
+public @NullMarked class ActivateJobDefinitionCmd extends AbstractSetJobDefinitionStateCmd {
 
   public ActivateJobDefinitionCmd(UpdateJobDefinitionSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateProcessDefinitionCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerActivateProcessDefinitionHandler;
 import org.operaton.bpm.engine.impl.management.UpdateJobDefinitionSuspensionStateBuilderImpl;
@@ -28,7 +29,7 @@ import org.operaton.bpm.engine.impl.runtime.UpdateProcessInstanceSuspensionState
  * @author Joram Barrez
  * @author roman.smirnov
  */
-public class ActivateProcessDefinitionCmd extends AbstractSetProcessDefinitionStateCmd {
+public @NullMarked class ActivateProcessDefinitionCmd extends AbstractSetProcessDefinitionStateCmd {
 
   public ActivateProcessDefinitionCmd(UpdateProcessDefinitionSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivateProcessInstanceCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.management.UpdateJobSuspensionStateBuilderImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.runtime.UpdateProcessInstanceSuspensionState
  *
  * @author Daniel Meyer
  */
-public class ActivateProcessInstanceCmd extends AbstractSetProcessInstanceStateCmd {
+public @NullMarked class ActivateProcessInstanceCmd extends AbstractSetProcessInstanceStateCmd {
 
   public ActivateProcessInstanceCmd(UpdateProcessInstanceSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityAfterInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityAfterInstantiationCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.impl.core.model.CoreModelElement;
@@ -29,7 +31,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  * @author Thorben Lindhauer
  *
  */
-public class ActivityAfterInstantiationCmd extends AbstractInstantiationCmd {
+public @NullMarked class ActivityAfterInstantiationCmd extends AbstractInstantiationCmd {
 
   protected String activityId;
 
@@ -37,12 +39,12 @@ public class ActivityAfterInstantiationCmd extends AbstractInstantiationCmd {
     this(null, activityId);
   }
 
-  public ActivityAfterInstantiationCmd(String processInstanceId, String activityId) {
+  public ActivityAfterInstantiationCmd(@Nullable String processInstanceId, String activityId) {
     this(processInstanceId, activityId, null);
   }
 
-  public ActivityAfterInstantiationCmd(String processInstanceId, String activityId,
-      String ancestorActivityInstanceId) {
+  public ActivityAfterInstantiationCmd(@Nullable String processInstanceId, String activityId,
+      @Nullable String ancestorActivityInstanceId) {
     super(processInstanceId, ancestorActivityInstanceId);
     this.activityId = activityId;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityBeforeInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityBeforeInstantiationCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.core.model.CoreModelElement;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -24,11 +26,13 @@ import org.operaton.bpm.engine.impl.pvm.PvmActivity;
 import org.operaton.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Thorben Lindhauer
  *
  */
-public class ActivityBeforeInstantiationCmd extends AbstractInstantiationCmd {
+public @NullMarked class ActivityBeforeInstantiationCmd extends AbstractInstantiationCmd {
 
   protected String activityId;
 
@@ -36,19 +40,19 @@ public class ActivityBeforeInstantiationCmd extends AbstractInstantiationCmd {
     this(null, activityId);
   }
 
-  public ActivityBeforeInstantiationCmd(String processInstanceId, String activityId) {
+  public ActivityBeforeInstantiationCmd(@Nullable String processInstanceId, String activityId) {
     this(processInstanceId, activityId, null);
   }
 
-  public ActivityBeforeInstantiationCmd(String processInstanceId, String activityId,
-      String ancestorActivityInstanceId) {
+  public ActivityBeforeInstantiationCmd(@Nullable String processInstanceId, String activityId,
+      @Nullable String ancestorActivityInstanceId) {
     super(processInstanceId, ancestorActivityInstanceId);
     this.activityId = activityId;
   }
 
   @Override
   public Void execute(CommandContext commandContext) {
-    ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
+    ExecutionEntity processInstance = requireNonNull(commandContext.getExecutionManager().findExecutionById(processInstanceId));
     ProcessDefinitionImpl processDefinition = processInstance.getProcessDefinition();
 
     PvmActivity activity = processDefinition.findActivity(activityId);
@@ -63,12 +67,12 @@ public class ActivityBeforeInstantiationCmd extends AbstractInstantiationCmd {
 
   @Override
   protected ScopeImpl getTargetFlowScope(ProcessDefinitionImpl processDefinition) {
-    PvmActivity activity = processDefinition.findActivity(activityId);
+    PvmActivity activity = requireNonNull(processDefinition.findActivity(activityId));
     return activity.getFlowScope();
   }
 
   @Override
-  protected CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition) {
+  protected @Nullable CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition) {
     return processDefinition.findActivity(activityId);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityCancellationCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.*;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import org.jspecify.annotations.Nullable;
@@ -27,21 +28,23 @@ import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.TransitionInstance;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Thorben Lindhauer
  *
  */
-public class ActivityCancellationCmd extends AbstractProcessInstanceModificationCommand {
+public @NullMarked class ActivityCancellationCmd extends AbstractProcessInstanceModificationCommand {
 
   protected String activityId;
   protected boolean cancelCurrentActiveActivityInstances;
-  protected ActivityInstance activityInstanceTree;
+  protected @Nullable ActivityInstance activityInstanceTree;
 
   public ActivityCancellationCmd(String activityId) {
     this(null, activityId);
   }
 
-  public ActivityCancellationCmd(String processInstanceId, String activityId) {
+  public ActivityCancellationCmd(@Nullable String processInstanceId, String activityId) {
     super(processInstanceId);
     this.activityId = activityId;
   }
@@ -114,7 +117,7 @@ public class ActivityCancellationCmd extends AbstractProcessInstanceModification
     return instances;
   }
 
-  public ActivityInstance getActivityInstanceTree(final CommandContext commandContext) {
+  public @Nullable ActivityInstance getActivityInstanceTree(final CommandContext commandContext) {
     return commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
   }
 
@@ -122,7 +125,7 @@ public class ActivityCancellationCmd extends AbstractProcessInstanceModification
     return activityId;
   }
 
-  public void setActivityInstanceTreeToCancel(ActivityInstance activityInstanceTreeToCancel) {
+  public void setActivityInstanceTreeToCancel(@Nullable ActivityInstance activityInstanceTreeToCancel) {
     this.activityInstanceTree = activityInstanceTreeToCancel;
   }
 
@@ -134,7 +137,7 @@ public class ActivityCancellationCmd extends AbstractProcessInstanceModification
   public List<AbstractInstanceCancellationCmd> createActivityInstanceCancellations(ActivityInstance activityInstanceTree, CommandContext commandContext) {
     List<AbstractInstanceCancellationCmd> commands = new ArrayList<>();
 
-    ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
+    ExecutionEntity processInstance = requireNonNull(commandContext.getExecutionManager().findExecutionById(processInstanceId));
     ProcessDefinitionImpl processDefinition = processInstance.getProcessDefinition();
     Set<String> parentScopeIds = collectParentScopeIdsForActivity(processDefinition, activityId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityCancellationCmd.java
@@ -51,7 +51,7 @@ public @NullMarked class ActivityCancellationCmd extends AbstractProcessInstance
 
   @Override
   public @Nullable Void execute(final CommandContext commandContext) {
-    ActivityInstance actInstTree = getActivityInstanceTree(commandContext);
+    ActivityInstance actInstTree = requireNonNull(getActivityInstanceTree(commandContext));
     List<AbstractInstanceCancellationCmd> commands = createActivityInstanceCancellations(actInstTree, commandContext);
 
     for (AbstractInstanceCancellationCmd cmd : commands) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityInstanceCancellationCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.impl.ActivityExecutionTreeMapping;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,11 +24,13 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Thorben Lindhauer
  *
  */
-public class ActivityInstanceCancellationCmd extends AbstractInstanceCancellationCmd {
+public @NullMarked class ActivityInstanceCancellationCmd extends AbstractInstanceCancellationCmd {
 
   protected String activityInstanceId;
 
@@ -48,18 +51,21 @@ public class ActivityInstanceCancellationCmd extends AbstractInstanceCancellatio
   @Override
   protected ExecutionEntity determineSourceInstanceExecution(final CommandContext commandContext) {
     ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
+    requireNonNull(processInstance);
 
     // rebuild the mapping because the execution tree changes with every iteration
     ActivityExecutionTreeMapping mapping = new ActivityExecutionTreeMapping(commandContext, processInstanceId);
 
     ActivityInstance instance = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
+    requireNonNull(instance);
 
     ActivityInstance instanceToCancel = findActivityInstance(instance, activityInstanceId);
     EnsureUtil.ensureNotNull(NotValidException.class,
         describeFailure("Activity instance '%s' does not exist".formatted(activityInstanceId)),
         "activityInstance",
         instanceToCancel);
-    return getScopeExecutionForActivityInstance(processInstance, mapping, instanceToCancel);
+
+    return getScopeExecutionForActivityInstance(processInstance, mapping, requireNonNull(instanceToCancel));
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddCommentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddCommentCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Date;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.history.event.HistoricProcessInstanceEventEntity;
@@ -30,18 +32,19 @@ import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.task.Event;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Tom Baeyens
  */
-public class AddCommentCmd implements Command<Comment> {
-  protected String taskId;
-  protected String processInstanceId;
+public @NullMarked class AddCommentCmd implements Command<Comment> {
+  protected @Nullable String taskId;
+  protected @Nullable String processInstanceId;
   protected String message;
 
-  public AddCommentCmd(String taskId, String processInstanceId, String message) {
+  public AddCommentCmd(@Nullable String taskId, @Nullable String processInstanceId, String message) {
     this.taskId = taskId;
     this.processInstanceId = processInstanceId;
     this.message = message;
@@ -91,7 +94,7 @@ public class AddCommentCmd implements Command<Comment> {
     return comment;
   }
 
-  protected ExecutionEntity getExecution(CommandContext commandContext) {
+  protected @Nullable ExecutionEntity getExecution(CommandContext commandContext) {
 
     if (taskId != null) {
       TaskEntity task = getTask(commandContext);
@@ -105,7 +108,7 @@ public class AddCommentCmd implements Command<Comment> {
     }
   }
 
-  protected ExecutionEntity getProcessInstance(CommandContext commandContext) {
+  protected @Nullable ExecutionEntity getProcessInstance(CommandContext commandContext) {
     if (processInstanceId != null) {
       return commandContext.getExecutionManager().findExecutionById(processInstanceId);
     } else {
@@ -113,7 +116,7 @@ public class AddCommentCmd implements Command<Comment> {
     }
   }
 
-  protected TaskEntity getTask(CommandContext commandContext) {
+  protected @Nullable TaskEntity getTask(CommandContext commandContext) {
     if (taskId != null) {
       return commandContext.getTaskManager().findTaskById(taskId);
     } else {
@@ -126,12 +129,14 @@ public class AddCommentCmd implements Command<Comment> {
   }
 
   protected String getHistoryRemovalTimeStrategy() {
-    return Context.getProcessEngineConfiguration()
+    var processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    return processEngineConfiguration
       .getHistoryRemovalTimeStrategy();
   }
 
-  protected HistoricProcessInstanceEventEntity getHistoricRootProcessInstance(String rootProcessInstanceId) {
-    return Context.getCommandContext()
+  protected @Nullable HistoricProcessInstanceEventEntity getHistoricRootProcessInstance(String rootProcessInstanceId) {
+    CommandContext commandContext = requireNonNull(Context.getCommandContext());
+    return commandContext
       .getDbEntityManager()
       .selectById(HistoricProcessInstanceEventEntity.class, rootProcessInstanceId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddGroupIdentityLinkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddGroupIdentityLinkCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -27,7 +28,7 @@ import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TY
  * @author Daniel Meyer
  *
  */
-public class AddGroupIdentityLinkCmd extends AbstractAddIdentityLinkCmd {
+public @NullMarked class AddGroupIdentityLinkCmd extends AbstractAddIdentityLinkCmd {
 
   public AddGroupIdentityLinkCmd(String taskId, String groupId, String type) {
     super(taskId, null, groupId, type);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddIdentityLinkForProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddIdentityLinkForProcessDefinitionCmd.java
@@ -16,10 +16,10 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
@@ -30,21 +30,19 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tijs Rademakers
  */
-public class AddIdentityLinkForProcessDefinitionCmd implements Command<Void> {
+public @NullMarked class AddIdentityLinkForProcessDefinitionCmd implements Command<Void> {
   protected String processDefinitionId;
+  protected @Nullable String userId;
+  protected @Nullable String groupId;
 
-  protected String userId;
-
-  protected String groupId;
-
-  public AddIdentityLinkForProcessDefinitionCmd(String processDefinitionId, String userId, String groupId) {
+  public AddIdentityLinkForProcessDefinitionCmd(String processDefinitionId, @Nullable String userId, @Nullable String groupId) {
     validateParams(userId, groupId, processDefinitionId);
     this.processDefinitionId = processDefinitionId;
     this.userId = userId;
     this.groupId = groupId;
   }
 
-  protected void validateParams(String userId, String groupId, String processDefinitionId) {
+  protected void validateParams(@Nullable String userId, @Nullable String groupId, String processDefinitionId) {
     ensureNotNull("processDefinitionId", processDefinitionId);
 
     if (userId == null && groupId == null) {
@@ -54,8 +52,7 @@ public class AddIdentityLinkForProcessDefinitionCmd implements Command<Void> {
 
   @Override
   public @Nullable Void execute(CommandContext commandContext) {
-    ProcessDefinitionEntity processDefinition = Context
-      .getCommandContext()
+    ProcessDefinitionEntity processDefinition = commandContext
       .getProcessDefinitionManager()
       .findLatestProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddUserIdentityLinkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AddUserIdentityLinkCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
@@ -26,8 +28,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.UserOperationLogManager;
  * @author Daniel Meyer
  *
  */
-public class AddUserIdentityLinkCmd extends AbstractAddIdentityLinkCmd {
-  public AddUserIdentityLinkCmd(String taskId, String userId, String type) {
+public @NullMarked class AddUserIdentityLinkCmd extends AbstractAddIdentityLinkCmd {
+  public AddUserIdentityLinkCmd(String taskId, @Nullable String userId, String type) {
     super(taskId, userId, null, type);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AssignTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AssignTaskCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -24,8 +26,8 @@ import org.operaton.bpm.engine.task.IdentityLinkType;
 /**
  * @author Danny Gräf
  */
-public class AssignTaskCmd extends AbstractAddIdentityLinkCmd {
-  public AssignTaskCmd(String taskId, String userId) {
+public @NullMarked class AssignTaskCmd extends AbstractAddIdentityLinkCmd {
+  public AssignTaskCmd(String taskId, @Nullable String userId) {
     super(taskId, userId, null, IdentityLinkType.ASSIGNEE);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AuthorizationCheckCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AuthorizationCheckCmd.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.List;
 import java.util.Objects;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Resource;
 import org.operaton.bpm.engine.authorization.Resources;
@@ -37,7 +39,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Daniel Meyer
  *
  */
-public class AuthorizationCheckCmd implements Command<Boolean> {
+public @NullMarked class AuthorizationCheckCmd implements Command<Boolean> {
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
@@ -45,9 +47,9 @@ public class AuthorizationCheckCmd implements Command<Boolean> {
   protected List<String> groupIds;
   protected Permission permission;
   protected Resource resource;
-  protected String resourceId;
+  protected @Nullable String resourceId;
 
-  public AuthorizationCheckCmd(String userId, List<String> groupIds, Permission permission, Resource resource, String resourceId) {
+  public AuthorizationCheckCmd(String userId, List<String> groupIds, Permission permission, Resource resource, @Nullable String resourceId) {
     this.userId = userId;
     this.groupIds = groupIds;
     this.permission = permission;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ClaimTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ClaimTaskCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.TaskAlreadyClaimedException;
@@ -31,11 +32,11 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Joram Barrez
  */
-public class ClaimTaskCmd implements Command<Void> {
+public @NullMarked class ClaimTaskCmd implements Command<Void> {
   protected String taskId;
-  protected String userId;
+  protected @Nullable String userId;
 
-  public ClaimTaskCmd(String taskId, String userId) {
+  public ClaimTaskCmd(String taskId, @Nullable String userId) {
     this.taskId = taskId;
     this.userId = userId;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ClaimTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ClaimTaskCmd.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -48,6 +49,7 @@ public @NullMarked class ClaimTaskCmd implements Command<Void> {
     TaskManager taskManager = commandContext.getTaskManager();
     TaskEntity task = taskManager.findTaskById(taskId);
     ensureNotNull("Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkClaimTask(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CommandLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CommandLogger.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Arrays;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.application.impl.ProcessApplicationIdentifier;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.MismatchingMessageCorrelationException;
@@ -35,7 +36,7 @@ import org.operaton.bpm.engine.impl.util.ClassNameUtil;
  * @author Daniel Meyer
  *
  */
-public class CommandLogger extends ProcessEngineLogger {
+public @NullMarked class CommandLogger extends ProcessEngineLogger {
 
 
   public void debugCreatingNewDeployment() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CompleteExternalTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CompleteExternalTaskCmd.java
@@ -18,18 +18,20 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 
 /**
  * @author Thorben Lindhauer
  * @author Christopher Zell
  */
-public class CompleteExternalTaskCmd extends HandleExternalTaskCmd {
+public @NullMarked class CompleteExternalTaskCmd extends HandleExternalTaskCmd {
 
-  protected Map<String, Object> variables;
-  protected Map<String, Object> localVariables;
+  protected @Nullable Map<String, Object> variables;
+  protected @Nullable Map<String, Object> localVariables;
 
-  public CompleteExternalTaskCmd(String externalTaskId, String workerId, Map<String, Object> variables, Map<String, Object> localVariables) {
+  public CompleteExternalTaskCmd(String externalTaskId, String workerId, @Nullable Map<String, Object> variables, @Nullable Map<String, Object> localVariables) {
     super(externalTaskId, workerId);
     this.localVariables = localVariables;
     this.variables = variables;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CompleteTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CompleteTaskCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -29,26 +31,27 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Joram Barrez
  */
-public class CompleteTaskCmd implements Command<VariableMap> {
+public @NullMarked class CompleteTaskCmd implements Command<VariableMap> {
   private static final VariableMapImpl EMPTY_VARIABLE_MAP = new VariableMapImpl();
   protected String taskId;
-  protected Map<String, Object> variables;
+  protected @Nullable Map<String, Object> variables;
 
   // only fetch variables if they are actually requested;
   // this avoids unnecessary loading of variables
   protected boolean returnVariables;
   protected boolean deserializeReturnedVariables;
 
-  public CompleteTaskCmd(String taskId, Map<String, Object> variables) {
+  public CompleteTaskCmd(String taskId, @Nullable Map<String, Object> variables) {
     this(taskId, variables, false, false);
   }
 
-  public CompleteTaskCmd(String taskId, Map<String, Object> variables,
+  public CompleteTaskCmd(String taskId, @Nullable Map<String, Object> variables,
       boolean returnVariables, boolean deserializeReturnedVariables) {
     this.taskId = taskId;
     this.variables = variables;
@@ -63,6 +66,7 @@ public class CompleteTaskCmd implements Command<VariableMap> {
     TaskManager taskManager = commandContext.getTaskManager();
     TaskEntity task = taskManager.findTaskById(taskId);
     ensureNotNull("Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkCompleteTask(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CorrelateAllMessageCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CorrelateAllMessageCmd.java
@@ -23,8 +23,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.MessageCorrelationBuilderImpl;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.history.SynchronousOperationLogProducer;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -36,6 +38,7 @@ import org.operaton.bpm.engine.impl.runtime.CorrelationSet;
 import org.operaton.bpm.engine.impl.runtime.MessageCorrelationResultImpl;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNull;
 
 /**
@@ -43,7 +46,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNu
  * @author Daniel Meyer
  * @author Michael Scholz
  */
-public class CorrelateAllMessageCmd extends AbstractCorrelateMessageCmd implements Command<List<MessageCorrelationResultImpl>>, SynchronousOperationLogProducer<MessageCorrelationResultImpl> {
+public @NullMarked class CorrelateAllMessageCmd extends AbstractCorrelateMessageCmd implements Command<List<MessageCorrelationResultImpl>>, SynchronousOperationLogProducer<MessageCorrelationResultImpl> {
 
   /**
    * Initialize the command with a builder
@@ -60,7 +63,8 @@ public class CorrelateAllMessageCmd extends AbstractCorrelateMessageCmd implemen
         "At least one of the following correlation criteria has to be present: " + "messageName, businessKey, correlationKeys, processInstanceId", messageName,
         builder.getBusinessKey(), builder.getCorrelationProcessInstanceVariables(), builder.getProcessInstanceId());
 
-    final CorrelationHandler correlationHandler = Context.getProcessEngineConfiguration().getCorrelationHandler();
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    final CorrelationHandler correlationHandler = processEngineConfiguration.getCorrelationHandler();
     final CorrelationSet correlationSet = new CorrelationSet(builder);
     List<CorrelationHandlerResult> correlationResults = commandContext.runWithoutAuthorization((Callable<List<CorrelationHandlerResult>>) () -> correlationHandler.correlateMessages(commandContext, messageName, correlationSet));
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CorrelateMessageCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CorrelateMessageCmd.java
@@ -20,9 +20,11 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.MismatchingMessageCorrelationException;
 import org.operaton.bpm.engine.impl.MessageCorrelationBuilderImpl;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -31,6 +33,7 @@ import org.operaton.bpm.engine.impl.runtime.CorrelationHandlerResult;
 import org.operaton.bpm.engine.impl.runtime.CorrelationSet;
 import org.operaton.bpm.engine.impl.runtime.MessageCorrelationResultImpl;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNull;
 
 /**
@@ -39,7 +42,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNu
  * @author Michael Scholz
  * @author Christopher Zell
  */
-public class CorrelateMessageCmd extends AbstractCorrelateMessageCmd implements Command<MessageCorrelationResultImpl> {
+public @NullMarked class CorrelateMessageCmd extends AbstractCorrelateMessageCmd implements Command<MessageCorrelationResultImpl> {
 
   private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
@@ -61,12 +64,14 @@ public class CorrelateMessageCmd extends AbstractCorrelateMessageCmd implements 
         "At least one of the following correlation criteria has to be present: " + "messageName, businessKey, correlationKeys, processInstanceId", messageName,
         builder.getBusinessKey(), builder.getCorrelationProcessInstanceVariables(), builder.getProcessInstanceId());
 
-    final CorrelationHandler correlationHandler = Context.getProcessEngineConfiguration().getCorrelationHandler();
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    final CorrelationHandler correlationHandler = processEngineConfiguration.getCorrelationHandler();
     final CorrelationSet correlationSet = new CorrelationSet(builder);
 
     CorrelationHandlerResult correlationResult = null;
     if (startMessageOnly) {
       List<CorrelationHandlerResult> correlationResults = commandContext.runWithoutAuthorization((Callable<List<CorrelationHandlerResult>>) () -> correlationHandler.correlateStartMessages(commandContext, messageName, correlationSet));
+      requireNonNull(correlationResults);
       if (correlationResults.isEmpty()) {
         throw new MismatchingMessageCorrelationException(messageName, "No process definition matches the parameters");
       } else if (correlationResults.size() > 1) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateAttachmentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateAttachmentCmd.java
@@ -20,7 +20,10 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.operaton.bpm.engine.impl.history.event.HistoricProcessInstanceEventEntity;
@@ -32,10 +35,12 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.impl.util.IoUtil;
 import org.operaton.bpm.engine.repository.ResourceTypes;
 import org.operaton.bpm.engine.task.Attachment;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -43,20 +48,19 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-// Not Serializable
-public class CreateAttachmentCmd implements Command<Attachment> {
+public @NullMarked class CreateAttachmentCmd implements Command<Attachment> {
 
-  protected String taskId;
+  protected @Nullable String taskId;
   protected String attachmentType;
   protected String processInstanceId;
   protected String attachmentName;
   protected String attachmentDescription;
-  protected InputStream content;
-  protected String url;
-  private TaskEntity task;
-  protected ExecutionEntity processInstance;
+  protected @Nullable InputStream content;
+  protected @Nullable String url;
+  private @Nullable TaskEntity task;
+  protected @Nullable ExecutionEntity processInstance;
 
-  public CreateAttachmentCmd(String attachmentType, String taskId, String processInstanceId, String attachmentName, String attachmentDescription, InputStream content, String url) {
+  public CreateAttachmentCmd(String attachmentType, @Nullable String taskId, String processInstanceId, String attachmentName, String attachmentDescription, @Nullable InputStream content, @Nullable String url) {
     this.attachmentType = attachmentType;
     this.taskId = taskId;
     this.processInstanceId = processInstanceId;
@@ -133,12 +137,13 @@ public class CreateAttachmentCmd implements Command<Attachment> {
   }
 
   protected String getHistoryRemovalTimeStrategy() {
-    return Context.getProcessEngineConfiguration()
-      .getHistoryRemovalTimeStrategy();
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    return processEngineConfiguration.getHistoryRemovalTimeStrategy();
   }
 
-  protected HistoricProcessInstanceEventEntity getHistoricRootProcessInstance(String rootProcessInstanceId) {
-    return Context.getCommandContext().getDbEntityManager()
+  protected @Nullable HistoricProcessInstanceEventEntity getHistoricRootProcessInstance(String rootProcessInstanceId) {
+    CommandContext commandContext = EnsureUtil.ensureActiveCommandContext(Context.getCommandContext());
+    return commandContext.getDbEntityManager()
       .selectById(HistoricProcessInstanceEventEntity.class, rootProcessInstanceId);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateAttachmentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateAttachmentCmd.java
@@ -35,12 +35,10 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
-import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.impl.util.IoUtil;
 import org.operaton.bpm.engine.repository.ResourceTypes;
 import org.operaton.bpm.engine.task.Attachment;
 
-import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -137,12 +135,12 @@ public @NullMarked class CreateAttachmentCmd implements Command<Attachment> {
   }
 
   protected String getHistoryRemovalTimeStrategy() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     return processEngineConfiguration.getHistoryRemovalTimeStrategy();
   }
 
   protected @Nullable HistoricProcessInstanceEventEntity getHistoricRootProcessInstance(String rootProcessInstanceId) {
-    CommandContext commandContext = EnsureUtil.ensureActiveCommandContext(Context.getCommandContext());
+    CommandContext commandContext = Context.getCommandContext();
     return commandContext.getDbEntityManager()
       .selectById(HistoricProcessInstanceEventEntity.class, rootProcessInstanceId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateAuthorizationCommand.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateAuthorizationCommand.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -24,7 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * @author Daniel Meyer
  *
  */
-public class CreateAuthorizationCommand implements Command<Authorization> {
+public @NullMarked class CreateAuthorizationCommand implements Command<Authorization> {
 
   protected int type;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateFilterCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateFilterCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Sebastian Menski
  */
-public class CreateFilterCmd implements Command<Filter> {
+public @NullMarked class CreateFilterCmd implements Command<Filter> {
 
   protected String resourceType;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateGroupCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateGroupCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +26,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class CreateGroupCmd extends AbstractWritableIdentityServiceCmd<Group> implements Command<Group> {
+public @NullMarked class CreateGroupCmd extends AbstractWritableIdentityServiceCmd<Group> implements Command<Group> {
   protected String groupId;
 
   public CreateGroupCmd(String groupId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateGroupQueryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateGroupQueryCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.GroupQuery;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,12 +24,11 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Tom Baeyens
  */
-public class CreateGroupQueryCmd implements Command<GroupQuery> {
+public @NullMarked class CreateGroupQueryCmd implements Command<GroupQuery> {
   @Override
   public GroupQuery execute(CommandContext commandContext) {
     return commandContext
       .getReadOnlyIdentityProvider()
       .createGroupQuery();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateIncidentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateIncidentCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -34,7 +35,7 @@ import org.operaton.bpm.engine.runtime.Incident;
  * @author Anna Pazola
  *
  */
-public class CreateIncidentCmd implements Command<Incident> {
+public @NullMarked class CreateIncidentCmd implements Command<Incident> {
 
   protected String incidentType;
   protected String executionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateMembershipCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateMembershipCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +27,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class CreateMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class CreateMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   String userId;
   String groupId;
 
@@ -35,7 +37,7 @@ public class CreateMembershipCmd extends AbstractWritableIdentityServiceCmd<Void
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("userId", userId);
     ensureNotNull("groupId", groupId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateMigrationPlanCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateMigrationPlanCmd.java
@@ -20,6 +20,8 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -46,7 +48,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  * @author Thorben Lindhauer
  *
  */
-public class CreateMigrationPlanCmd implements Command<MigrationPlan> {
+public @NullMarked class CreateMigrationPlanCmd implements Command<MigrationPlan> {
 
   public static final MigrationLogger LOG = ProcessEngineLogger.MIGRATION_LOGGER;
 
@@ -209,7 +211,7 @@ public class CreateMigrationPlanCmd implements Command<MigrationPlan> {
     }
   }
 
-  private void validateActivityIds(MigrationInstructionValidationReportImpl instructionReport, String sourceActivityId, String targetActivityId) {
+  private void validateActivityIds(MigrationInstructionValidationReportImpl instructionReport, @Nullable String sourceActivityId, @Nullable String targetActivityId) {
     if (sourceActivityId == null) {
       instructionReport.addFailure("Source activity id is null");
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateNativeUserQueryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateNativeUserQueryCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.NativeUserQuery;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Svetlana Dorokhova
  */
-public class CreateNativeUserQueryCmd implements Command<NativeUserQuery> {
+public @NullMarked class CreateNativeUserQueryCmd implements Command<NativeUserQuery> {
   @Override
   public NativeUserQuery execute(CommandContext commandContext) {
     return commandContext.getReadOnlyIdentityProvider().createNativeUserQuery();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTaskCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.task.Task;
  * @author Roman Smirnov
  *
  */
-public class CreateTaskCmd implements Command<Task> {
+public @NullMarked class CreateTaskCmd implements Command<Task> {
 
   protected String taskId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantCmd.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.Tenant;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class CreateTenantCmd extends AbstractWritableIdentityServiceCmd<Tenant> implements Command<Tenant> {
+public @NullMarked class CreateTenantCmd extends AbstractWritableIdentityServiceCmd<Tenant> implements Command<Tenant> {
   protected final String tenantId;
 
   public CreateTenantCmd(String tenantId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantGroupMembershipCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantGroupMembershipCmd.java
@@ -16,13 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class CreateTenantGroupMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class CreateTenantGroupMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected final String tenantId;
   protected final String groupId;
 
@@ -32,7 +34,7 @@ public class CreateTenantGroupMembershipCmd extends AbstractWritableIdentityServ
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("tenantId", tenantId);
     ensureNotNull("groupId", groupId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantQueryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantQueryCmd.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.TenantQuery;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
-public class CreateTenantQueryCmd implements Command<TenantQuery> {
+public @NullMarked class CreateTenantQueryCmd implements Command<TenantQuery> {
   @Override
   public TenantQuery execute(CommandContext commandContext) {
     return commandContext
       .getReadOnlyIdentityProvider()
       .createTenantQuery();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantUserMembershipCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateTenantUserMembershipCmd.java
@@ -16,13 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class CreateTenantUserMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class CreateTenantUserMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected final String tenantId;
   protected final String userId;
 
@@ -32,7 +34,7 @@ public class CreateTenantUserMembershipCmd extends AbstractWritableIdentityServi
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("tenantId", tenantId);
     ensureNotNull("userId", userId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateUserCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateUserCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.User;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +26,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class CreateUserCmd extends AbstractWritableIdentityServiceCmd<User> implements Command<User> {
+public @NullMarked class CreateUserCmd extends AbstractWritableIdentityServiceCmd<User> implements Command<User> {
   protected String userId;
 
   public CreateUserCmd(String userId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateUserQueryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CreateUserQueryCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.identity.UserQuery;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,12 +24,11 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Tom Baeyens
  */
-public class CreateUserQueryCmd implements Command<UserQuery> {
+public @NullMarked class CreateUserQueryCmd implements Command<UserQuery> {
   @Override
   public UserQuery execute(CommandContext commandContext) {
     return commandContext
       .getReadOnlyIdentityProvider()
       .createUserQuery();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 
 import org.jspecify.annotations.Nullable;
@@ -43,7 +44,7 @@ import org.operaton.bpm.engine.impl.util.ParseUtil;
 /**
  * @author Roman Smirnov
  */
-public class DefaultJobRetryCmd extends JobRetryCmd {
+public @NullMarked class DefaultJobRetryCmd extends JobRetryCmd {
   private static final List<String> SUPPORTED_TYPES = List.of(
       TimerExecuteNestedActivityJobHandler.TYPE,
       TimerCatchIntermediateEventJobHandler.TYPE,
@@ -54,7 +55,7 @@ public class DefaultJobRetryCmd extends JobRetryCmd {
 
   private static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
 
-  public DefaultJobRetryCmd(String jobId, Throwable exception) {
+  public DefaultJobRetryCmd(String jobId, @Nullable Throwable exception) {
     super(jobId, exception);
   }
 
@@ -127,7 +128,7 @@ public class DefaultJobRetryCmd extends JobRetryCmd {
   }
 
   @SuppressWarnings("unused")
-  public ActivityImpl getCurrentActivity(CommandContext commandContext, JobEntity job) {
+  public @Nullable ActivityImpl getCurrentActivity(CommandContext commandContext, JobEntity job) {
     String type = job.getJobHandlerType();
     ActivityImpl activity = null;
 
@@ -144,13 +145,13 @@ public class DefaultJobRetryCmd extends JobRetryCmd {
     return activity;
   }
 
-  protected ExecutionEntity fetchExecutionEntity(String executionId) {
-    return Context.getCommandContext()
+  protected @Nullable ExecutionEntity fetchExecutionEntity(String executionId) {
+    return Context.getRequiredCommandContext()
                   .getExecutionManager()
                   .findExecutionById(executionId);
   }
 
-  public FailedJobRetryConfiguration getFailedJobRetryConfiguration(JobEntity job, ActivityImpl activity) {
+  public @Nullable FailedJobRetryConfiguration getFailedJobRetryConfiguration(JobEntity job, ActivityImpl activity) {
     FailedJobRetryConfiguration retryConfiguration = activity.getProperties().get(DefaultFailedJobParseListener.FAILED_JOB_CONFIGURATION);
 
     while (retryConfiguration != null && retryConfiguration.getExpression() != null) {
@@ -161,7 +162,7 @@ public class DefaultJobRetryCmd extends JobRetryCmd {
     return retryConfiguration;
   }
 
-  protected String getFailedJobRetryTimeCycle(JobEntity job, Expression expression) {
+  protected @Nullable String getFailedJobRetryTimeCycle(JobEntity job, @Nullable Expression expression) {
 
     String executionId = job.getExecutionId();
     ExecutionEntity execution = null;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
-import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.parser.DefaultFailedJobParseListener;
@@ -29,7 +28,6 @@ import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.el.Expression;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.jobexecutor.AsyncContinuationJobHandler;
-import org.operaton.bpm.engine.impl.jobexecutor.JobExecutorLogger;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerCatchIntermediateEventJobHandler;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerExecuteNestedActivityJobHandler;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerStartEventJobHandler;
@@ -53,15 +51,16 @@ public @NullMarked class DefaultJobRetryCmd extends JobRetryCmd {
       AsyncContinuationJobHandler.TYPE
   );
 
-  private static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
-
   public DefaultJobRetryCmd(String jobId, @Nullable Throwable exception) {
     super(jobId, exception);
   }
 
   @Override
   public @Nullable Object execute(CommandContext commandContext) {
-    JobEntity job = getJob();
+    JobEntity job = getJob().orElse(null);
+    if (job == null) {
+      return null;
+    }
 
     ActivityImpl activity = getCurrentActivity(commandContext, job);
 
@@ -83,15 +82,12 @@ public @NullMarked class DefaultJobRetryCmd extends JobRetryCmd {
   }
 
   protected void executeStandardStrategy(CommandContext commandContext) {
-    JobEntity job = getJob();
-    if (job != null) {
+    getJob().ifPresent(job -> {
       job.unlock();
       logException(job);
       decrementRetries(job);
       notifyAcquisition(commandContext);
-    } else {
-      LOG.debugFailedJobNotFound(jobId);
-    }
+    });
   }
 
   protected void executeCustomStrategy(CommandContext commandContext, JobEntity job, ActivityImpl activity) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
@@ -146,7 +146,7 @@ public @NullMarked class DefaultJobRetryCmd extends JobRetryCmd {
   }
 
   protected @Nullable ExecutionEntity fetchExecutionEntity(String executionId) {
-    return Context.getRequiredCommandContext()
+    return Context.getCommandContext()
                   .getExecutionManager()
                   .findExecutionById(executionId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DelegateTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DelegateTaskCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -25,12 +26,13 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Tom Baeyens
  */
-public class DelegateTaskCmd implements Command<Object> {
+public @NullMarked class DelegateTaskCmd implements Command<Object> {
   protected String taskId;
   protected String userId;
 
@@ -46,6 +48,7 @@ public class DelegateTaskCmd implements Command<Object> {
     TaskManager taskManager = commandContext.getTaskManager();
     TaskEntity task = taskManager.findTaskById(taskId);
     ensureNotNull("Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkDelegateTask(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteAttachmentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteAttachmentCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -32,15 +33,15 @@ import static org.operaton.bpm.engine.impl.util.StringUtil.hasText;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public class DeleteAttachmentCmd implements Command<Object> {
+public @NullMarked class DeleteAttachmentCmd implements Command<Object> {
   protected String attachmentId;
-  protected String taskId;
+  protected @Nullable String taskId;
 
   public DeleteAttachmentCmd(String attachmentId) {
-    this.attachmentId = attachmentId;
+    this(null, attachmentId);
   }
 
-  public DeleteAttachmentCmd(String taskId, String attachmentId) {
+  public DeleteAttachmentCmd(@Nullable String taskId, String attachmentId) {
     this.taskId = taskId;
     this.attachmentId = attachmentId;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteAuthorizationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteAuthorizationCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -29,8 +30,8 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Daniel Meyer
- *
  */
+@NullMarked
 public class DeleteAuthorizationCmd implements Command<Void> {
 
   protected String authorizationId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteDeploymentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteDeploymentCmd.java
@@ -20,12 +20,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.application.ProcessApplicationReference;
 
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cfg.TransactionLogger;
 import org.operaton.bpm.engine.impl.cfg.TransactionState;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -36,12 +38,14 @@ import org.operaton.bpm.engine.impl.persistence.entity.DeploymentEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.UserOperationLogManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Joram Barrez
  * @author Thorben Lindhauer
  */
+@NullMarked
 public class DeleteDeploymentCmd implements Command<Void> {
 
   private static final TransactionLogger TX_LOG = ProcessEngineLogger.TX_LOGGER;
@@ -76,13 +80,13 @@ public class DeleteDeploymentCmd implements Command<Void> {
       .getDeploymentManager()
       .deleteDeployment(deploymentId, cascade, skipCustomListeners, skipIoMappings);
 
-    ProcessApplicationReference processApplicationReference = Context
-      .getProcessEngineConfiguration()
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    ProcessApplicationReference processApplicationReference = processEngineConfiguration
       .getProcessApplicationManager()
       .getProcessApplicationForDeployment(deploymentId);
 
     DeleteDeploymentFailListener listener = new DeleteDeploymentFailListener(deploymentId, processApplicationReference,
-      Context.getProcessEngineConfiguration().getCommandExecutorTxRequiresNew());
+      processEngineConfiguration.getCommandExecutorTxRequiresNew());
 
     try {
       commandContext.runWithoutAuthorization(new UnregisterProcessApplicationCmd(deploymentId, false));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteFilterCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteFilterCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Sebastian Menski
  */
-public class DeleteFilterCmd implements Command<Void> {
+public @NullMarked class DeleteFilterCmd implements Command<Void> {
   protected String filterId;
 
   public DeleteFilterCmd(String filterId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteGroupCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteGroupCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +27,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class DeleteGroupCmd extends AbstractWritableIdentityServiceCmd<Void>  implements Command<Void> {
+public @NullMarked class DeleteGroupCmd extends AbstractWritableIdentityServiceCmd<Void>  implements Command<Void> {
   String groupId;
 
   public DeleteGroupCmd(String groupId) {
@@ -33,7 +35,7 @@ public class DeleteGroupCmd extends AbstractWritableIdentityServiceCmd<Void>  im
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("groupId", groupId);
 
     IdentityOperationResult operationResult = commandContext

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteGroupIdentityLinkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteGroupIdentityLinkCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 /**
  * @author Danny Gräf
  */
-public class DeleteGroupIdentityLinkCmd extends DeleteIdentityLinkCmd {
+public @NullMarked class DeleteGroupIdentityLinkCmd extends DeleteIdentityLinkCmd {
   public DeleteGroupIdentityLinkCmd(String taskId, String groupId, String type) {
     super(taskId, null, groupId, type);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstanceCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.HistoricCaseInstance;
 
 import org.jspecify.annotations.Nullable;
@@ -28,12 +29,13 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Sebastian Menski
  */
-public class DeleteHistoricCaseInstanceCmd implements Command<Object> {
+public @NullMarked class DeleteHistoricCaseInstanceCmd implements Command<Object> {
   protected String caseInstanceId;
 
   public DeleteHistoricCaseInstanceCmd(String caseInstanceId) {
@@ -49,6 +51,7 @@ public class DeleteHistoricCaseInstanceCmd implements Command<Object> {
       .findHistoricCaseInstance(caseInstanceId);
 
     ensureNotNull("No historic case instance found with id: %s".formatted(caseInstanceId), "instance", instance);
+    requireNonNull(instance);
 
     for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkDeleteHistoricCaseInstance(instance);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstancesBulkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstancesBulkCmd.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -33,7 +34,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureEquals;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 
-public class DeleteHistoricCaseInstancesBulkCmd implements Command<Void> {
+public @NullMarked class DeleteHistoricCaseInstancesBulkCmd implements Command<Void> {
   protected final List<String> caseInstanceIds;
 
   public DeleteHistoricCaseInstancesBulkCmd(List<String> caseInstanceIds) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricProcessInstancesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricProcessInstancesCmd.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -31,6 +32,7 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotContainsNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
@@ -39,7 +41,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Askar Akhmerov
  */
-public class DeleteHistoricProcessInstancesCmd implements Command<Void> {
+public @NullMarked class DeleteHistoricProcessInstancesCmd implements Command<Void> {
 
   protected final List<String> processInstanceIds;
   protected final boolean failIfNotExists;
@@ -69,7 +71,7 @@ public class DeleteHistoricProcessInstancesCmd implements Command<Void> {
 
     List<String> existingIds = new ArrayList<>();
 
-    for (HistoricProcessInstance historicProcessInstance : instances) {
+    for (HistoricProcessInstance historicProcessInstance : requireNonNull(instances)) {
       existingIds.add(historicProcessInstance.getId());
 
       for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricProcessInstancesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricProcessInstancesCmd.java
@@ -59,6 +59,7 @@ public @NullMarked class DeleteHistoricProcessInstancesCmd implements Command<Vo
     // Check if process instance is still running
     List<HistoricProcessInstance> instances = commandContext.runWithoutAuthorization(
         () -> new HistoricProcessInstanceQueryImpl().processInstanceIds(new HashSet<>(processInstanceIds)).list());
+    requireNonNull(instances);
 
     if (failIfNotExists) {
       if (processInstanceIds.size() == 1) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricTaskInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricTaskInstanceCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -26,14 +27,16 @@ import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricTaskInstanceEntity;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricTaskInstanceManager;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Tom Baeyens
  */
-public class DeleteHistoricTaskInstanceCmd implements Command<Object> {
+public @NullMarked class DeleteHistoricTaskInstanceCmd implements Command<Object> {
   protected String taskId;
 
   public DeleteHistoricTaskInstanceCmd(String taskId) {
@@ -44,16 +47,17 @@ public class DeleteHistoricTaskInstanceCmd implements Command<Object> {
   public @Nullable Object execute(CommandContext commandContext) {
     ensureNotNull("taskId", taskId);
 
-    HistoricTaskInstanceEntity task = commandContext.getHistoricTaskInstanceManager().findHistoricTaskInstanceById(taskId);
+    HistoricTaskInstanceManager historicTaskInstanceManager = commandContext.getHistoricTaskInstanceManager();
+    HistoricTaskInstanceEntity task = historicTaskInstanceManager.findHistoricTaskInstanceById(taskId);
 
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
-      checker.checkDeleteHistoricTaskInstance(task);
+    if (task != null) {
+      for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+        checker.checkDeleteHistoricTaskInstance(task);
+      }
+      writeUserOperationLog(commandContext, task);
     }
 
-    writeUserOperationLog(commandContext, task);
-
-    commandContext
-      .getHistoricTaskInstanceManager()
+    historicTaskInstanceManager
       .deleteHistoricTaskInstanceById(taskId);
 
     return null;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricTaskInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricTaskInstanceCmd.java
@@ -30,7 +30,6 @@ import org.operaton.bpm.engine.impl.persistence.entity.HistoricTaskInstanceEntit
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricTaskInstanceManager;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
-import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricVariableInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricVariableInstanceCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.BadUserRequestException;
@@ -35,7 +36,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tobias Metzke
  *
  */
-public class DeleteHistoricVariableInstanceCmd implements Command<Void> {
+public @NullMarked class DeleteHistoricVariableInstanceCmd implements Command<Void> {
   private final String variableInstanceId;
 
   public DeleteHistoricVariableInstanceCmd(String variableInstanceId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricVariableInstancesByProcessInstanceIdCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricVariableInstancesByProcessInstanceIdCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Arrays;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -30,6 +31,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEn
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.repository.ResourceDefinitionEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -37,7 +39,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tobias Metzke
  *
  */
-public class DeleteHistoricVariableInstancesByProcessInstanceIdCmd implements Command<Void> {
+public @NullMarked class DeleteHistoricVariableInstancesByProcessInstanceIdCmd implements Command<Void> {
   private final String processInstanceId;
 
   public DeleteHistoricVariableInstancesByProcessInstanceIdCmd(String processInstanceId) {
@@ -50,6 +52,7 @@ public class DeleteHistoricVariableInstancesByProcessInstanceIdCmd implements Co
 
     HistoricProcessInstanceEntity instance = commandContext.getHistoricProcessInstanceManager().findHistoricProcessInstance(processInstanceId);
     ensureNotNull(NotFoundException.class, "No historic process instance found with id: %s".formatted(processInstanceId), "instance", instance);
+    requireNonNull(instance);
 
     for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkDeleteHistoricVariableInstancesByProcessInstance(instance);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteIdentityLinkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteIdentityLinkCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -26,6 +27,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 import org.operaton.bpm.engine.task.IdentityLinkType;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -33,18 +35,18 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Falko Menge
  * @author Joram Barrez
  */
-public abstract class DeleteIdentityLinkCmd implements Command<Void> {
-  protected String userId;
+public abstract @NullMarked class DeleteIdentityLinkCmd implements Command<Void> {
+  protected @Nullable String userId;
 
-  protected String groupId;
+  protected @Nullable String groupId;
 
   protected String type;
 
   protected String taskId;
 
-  protected TaskEntity task;
+  protected @Nullable TaskEntity task;
 
-  protected DeleteIdentityLinkCmd(String taskId, String userId, String groupId, String type) {
+  protected DeleteIdentityLinkCmd(String taskId, @Nullable String userId, @Nullable String groupId, String type) {
     validateParams(userId, groupId, type, taskId);
     this.taskId = taskId;
     this.userId = userId;
@@ -52,7 +54,7 @@ public abstract class DeleteIdentityLinkCmd implements Command<Void> {
     this.type = type;
   }
 
-  protected void validateParams(String userId, String groupId, String type, String taskId) {
+  protected void validateParams(@Nullable String userId, @Nullable String groupId, String type, String taskId) {
     ensureNotNull("taskId", taskId);
     ensureNotNull("type is required when adding a new task identity link", "type", type);
 
@@ -75,6 +77,7 @@ public abstract class DeleteIdentityLinkCmd implements Command<Void> {
     TaskManager taskManager = commandContext.getTaskManager();
     task = taskManager.findTaskById(taskId);
     ensureNotNull("Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkDeleteIdentityLink(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteIdentityLinkForProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteIdentityLinkForProcessDefinitionCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -29,21 +30,19 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tijs Rademakers
  */
-public class DeleteIdentityLinkForProcessDefinitionCmd implements Command<Object> {
+public @NullMarked class DeleteIdentityLinkForProcessDefinitionCmd implements Command<Object> {
   protected String processDefinitionId;
+  protected @Nullable String userId;
+  protected @Nullable String groupId;
 
-  protected String userId;
-
-  protected String groupId;
-
-  public DeleteIdentityLinkForProcessDefinitionCmd(String processDefinitionId, String userId, String groupId) {
+  public DeleteIdentityLinkForProcessDefinitionCmd(String processDefinitionId, @Nullable String userId, @Nullable String groupId) {
     validateParams(userId, groupId, processDefinitionId);
     this.processDefinitionId = processDefinitionId;
     this.userId = userId;
     this.groupId = groupId;
   }
 
-  protected void validateParams(String userId, String groupId, String processDefinitionId) {
+  protected void validateParams(@Nullable String userId, @Nullable String groupId, String processDefinitionId) {
     ensureNotNull("processDefinitionId", processDefinitionId);
 
     if (userId == null && groupId == null) {
@@ -53,8 +52,7 @@ public class DeleteIdentityLinkForProcessDefinitionCmd implements Command<Object
 
   @Override
   public @Nullable Void execute(CommandContext commandContext) {
-    ProcessDefinitionEntity processDefinition = Context
-      .getCommandContext()
+    ProcessDefinitionEntity processDefinition = commandContext
       .getProcessDefinitionManager()
       .findLatestProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteIdentityLinkForProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteIdentityLinkForProcessDefinitionCmd.java
@@ -20,7 +20,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteJobCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteJobCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -33,7 +34,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Joram Barrez
  */
 
-public class DeleteJobCmd implements Command<Object> {
+public @NullMarked class DeleteJobCmd implements Command<Object> {
   protected String jobId;
 
   public DeleteJobCmd(String jobId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteJobsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteJobsCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.context.Context;
 
 import org.jspecify.annotations.Nullable;
@@ -30,7 +31,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 /**
  * @author Tom Baeyens
  */
-public class DeleteJobsCmd implements Command<Void> {
+public @NullMarked class DeleteJobsCmd implements Command<Void> {
 
   protected List<String> jobIds;
   protected boolean cascade;
@@ -58,8 +59,7 @@ public class DeleteJobsCmd implements Command<Void> {
   public @Nullable Void execute(CommandContext commandContext) {
     JobEntity jobToDelete = null;
     for (String jobId: jobIds) {
-      jobToDelete = Context
-        .getCommandContext()
+      jobToDelete = commandContext
         .getJobManager()
         .findJobById(jobId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteJobsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteJobsCmd.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
-import org.operaton.bpm.engine.impl.context.Context;
 
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.interceptor.Command;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteMembershipCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteMembershipCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +27,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class DeleteMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class DeleteMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   String userId;
   String groupId;
 
@@ -35,7 +37,7 @@ public class DeleteMembershipCmd extends AbstractWritableIdentityServiceCmd<Void
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("userId", userId);
     ensureNotNull("groupId", groupId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteMetricsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteMetricsCmd.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -32,7 +33,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
  * @author Daniel Meyer
  *
  */
-public class DeleteMetricsCmd implements Command<Void> {
+public @NullMarked class DeleteMetricsCmd implements Command<Void> {
   protected @Nullable Date timestamp;
   protected @Nullable String reporter;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessDefinitionsByIdsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessDefinitionsByIdsCmd.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.exception.NotFoundException;
 
 import org.jspecify.annotations.Nullable;
@@ -41,6 +42,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.UserOperationLogManager;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -49,7 +51,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @author Tassilo Weidner
  */
-public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
+public @NullMarked class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
   protected final Set<String> processDefinitionIds;
   protected boolean cascadeToHistory;
   protected boolean cascadeToInstances;
@@ -108,7 +110,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
     ProcessDefinition processDefinition = commandContext.getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
     ensureNotNull(NotFoundException.class, "No process definition found with id '%s'".formatted(processDefinitionId), "processDefinition", processDefinition);
 
-    return processDefinition;
+    return requireNonNull(processDefinition);
   }
 
   protected Set<ProcessDefinitionGroup> groupByKeyAndTenant(List<ProcessDefinition> processDefinitions) {
@@ -137,7 +139,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
     return groups;
   }
 
-  protected ProcessDefinitionEntity findNewLatestProcessDefinition(ProcessDefinitionGroup group) {
+  protected @Nullable ProcessDefinitionEntity findNewLatestProcessDefinition(ProcessDefinitionGroup group) {
     ProcessDefinitionEntity newLatestProcessDefinition = null;
 
     List<ProcessDefinitionEntity> processDefinitions = group.processDefinitions;
@@ -147,7 +149,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
       for (ProcessDefinitionEntity processDefinition : processDefinitions) {
         String previousProcessDefinitionId = processDefinition.getPreviousProcessDefinitionId();
         if (previousProcessDefinitionId != null && !this.processDefinitionIds.contains(previousProcessDefinitionId)) {
-          CommandContext commandContext = Context.getCommandContext();
+          CommandContext commandContext = Context.getRequiredCommandContext();
           ProcessDefinitionManager processDefinitionManager = commandContext.getProcessDefinitionManager();
           newLatestProcessDefinition = processDefinitionManager.findLatestDefinitionById(previousProcessDefinitionId);
           break;
@@ -159,7 +161,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
   }
 
   protected boolean isLatestProcessDefinition(ProcessDefinitionEntity processDefinition) {
-    ProcessDefinitionManager processDefinitionManager = Context.getCommandContext().getProcessDefinitionManager();
+    ProcessDefinitionManager processDefinitionManager = Context.getRequiredCommandContext().getProcessDefinitionManager();
     String key = processDefinition.getKey();
     String tenantId = processDefinition.getTenantId();
     ProcessDefinitionEntity latestProcessDefinition = processDefinitionManager.findLatestDefinitionByKeyAndTenantId(key, tenantId);
@@ -167,7 +169,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
   }
 
   protected void checkAuthorization(ProcessDefinitionGroup group) {
-    List<CommandChecker> commandCheckers = Context.getCommandContext().getProcessEngineConfiguration().getCommandCheckers();
+    List<CommandChecker> commandCheckers = Context.getRequiredProcessEngineConfiguration().getCommandCheckers();
     List<ProcessDefinitionEntity> processDefinitions = group.processDefinitions;
     for (ProcessDefinitionEntity processDefinition : processDefinitions) {
       for (CommandChecker commandChecker : commandCheckers) {
@@ -179,7 +181,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
   protected void deleteProcessDefinitions(ProcessDefinitionGroup group) {
     ProcessDefinitionEntity newLatestProcessDefinition = findNewLatestProcessDefinition(group);
 
-    CommandContext commandContext = Context.getCommandContext();
+    CommandContext commandContext = Context.getRequiredCommandContext();
     UserOperationLogManager userOperationLogManager = commandContext.getOperationLogManager();
     ProcessDefinitionManager definitionManager = commandContext.getProcessDefinitionManager();
 
@@ -196,7 +198,7 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
     }
 
     if (newLatestProcessDefinition != null) {
-      ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
+      ProcessEngineConfigurationImpl configuration = Context.getRequiredProcessEngineConfiguration();
       DeploymentCache deploymentCache = configuration.getDeploymentCache();
       newLatestProcessDefinition = deploymentCache.resolveProcessDefinition(newLatestProcessDefinition);
 
@@ -212,8 +214,8 @@ public class DeleteProcessDefinitionsByIdsCmd implements Command<Void> {
 
   private static class ProcessDefinitionGroup {
 
-    String key;
-    String tenant;
+    @Nullable String key;
+    @Nullable String tenant;
     List<ProcessDefinitionEntity> processDefinitions = new ArrayList<>();
 
     @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessDefinitionsByIdsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessDefinitionsByIdsCmd.java
@@ -149,7 +149,7 @@ public @NullMarked class DeleteProcessDefinitionsByIdsCmd implements Command<Voi
       for (ProcessDefinitionEntity processDefinition : processDefinitions) {
         String previousProcessDefinitionId = processDefinition.getPreviousProcessDefinitionId();
         if (previousProcessDefinitionId != null && !this.processDefinitionIds.contains(previousProcessDefinitionId)) {
-          CommandContext commandContext = Context.getRequiredCommandContext();
+          CommandContext commandContext = Context.getCommandContext();
           ProcessDefinitionManager processDefinitionManager = commandContext.getProcessDefinitionManager();
           newLatestProcessDefinition = processDefinitionManager.findLatestDefinitionById(previousProcessDefinitionId);
           break;
@@ -161,7 +161,7 @@ public @NullMarked class DeleteProcessDefinitionsByIdsCmd implements Command<Voi
   }
 
   protected boolean isLatestProcessDefinition(ProcessDefinitionEntity processDefinition) {
-    ProcessDefinitionManager processDefinitionManager = Context.getRequiredCommandContext().getProcessDefinitionManager();
+    ProcessDefinitionManager processDefinitionManager = Context.getCommandContext().getProcessDefinitionManager();
     String key = processDefinition.getKey();
     String tenantId = processDefinition.getTenantId();
     ProcessDefinitionEntity latestProcessDefinition = processDefinitionManager.findLatestDefinitionByKeyAndTenantId(key, tenantId);
@@ -169,7 +169,7 @@ public @NullMarked class DeleteProcessDefinitionsByIdsCmd implements Command<Voi
   }
 
   protected void checkAuthorization(ProcessDefinitionGroup group) {
-    List<CommandChecker> commandCheckers = Context.getRequiredProcessEngineConfiguration().getCommandCheckers();
+    List<CommandChecker> commandCheckers = Context.getProcessEngineConfiguration().getCommandCheckers();
     List<ProcessDefinitionEntity> processDefinitions = group.processDefinitions;
     for (ProcessDefinitionEntity processDefinition : processDefinitions) {
       for (CommandChecker commandChecker : commandCheckers) {
@@ -181,7 +181,7 @@ public @NullMarked class DeleteProcessDefinitionsByIdsCmd implements Command<Voi
   protected void deleteProcessDefinitions(ProcessDefinitionGroup group) {
     ProcessDefinitionEntity newLatestProcessDefinition = findNewLatestProcessDefinition(group);
 
-    CommandContext commandContext = Context.getRequiredCommandContext();
+    CommandContext commandContext = Context.getCommandContext();
     UserOperationLogManager userOperationLogManager = commandContext.getOperationLogManager();
     ProcessDefinitionManager definitionManager = commandContext.getProcessDefinitionManager();
 
@@ -198,7 +198,7 @@ public @NullMarked class DeleteProcessDefinitionsByIdsCmd implements Command<Voi
     }
 
     if (newLatestProcessDefinition != null) {
-      ProcessEngineConfigurationImpl configuration = Context.getRequiredProcessEngineConfiguration();
+      ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
       DeploymentCache deploymentCache = configuration.getDeploymentCache();
       newLatestProcessDefinition = deploymentCache.resolveProcessDefinition(newLatestProcessDefinition);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessDefinitionsByKeyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessDefinitionsByKeyCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.exception.NotFoundException;
 
 import org.jspecify.annotations.Nullable;
@@ -32,7 +33,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @author Tassilo Weidner
  */
-public class DeleteProcessDefinitionsByKeyCmd extends AbstractDeleteProcessDefinitionCmd {
+public @NullMarked class DeleteProcessDefinitionsByKeyCmd extends AbstractDeleteProcessDefinitionCmd {
   private final String processDefinitionKey;
   private final String tenantId;
   private final boolean isTenantIdSet;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessInstanceCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -24,7 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Joram Barrez
  */
-public class DeleteProcessInstanceCmd extends AbstractDeleteProcessInstanceCmd implements Command<Void> {
+public @NullMarked class DeleteProcessInstanceCmd extends AbstractDeleteProcessInstanceCmd implements Command<Void> {
   protected String processInstanceId;
 
   public DeleteProcessInstanceCmd(String processInstanceId, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessInstanceCommentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessInstanceCommentCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -31,6 +32,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.task.Comment;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -38,17 +40,17 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * of a given processInstanceId
  */
 
-public class DeleteProcessInstanceCommentCmd implements Command<Object> {
-  protected String commentId;
+public @NullMarked class DeleteProcessInstanceCommentCmd implements Command<Object> {
+  protected @Nullable String commentId;
   protected String processInstanceId;
 
-  public DeleteProcessInstanceCommentCmd(String processInstanceId, String commentId) {
+  public DeleteProcessInstanceCommentCmd(String processInstanceId, @Nullable String commentId) {
     this.processInstanceId = processInstanceId;
     this.commentId = commentId;
   }
 
   public DeleteProcessInstanceCommentCmd(String processInstanceId) {
-    this.processInstanceId = processInstanceId;
+    this(processInstanceId, null);
   }
 
   @Override
@@ -74,7 +76,7 @@ public class DeleteProcessInstanceCommentCmd implements Command<Object> {
       }
     }
 
-    logOperation(processInstance, commandContext);
+    logOperation(requireNonNull(processInstance), commandContext);
 
     return null;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessInstancesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteProcessInstancesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 
 import org.jspecify.annotations.Nullable;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Joram Barrez
  */
-public class DeleteProcessInstancesCmd extends AbstractDeleteProcessInstanceCmd implements Command<Void> {
+public @NullMarked class DeleteProcessInstancesCmd extends AbstractDeleteProcessInstanceCmd implements Command<Void> {
   protected List<String> processInstanceIds;
 
   public DeleteProcessInstancesCmd(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeletePropertyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeletePropertyCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collections;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -30,15 +31,11 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyManager;
 
 /**
  * @author Daniel Meyer
- *
  */
-public class DeletePropertyCmd implements Command<Object> {
+public @NullMarked class DeletePropertyCmd implements Command<Object> {
 
   protected String name;
 
-  /**
-   * @param name
-   */
   public DeletePropertyCmd(String name) {
     this.name = name;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskCmd.java
@@ -18,12 +18,12 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -32,19 +32,22 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 /**
  * @author Joram Barrez
  */
+@NullMarked
 public class DeleteTaskCmd implements Command<Void> {
-  protected String taskId;
-  protected Collection<String> taskIds;
+  protected @Nullable String taskId;
+  protected @Nullable Collection<String> taskIds;
   protected boolean cascade;
-  protected String deleteReason;
+  protected @Nullable String deleteReason;
 
-  public DeleteTaskCmd(String taskId, String deleteReason, boolean cascade) {
+  public DeleteTaskCmd(@Nullable String taskId, @Nullable String deleteReason, boolean cascade) {
     this.taskId = taskId;
+    this.taskIds = null;
     this.cascade = cascade;
     this.deleteReason = deleteReason;
   }
 
-  public DeleteTaskCmd(Collection<String> taskIds, String deleteReason, boolean cascade) {
+  public DeleteTaskCmd(@Nullable Collection<String> taskIds, @Nullable String deleteReason, boolean cascade) {
+    this.taskId = null;
     this.taskIds = taskIds;
     this.cascade = cascade;
     this.deleteReason = deleteReason;
@@ -80,8 +83,7 @@ public class DeleteTaskCmd implements Command<Void> {
       String reason = deleteReason == null || deleteReason.isEmpty() ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
       task.delete(reason, cascade);
     } else if (cascade) {
-      Context
-        .getCommandContext()
+      commandContext
         .getHistoricTaskInstanceManager()
         .deleteHistoricTaskInstanceById(taskId);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskCommentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskCommentCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -30,24 +31,24 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.task.Comment;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * Command to delete a comment by a given commentId and taskId or to delete all comments
  * of a given task Id
  */
-
-public class DeleteTaskCommentCmd implements Command<Object> {
-  protected String commentId;
+public @NullMarked class DeleteTaskCommentCmd implements Command<Object> {
+  protected @Nullable String commentId;
   protected String taskId;
 
-  public DeleteTaskCommentCmd(String taskId, String commentId) {
+  public DeleteTaskCommentCmd(String taskId, @Nullable String commentId) {
     this.taskId = taskId;
     this.commentId = commentId;
   }
 
   public DeleteTaskCommentCmd(String taskId) {
-    this.taskId = taskId;
+    this(taskId, null);
   }
 
   @Override
@@ -56,6 +57,7 @@ public class DeleteTaskCommentCmd implements Command<Object> {
 
     TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
     ensureNotNull("No task exists with taskId: %s".formatted(taskId), "task", task);
+    requireNonNull(task);
     checkTaskWork(task, commandContext);
 
     if (commentId != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskMetricsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskMetricsCmd.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -28,7 +29,7 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
-public class DeleteTaskMetricsCmd implements Command<Void> {
+public @NullMarked class DeleteTaskMetricsCmd implements Command<Void> {
   protected Date timestamp;
 
   public DeleteTaskMetricsCmd(Date timestamp) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTenantCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTenantCmd.java
@@ -16,13 +16,16 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class DeleteTenantCmd extends AbstractWritableIdentityServiceCmd<Void>  implements Command<Void> {
+
+public @NullMarked class DeleteTenantCmd extends AbstractWritableIdentityServiceCmd<Void>  implements Command<Void> {
   protected final String tenantId;
 
   public DeleteTenantCmd(String tenantId) {
@@ -32,7 +35,7 @@ public class DeleteTenantCmd extends AbstractWritableIdentityServiceCmd<Void>  i
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     IdentityOperationResult operationResult = commandContext
       .getWritableIdentityProvider()
       .deleteTenant(tenantId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTenantGroupMembershipCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTenantGroupMembershipCmd.java
@@ -16,13 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class DeleteTenantGroupMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class DeleteTenantGroupMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected final String tenantId;
   protected final String groupId;
 
@@ -32,7 +34,7 @@ public class DeleteTenantGroupMembershipCmd extends AbstractWritableIdentityServ
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("tenantId", tenantId);
     ensureNotNull("groupId", groupId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTenantUserMembershipCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTenantUserMembershipCmd.java
@@ -16,13 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class DeleteTenantUserMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class DeleteTenantUserMembershipCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected final String tenantId;
   protected final String userId;
 
@@ -32,7 +34,7 @@ public class DeleteTenantUserMembershipCmd extends AbstractWritableIdentityServi
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("tenantId", tenantId);
     ensureNotNull("userId", userId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +27,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class DeleteUserCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class DeleteUserCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   String userId;
 
   public DeleteUserCmd(String userId) {
@@ -33,7 +35,7 @@ public class DeleteUserCmd extends AbstractWritableIdentityServiceCmd<Void> impl
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("userId", userId);
 
     // delete user picture

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserIdentityLinkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserIdentityLinkCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 /**
  * @author Danny Gräf
  */
-public class DeleteUserIdentityLinkCmd extends DeleteIdentityLinkCmd {
+public @NullMarked class DeleteUserIdentityLinkCmd extends DeleteIdentityLinkCmd {
   public DeleteUserIdentityLinkCmd(String taskId, String userId, String type) {
     super(taskId, userId, null, type);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserInfoCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserInfoCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -24,7 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Tom Baeyens
  */
-public class DeleteUserInfoCmd implements Command<Object> {
+public @NullMarked class DeleteUserInfoCmd implements Command<Object> {
   protected String userId;
   protected String key;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserOperationLogEntryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserOperationLogEntryCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.exception.NotValidException;
@@ -30,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Thorben Lindhauer
  *
  */
-public class DeleteUserOperationLogEntryCmd implements Command<Void> {
+public @NullMarked class DeleteUserOperationLogEntryCmd implements Command<Void> {
 
   protected String entryId;
 
@@ -46,8 +47,10 @@ public class DeleteUserOperationLogEntryCmd implements Command<Void> {
       .getOperationLogManager()
       .findOperationLogById(entryId);
 
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
-      checker.checkDeleteUserOperationLog(entry);
+    if (entry != null) {
+      for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+        checker.checkDeleteUserOperationLog(entry);
+      }
     }
 
     commandContext.getOperationLogManager().deleteOperationLogEntryById(entryId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserPictureCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteUserPictureCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -28,7 +29,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Daniel Meyer
  *
  */
-public class DeleteUserPictureCmd implements Command<Void> {
+public @NullMarked class DeleteUserPictureCmd implements Command<Void> {
 
   protected String userId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeployCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeployCmd.java
@@ -292,11 +292,11 @@ public @NullMarked class DeployCmd implements Command<DeploymentWithDefinitions>
     }
   }
 
-  protected ProcessApplicationRegistration registerProcessApplication(CommandContext commandContext,
+  protected @Nullable ProcessApplicationRegistration registerProcessApplication(CommandContext commandContext,
       DeploymentEntity deploymentToRegister,
       CandidateDeployment candidateDeployment, Collection<Resource> ignoredResources) {
 
-    ProcessApplicationDeploymentBuilderImpl appDeploymentBuilder = (ProcessApplicationDeploymentBuilderImpl) deploymentBuilder;
+    ProcessApplicationDeploymentBuilderImpl appDeploymentBuilder = (ProcessApplicationDeploymentBuilderImpl) requireNonNull(deploymentBuilder);
     final ProcessApplicationReference appReference = appDeploymentBuilder.getProcessApplicationReference();
 
     // build set of deployment ids this process app should be registered for:

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeployCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeployCmd.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.application.ProcessApplicationRegistration;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -69,6 +71,7 @@ import org.operaton.bpm.model.cmmn.Cmmn;
 import org.operaton.bpm.model.cmmn.CmmnModelInstance;
 import org.operaton.bpm.model.cmmn.instance.Case;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.ResourceSuffixes.BPMN_RESOURCE_SUFFIXES;
 import static org.operaton.bpm.engine.impl.ResourceSuffixes.CMMN_RESOURCE_SUFFIXES;
 
@@ -78,12 +81,12 @@ import static org.operaton.bpm.engine.impl.ResourceSuffixes.CMMN_RESOURCE_SUFFIX
  * @author Thorben Lindhauer
  * @author Daniel Meyer
  */
-public class DeployCmd implements Command<DeploymentWithDefinitions> {
+public @NullMarked class DeployCmd implements Command<DeploymentWithDefinitions> {
   private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
   private static final TransactionLogger TX_LOG = ProcessEngineLogger.TX_LOGGER;
 
   protected DeploymentBuilderImpl deploymentBuilder;
-  protected DeploymentHandler deploymentHandler;
+  protected @Nullable DeploymentHandler deploymentHandler;
 
   public DeployCmd(DeploymentBuilderImpl deploymentBuilder) {
     this.deploymentBuilder = deploymentBuilder;
@@ -111,6 +114,7 @@ public class DeployCmd implements Command<DeploymentWithDefinitions> {
     deploymentHandler = commandContext.getProcessEngineConfiguration()
         .getDeploymentHandlerFactory()
         .buildDeploymentHandler(processEngine);
+    requireNonNull(deploymentHandler);
 
     Set<String> deploymentIds = getAllDeploymentIds(deploymentBuilder);
     if (!deploymentIds.isEmpty()) {
@@ -178,6 +182,7 @@ public class DeployCmd implements Command<DeploymentWithDefinitions> {
       return deploymentToRegister;
     });
 
+    requireNonNull(deployment, "Deployment should not be null");
     createUserOperationLog(deploymentBuilder, deployment, commandContext);
 
     return deployment;
@@ -368,7 +373,7 @@ public class DeployCmd implements Command<DeploymentWithDefinitions> {
     return deployment;
   }
 
-  protected void setDeploymentName(String deploymentId, DeploymentBuilderImpl deploymentBuilder, CommandContext commandContext) {
+  protected void setDeploymentName(@Nullable String deploymentId, DeploymentBuilderImpl deploymentBuilder, CommandContext commandContext) {
     if (deploymentId != null && !deploymentId.isEmpty()) {
       DeploymentManager deploymentManager = commandContext.getDeploymentManager();
       DeploymentEntity deployment = deploymentManager.findDeploymentById(deploymentId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DetermineHistoryLevelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DetermineHistoryLevelCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 
 import org.jspecify.annotations.Nullable;
@@ -29,7 +30,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * Read the already configured historyLevel from DB and map to given list of total levels.
  */
-public class DetermineHistoryLevelCmd implements Command<HistoryLevel> {
+public @NullMarked class DetermineHistoryLevelCmd implements Command<HistoryLevel> {
 
   private final List<HistoryLevel> historyLevels;
 
@@ -63,6 +64,5 @@ public class DetermineHistoryLevelCmd implements Command<HistoryLevel> {
       return null;
     }
   }
-
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/EvaluateStartConditionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/EvaluateStartConditionCmd.java
@@ -20,6 +20,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ConditionEvaluationBuilderImpl;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -38,7 +39,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
  * @author Yana Vasileva
  *
  */
-public class EvaluateStartConditionCmd implements Command<List<ProcessInstance>> {
+public @NullMarked class EvaluateStartConditionCmd implements Command<List<ProcessInstance>> {
 
   protected ConditionEvaluationBuilderImpl builder;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterCountCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterCountCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -24,7 +25,7 @@ import org.operaton.bpm.engine.query.Query;
 /**
  * @author Sebastian Menski
  */
-public class ExecuteFilterCountCmd extends AbstractExecuteFilterCmd implements Command<Long> {
+public @NullMarked class ExecuteFilterCountCmd extends AbstractExecuteFilterCmd implements Command<Long> {
   public ExecuteFilterCountCmd(String filterId) {
     super(filterId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterListCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterListCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.AbstractQuery;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.query.Query;
 /**
  * @author Sebastian Menski
  */
-public class ExecuteFilterListCmd extends AbstractExecuteFilterCmd implements Command<List<?>> {
+public @NullMarked class ExecuteFilterListCmd extends AbstractExecuteFilterCmd implements Command<List<?>> {
   public ExecuteFilterListCmd(String filterId) {
     super(filterId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterListPageCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterListPageCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.AbstractQuery;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.query.Query;
 /**
  * @author Sebastian Menski
  */
-public class ExecuteFilterListPageCmd extends AbstractExecuteFilterCmd implements Command<List<?>> {
+public @NullMarked class ExecuteFilterListPageCmd extends AbstractExecuteFilterCmd implements Command<List<?>> {
   protected int firstResult;
   protected int maxResults;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterSingleResultCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteFilterSingleResultCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.query.Query;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.query.Query;
 /**
  * @author Sebastian Menski
  */
-public class ExecuteFilterSingleResultCmd extends AbstractExecuteFilterCmd implements Command<Object> {
+public @NullMarked class ExecuteFilterSingleResultCmd extends AbstractExecuteFilterCmd implements Command<Object> {
   public ExecuteFilterSingleResultCmd(String filterId) {
     super(filterId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteJobsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteJobsCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collections;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.IdentityService;
 
 import org.jspecify.annotations.Nullable;
@@ -28,19 +29,21 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.engine.impl.interceptor.ProcessDataContext;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutorContext;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutorLogger;
 import org.operaton.bpm.engine.impl.jobexecutor.JobFailureCollector;
 import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Tom Baeyens
  * @author Daniel Meyer
  */
-public class ExecuteJobsCmd implements Command<Void> {
+public @NullMarked class ExecuteJobsCmd implements Command<Void> {
   private static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
 
   protected String jobId;
@@ -58,7 +61,7 @@ public class ExecuteJobsCmd implements Command<Void> {
 
     final JobEntity job = commandContext.getDbEntityManager().selectById(JobEntity.class, jobId);
 
-    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
     final IdentityService identityService = processEngineConfiguration.getIdentityService();
 
     final JobExecutorContext jobExecutorContext = Context.getJobExecutorContext();
@@ -108,8 +111,8 @@ public class ExecuteJobsCmd implements Command<Void> {
       job.execute(commandContext);
 
     } catch (Exception t) {
-      String failedActivityId = Context.getCommandInvocationContext()
-          .getProcessDataContext()
+      ProcessDataContext processDataContext = requireNonNull(Context.getCommandInvocationContext()).getProcessDataContext();
+      String failedActivityId = processDataContext
           .getLatestActivityId();
 
       jobFailureCollector.setFailedActivityId(failedActivityId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteJobsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExecuteJobsCmd.java
@@ -61,7 +61,7 @@ public @NullMarked class ExecuteJobsCmd implements Command<Void> {
 
     final JobEntity job = commandContext.getDbEntityManager().selectById(JobEntity.class, jobId);
 
-    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
+    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     final IdentityService identityService = processEngineConfiguration.getIdentityService();
 
     final JobExecutorContext jobExecutorContext = Context.getJobExecutorContext();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExtendLockOnExternalTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExtendLockOnExternalTaskCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  * @author Anna.Pazola
  *
  */
-public class ExtendLockOnExternalTaskCmd extends HandleExternalTaskCmd {
+public @NullMarked class ExtendLockOnExternalTaskCmd extends HandleExternalTaskCmd {
 
   private final long newLockTime;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExternalTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ExternalTaskCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.exception.NotFoundException;
 
 import org.jspecify.annotations.Nullable;
@@ -38,7 +39,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public abstract class ExternalTaskCmd implements Command<Void> {
+public abstract @NullMarked class ExternalTaskCmd implements Command<Void> {
 
   /**
    * The corresponding external task id.
@@ -70,7 +71,7 @@ public abstract class ExternalTaskCmd implements Command<Void> {
     return null;
   }
 
-  protected void writeUserOperationLog(CommandContext commandContext, ExternalTaskEntity externalTask, String operationType, List<PropertyChange> propertyChanges) {
+  protected void writeUserOperationLog(CommandContext commandContext, ExternalTaskEntity externalTask, @Nullable String operationType, @Nullable List<PropertyChange> propertyChanges) {
     if (operationType != null) {
       commandContext.getOperationLogManager().logExternalTaskOperation(operationType, externalTask,
           propertyChanges == null || propertyChanges.isEmpty() ?
@@ -78,7 +79,7 @@ public abstract class ExternalTaskCmd implements Command<Void> {
     }
   }
 
-  protected String getUserOperationLogOperationType() {
+  protected @Nullable String getUserOperationLogOperationType() {
     return null;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FetchExternalTasksCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FetchExternalTasksCmd.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.QueryOrderingProperty;
@@ -47,7 +48,7 @@ import static org.operaton.bpm.engine.impl.ExternalTaskQueryProperty.PRIORITY;
  * @author Christopher Zell
  *
  */
-public class FetchExternalTasksCmd implements Command<List<LockedExternalTask>> {
+public @NullMarked class FetchExternalTasksCmd implements Command<List<LockedExternalTask>> {
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FindActiveActivityIdsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FindActiveActivityIdsCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -29,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class FindActiveActivityIdsCmd implements Command<List<String>> {
+public @NullMarked class FindActiveActivityIdsCmd implements Command<List<String>> {
   protected String executionId;
 
   public FindActiveActivityIdsCmd(String executionId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FindActiveActivityIdsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FindActiveActivityIdsCmd.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -45,6 +46,7 @@ public @NullMarked class FindActiveActivityIdsCmd implements Command<List<String
     ExecutionManager executionManager = commandContext.getExecutionManager();
     ExecutionEntity execution = executionManager.findExecutionById(executionId);
     ensureNotNull("execution %s doesn't exist".formatted(executionId), "execution", execution);
+    requireNonNull(execution);
 
     checkGetActivityIds(execution, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FindHistoryCleanupJobsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/FindHistoryCleanupJobsCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandler;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.runtime.Job;
 /**
  * @author Svetlana Dorokhova
  */
-public class FindHistoryCleanupJobsCmd implements Command<List<Job>> {
+public @NullMarked class FindHistoryCleanupJobsCmd implements Command<List<Job>> {
   @Override
   public List<Job> execute(CommandContext commandContext) {
     return commandContext.getJobManager().findJobsByHandlerType(HistoryCleanupJobHandler.TYPE);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetActivityInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetActivityInstanceCmd.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 
 import org.jspecify.annotations.Nullable;
@@ -66,7 +67,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Thorben Lindhauer
  *
  */
-public class GetActivityInstanceCmd implements Command<ActivityInstance> {
+public @NullMarked class GetActivityInstanceCmd implements Command<ActivityInstance> {
   private static final ExecutionIdComparator EXECUTION_ID_COMPARATOR = new ExecutionIdComparator();
 
   protected String processInstanceId;
@@ -207,7 +208,7 @@ public class GetActivityInstanceCmd implements Command<ActivityInstance> {
   }
 
   protected ActivityInstanceImpl createActivityInstance(PvmExecutionImpl scopeExecution, ScopeImpl scope,
-      String activityInstanceId, String parentActivityInstanceId,
+      String activityInstanceId, @Nullable String parentActivityInstanceId,
       Map<String, List<Incident>> incidentsByExecution) {
     ActivityInstanceImpl actInst = new ActivityInstanceImpl();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetAttachmentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetAttachmentCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.AttachmentEntity;
@@ -24,7 +26,7 @@ import org.operaton.bpm.engine.task.Attachment;
 /**
  * @author Tom Baeyens
  */
-public class GetAttachmentCmd implements Command<Attachment> {
+public @NullMarked class GetAttachmentCmd implements Command<Attachment> {
   protected String attachmentId;
 
   public GetAttachmentCmd(String attachmentId) {
@@ -32,10 +34,9 @@ public class GetAttachmentCmd implements Command<Attachment> {
   }
 
   @Override
-  public Attachment execute(CommandContext commandContext) {
+  public @Nullable Attachment execute(CommandContext commandContext) {
     return commandContext
       .getDbEntityManager()
       .selectById(AttachmentEntity.class, attachmentId);
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetAttachmentContentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetAttachmentContentCmd.java
@@ -41,6 +41,9 @@ public class GetAttachmentContentCmd implements Command<InputStream> {
   public @Nullable InputStream execute(CommandContext commandContext) {
     DbEntityManager dbEntityManger = commandContext.getDbEntityManager();
     AttachmentEntity attachment = dbEntityManger.selectById(AttachmentEntity.class, attachmentId);
+    if (attachment==null) {
+      return null;
+    }
 
     String contentId = attachment.getContentId();
     if (contentId==null) {
@@ -48,6 +51,9 @@ public class GetAttachmentContentCmd implements Command<InputStream> {
     }
 
     ByteArrayEntity byteArray = dbEntityManger.selectById(ByteArrayEntity.class, contentId);
+    if (byteArray==null) {
+      return null;
+    }
     byte[] bytes = byteArray.getBytes();
 
     return new ByteArrayInputStream(bytes);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeployedProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeployedProcessDefinitionCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.ProcessInstantiationBuilderImpl;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -25,12 +27,12 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureOnlyOneNotNull;
 
-public class GetDeployedProcessDefinitionCmd implements Command<ProcessDefinitionEntity> {
+public @NullMarked class GetDeployedProcessDefinitionCmd implements Command<ProcessDefinitionEntity> {
 
   protected String processDefinitionId;
-  protected String processDefinitionKey;
+  protected @Nullable String processDefinitionKey;
 
-  protected String processDefinitionTenantId;
+  protected @Nullable String processDefinitionTenantId;
   protected boolean isTenantIdSet;
 
   protected final boolean checkReadPermission;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeployedStartFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeployedStartFormCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.FormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -30,7 +32,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  * @author Anna Pazola
  *
  */
-public class GetDeployedStartFormCmd extends AbstractGetDeployedFormCmd {
+public @NullMarked class GetDeployedStartFormCmd extends AbstractGetDeployedFormCmd {
 
   protected String processDefinitionId;
 
@@ -40,16 +42,16 @@ public class GetDeployedStartFormCmd extends AbstractGetDeployedFormCmd {
   }
 
   @Override
-  protected FormData getFormData() {
-    return commandContext.runWithoutAuthorization(new GetStartFormCmd(processDefinitionId));
+  protected @Nullable FormData getFormData() {
+    return getCommandContext().runWithoutAuthorization(new GetStartFormCmd(processDefinitionId));
   }
 
   @Override
   protected void checkAuthorization() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = getCommandContext().getProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
-    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    for (CommandChecker checker : getCommandContext().getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkReadProcessDefinition(processDefinition);
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeployedStartFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeployedStartFormCmd.java
@@ -22,7 +22,6 @@ import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.FormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentBpmnModelInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentBpmnModelInstanceCmd.java
@@ -16,8 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import org.jspecify.annotations.NonNull;
-
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -36,10 +35,10 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @author Sebastian Menski
  */
-public class GetDeploymentBpmnModelInstanceCmd implements Command<BpmnModelInstance> {
+public @NullMarked class GetDeploymentBpmnModelInstanceCmd implements Command<BpmnModelInstance> {
   protected String processDefinitionId;
 
-  public GetDeploymentBpmnModelInstanceCmd(@NonNull String processDefinitionId) {
+  public GetDeploymentBpmnModelInstanceCmd(String processDefinitionId) {
     if (processDefinitionId.isEmpty()) {
       throw new ProcessEngineException("The process definition id is mandatory, but '%s' has been provided.".formatted(processDefinitionId));
     }
@@ -48,7 +47,7 @@ public class GetDeploymentBpmnModelInstanceCmd implements Command<BpmnModelInsta
 
   @Override
   public BpmnModelInstance execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl configuration = Context.getRequiredProcessEngineConfiguration();
     final DeploymentCache deploymentCache = configuration.getDeploymentCache();
 
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentBpmnModelInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentBpmnModelInstanceCmd.java
@@ -47,7 +47,7 @@ public @NullMarked class GetDeploymentBpmnModelInstanceCmd implements Command<Bp
 
   @Override
   public BpmnModelInstance execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl configuration = Context.getRequiredProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
     final DeploymentCache deploymentCache = configuration.getDeploymentCache();
 
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -18,9 +18,9 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.ProcessEngineException;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -34,10 +34,10 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
  *
  * @author Falko Menge
  */
-public class GetDeploymentProcessDiagramCmd implements Command<InputStream> {
+public @NullMarked class GetDeploymentProcessDiagramCmd implements Command<InputStream> {
   protected String processDefinitionId;
 
-  public GetDeploymentProcessDiagramCmd(@NonNull String processDefinitionId) {
+  public GetDeploymentProcessDiagramCmd(String processDefinitionId) {
     if (processDefinitionId.isEmpty()) {
       throw new ProcessEngineException("The process definition id is mandatory, but '%s' has been provided.".formatted(processDefinitionId));
     }
@@ -47,7 +47,7 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream> {
   @Override
   public @Nullable InputStream execute(final CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-            .getProcessEngineConfiguration()
+            .getRequiredProcessEngineConfiguration()
             .getDeploymentCache()
             .findDeployedProcessDefinitionById(processDefinitionId);
 
@@ -58,7 +58,7 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream> {
     final String deploymentId = processDefinition.getDeploymentId();
     final String resourceName = processDefinition.getDiagramResourceName();
 
-    if (resourceName == null ) {
+    if (deploymentId == null || resourceName == null ) {
       return null;
     } else {
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -47,7 +47,7 @@ public @NullMarked class GetDeploymentProcessDiagramCmd implements Command<Input
   @Override
   public @Nullable InputStream execute(final CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-            .getRequiredProcessEngineConfiguration()
+            .getProcessEngineConfiguration()
             .getDeploymentCache()
             .findDeployedProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 
 import org.jspecify.annotations.NonNull;
@@ -37,10 +39,10 @@ import org.operaton.bpm.engine.repository.DiagramLayout;
  * </p>
  * @author Falko Menge
  */
-public class GetDeploymentProcessDiagramLayoutCmd implements Command<DiagramLayout> {
+public @NullMarked class GetDeploymentProcessDiagramLayoutCmd implements Command<DiagramLayout> {
   protected String processDefinitionId;
 
-  public GetDeploymentProcessDiagramLayoutCmd(@NonNull String processDefinitionId) {
+  public GetDeploymentProcessDiagramLayoutCmd(String processDefinitionId) {
     if (processDefinitionId.isEmpty()) {
       throw new ProcessEngineException("The process definition id is mandatory, but '%s' has been provided.".formatted(processDefinitionId));
     }
@@ -48,9 +50,9 @@ public class GetDeploymentProcessDiagramLayoutCmd implements Command<DiagramLayo
   }
 
   @Override
-  public DiagramLayout execute(final CommandContext commandContext) {
+  public @Nullable DiagramLayout execute(final CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-        .getProcessEngineConfiguration()
+        .getRequiredProcessEngineConfiguration()
         .getDeploymentCache()
         .findDeployedProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
@@ -52,7 +52,7 @@ public @NullMarked class GetDeploymentProcessDiagramLayoutCmd implements Command
   @Override
   public @Nullable DiagramLayout execute(final CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-        .getRequiredProcessEngineConfiguration()
+        .getProcessEngineConfiguration()
         .getDeploymentCache()
         .findDeployedProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 
-import org.jspecify.annotations.NonNull;
 import org.operaton.bpm.engine.impl.bpmn.diagram.ProcessDiagramLayoutFactory;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 
 import org.jspecify.annotations.NonNull;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -33,10 +35,10 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
  *
  * @author Falko Menge
  */
-public class GetDeploymentProcessModelCmd implements Command<InputStream> {
+public @NullMarked class GetDeploymentProcessModelCmd implements Command<InputStream> {
   protected String processDefinitionId;
 
-  public GetDeploymentProcessModelCmd(@NonNull String processDefinitionId) {
+  public GetDeploymentProcessModelCmd(String processDefinitionId) {
     if (processDefinitionId.isEmpty()) {
       throw new ProcessEngineException("The process definition id is mandatory, but '%s' has been provided.".formatted(processDefinitionId));
     }
@@ -44,9 +46,9 @@ public class GetDeploymentProcessModelCmd implements Command<InputStream> {
   }
 
   @Override
-  public InputStream execute(final CommandContext commandContext) {
+  public @Nullable InputStream execute(final CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-            .getProcessEngineConfiguration()
+            .getRequiredProcessEngineConfiguration()
             .getDeploymentCache()
             .findDeployedProcessDefinitionById(processDefinitionId);
 
@@ -56,6 +58,10 @@ public class GetDeploymentProcessModelCmd implements Command<InputStream> {
 
     final String deploymentId = processDefinition.getDeploymentId();
     final String resourceName = processDefinition.getResourceName();
+
+    if (deploymentId == null || resourceName == null) {
+      return null;
+    }
 
     return commandContext.runWithoutAuthorization(
         new GetDeploymentResourceCmd(deploymentId, resourceName));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
@@ -48,7 +48,7 @@ public @NullMarked class GetDeploymentProcessModelCmd implements Command<InputSt
   @Override
   public @Nullable InputStream execute(final CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-            .getRequiredProcessEngineConfiguration()
+            .getProcessEngineConfiguration()
             .getDeploymentCache()
             .findDeployedProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
@@ -18,8 +18,6 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 
-import org.jspecify.annotations.NonNull;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.exception.DeploymentResourceNotFoundException;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -30,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Joram Barrez
  */
-public class GetDeploymentResourceCmd implements Command<InputStream> {
+public @NullMarked class GetDeploymentResourceCmd implements Command<InputStream> {
   protected String deploymentId;
   protected String resourceName;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceForIdCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceForIdCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -29,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author kristin.polenz@camunda.com
  */
-public class GetDeploymentResourceForIdCmd implements Command<InputStream> {
+public @NullMarked class GetDeploymentResourceForIdCmd implements Command<InputStream> {
   protected String deploymentId;
   protected String resourceId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceNamesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceNamesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -29,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Joram Barrez
  */
 @SuppressWarnings("rawtypes")
-public class GetDeploymentResourceNamesCmd implements Command<List> {
+public @NullMarked class GetDeploymentResourceNamesCmd implements Command<List> {
   protected String deploymentId;
 
   public GetDeploymentResourceNamesCmd(String deploymentId) {
@@ -45,7 +46,7 @@ public class GetDeploymentResourceNamesCmd implements Command<List> {
     }
 
     return Context
-      .getCommandContext()
+      .getRequiredCommandContext()
       .getDeploymentManager()
       .getDeploymentResourceNames(deploymentId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceNamesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourceNamesCmd.java
@@ -46,7 +46,7 @@ public @NullMarked class GetDeploymentResourceNamesCmd implements Command<List> 
     }
 
     return Context
-      .getRequiredCommandContext()
+      .getCommandContext()
       .getDeploymentManager()
       .getDeploymentResourceNames(deploymentId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourcesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourcesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -29,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author kristin.polenz@camunda.com
  */
 @SuppressWarnings("rawtypes")
-public class GetDeploymentResourcesCmd implements Command<List> {
+public @NullMarked class GetDeploymentResourcesCmd implements Command<List> {
   protected String deploymentId;
 
   public GetDeploymentResourcesCmd(String deploymentId) {
@@ -45,7 +46,7 @@ public class GetDeploymentResourcesCmd implements Command<List> {
     }
 
     return Context
-      .getCommandContext()
+      .getRequiredCommandContext()
       .getResourceManager()
       .findResourcesByDeploymentId(deploymentId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourcesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentResourcesCmd.java
@@ -46,7 +46,7 @@ public @NullMarked class GetDeploymentResourcesCmd implements Command<List> {
     }
 
     return Context
-      .getRequiredCommandContext()
+      .getCommandContext()
       .getResourceManager()
       .findResourcesByDeploymentId(deploymentId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -28,7 +29,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class GetExecutionVariableCmd implements Command<Object> {
+public @NullMarked class GetExecutionVariableCmd implements Command<Object> {
   protected String executionId;
   protected String variableName;
   protected boolean isLocal;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableCmd.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -50,6 +51,7 @@ public @NullMarked class GetExecutionVariableCmd implements Command<Object> {
       .findExecutionById(executionId);
 
     ensureNotNull("execution %s doesn't exist".formatted(executionId), "execution", execution);
+    requireNonNull(execution);
 
     checkGetExecutionVariable(execution, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableTypedCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableTypedCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -30,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Daniel Meyer
  *
  */
-public class GetExecutionVariableTypedCmd<T extends TypedValue> implements Command<T> {
+public @NullMarked class GetExecutionVariableTypedCmd<T extends TypedValue> implements Command<T> {
   protected String executionId;
   protected String variableName;
   protected boolean isLocal;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableTypedCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariableTypedCmd.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -54,6 +55,7 @@ public @NullMarked class GetExecutionVariableTypedCmd<T extends TypedValue> impl
       .findExecutionById(executionId);
 
     ensureNotNull("execution %s doesn't exist".formatted(executionId), "execution", execution);
+    requireNonNull(execution);
 
     checkGetExecutionVariableTyped(execution, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariablesCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -31,13 +33,13 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tom Baeyens
  * @author Daniel Meyer
  */
-public class GetExecutionVariablesCmd implements Command<VariableMap> {
+public @NullMarked class GetExecutionVariablesCmd implements Command<VariableMap> {
   protected String executionId;
-  protected Collection<String> variableNames;
+  protected @Nullable Collection<String> variableNames;
   protected boolean isLocal;
   protected boolean deserializeValues;
 
-  public GetExecutionVariablesCmd(String executionId, Collection<String> variableNames, boolean isLocal, boolean deserializeValues) {
+  public GetExecutionVariablesCmd(String executionId, @Nullable Collection<String> variableNames, boolean isLocal, boolean deserializeValues) {
     this.executionId = executionId;
     this.variableNames = variableNames;
     this.isLocal = isLocal;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExecutionVariablesCmd.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -55,6 +56,7 @@ public @NullMarked class GetExecutionVariablesCmd implements Command<VariableMap
       .findExecutionById(executionId);
 
     ensureNotNull("execution %s doesn't exist".formatted(executionId), "execution", execution);
+    requireNonNull(execution);
 
     checkGetExecutionVariables(execution, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExternalTaskErrorDetailsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetExternalTaskErrorDetailsCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -27,7 +28,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @author Askar Akhmerov
  */
-public class GetExternalTaskErrorDetailsCmd implements Command<String> {
+public @NullMarked class GetExternalTaskErrorDetailsCmd implements Command<String> {
   private final String externalTaskId;
 
   public GetExternalTaskErrorDetailsCmd(String externalTaskId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFilterCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFilterCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Sebastian Menski
  */
-public class GetFilterCmd implements Command<Filter> {
+public @NullMarked class GetFilterCmd implements Command<Filter> {
   protected String filterId;
 
   public GetFilterCmd(String filterId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFormKeyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFormKeyCmd.java
@@ -72,7 +72,7 @@ public @NullMarked class GetFormKeyCmd implements Command<String> {
 
   @Override
   public @Nullable String execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFormKeyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFormKeyCmd.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -31,15 +31,16 @@ import org.operaton.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.impl.task.TaskDefinition;
 
+import static java.util.Objects.requireNonNull;
 
 /**
  * Command for retrieving start or task form keys.
  *
  * @author Falko Menge (Camunda)
  */
-public class GetFormKeyCmd implements Command<String> {
+public @NullMarked class GetFormKeyCmd implements Command<String> {
 
-  protected String taskDefinitionKey;
+  protected @Nullable String taskDefinitionKey;
   protected String processDefinitionId;
 
   /**
@@ -47,20 +48,22 @@ public class GetFormKeyCmd implements Command<String> {
    */
   public GetFormKeyCmd(String processDefinitionId) {
     setProcessDefinitionId(processDefinitionId);
+    requireNonNull(this.processDefinitionId);
   }
 
   /**
    * Retrieves a task form key.
    */
-  public GetFormKeyCmd(String processDefinitionId, @NonNull String taskDefinitionKey) {
+  public GetFormKeyCmd(String processDefinitionId, String taskDefinitionKey) {
     setProcessDefinitionId(processDefinitionId);
+    requireNonNull(this.processDefinitionId);
     if (taskDefinitionKey.isEmpty()) {
       throw new ProcessEngineException("The task definition key is mandatory, but '%s' has been provided.".formatted(taskDefinitionKey));
     }
     this.taskDefinitionKey = taskDefinitionKey;
   }
 
-  protected void setProcessDefinitionId(String processDefinitionId) {
+  protected void setProcessDefinitionId(@Nullable String processDefinitionId) {
     if (processDefinitionId == null || processDefinitionId.isEmpty()) {
       throw new ProcessEngineException("The process definition id is mandatory, but '%s' has been provided.".formatted(processDefinitionId));
     }
@@ -69,7 +72,7 @@ public class GetFormKeyCmd implements Command<String> {
 
   @Override
   public @Nullable String execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoricExternalTaskLogErrorDetailsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoricExternalTaskLogErrorDetailsCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.history.event.HistoricExternalTaskLogEntity;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class GetHistoricExternalTaskLogErrorDetailsCmd implements Command<String> {
+public @NullMarked class GetHistoricExternalTaskLogErrorDetailsCmd implements Command<String> {
 
   protected String historicExternalTaskLogId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoricJobLogExceptionStacktraceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoricJobLogExceptionStacktraceCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -27,7 +28,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Roman Smirnov
  *
  */
-public class GetHistoricJobLogExceptionStacktraceCmd implements Command<String> {
+public @NullMarked class GetHistoricJobLogExceptionStacktraceCmd implements Command<String> {
 
   protected String historicJobLogId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoryLevelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoryLevelCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -24,12 +25,12 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Sebastian Menski
  */
-public class GetHistoryLevelCmd implements Command<Integer> {
+public @NullMarked class GetHistoryLevelCmd implements Command<Integer> {
 
   @Override
   public Integer execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkReadHistoryLevel);
-    return Context.getProcessEngineConfiguration().getHistoryLevel().getId();
+    return Context.getRequiredProcessEngineConfiguration().getHistoryLevel().getId();
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoryLevelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetHistoryLevelCmd.java
@@ -30,7 +30,7 @@ public @NullMarked class GetHistoryLevelCmd implements Command<Integer> {
   @Override
   public Integer execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkReadHistoryLevel);
-    return Context.getRequiredProcessEngineConfiguration().getHistoryLevel().getId();
+    return Context.getProcessEngineConfiguration().getHistoryLevel().getId();
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForProcessDefinitionCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -29,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tijs Rademakers
  */
-public class GetIdentityLinksForProcessDefinitionCmd implements Command<List<IdentityLink>> {
+public @NullMarked class GetIdentityLinksForProcessDefinitionCmd implements Command<List<IdentityLink>> {
   protected String processDefinitionId;
 
   public GetIdentityLinksForProcessDefinitionCmd(String processDefinitionId) {
@@ -40,7 +41,7 @@ public class GetIdentityLinksForProcessDefinitionCmd implements Command<List<Ide
   @SuppressWarnings({"unchecked", "rawtypes"})
   public List<IdentityLink> execute(CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-      .getCommandContext()
+      .getRequiredCommandContext()
       .getProcessDefinitionManager()
       .findLatestProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForProcessDefinitionCmd.java
@@ -41,7 +41,7 @@ public @NullMarked class GetIdentityLinksForProcessDefinitionCmd implements Comm
   @SuppressWarnings({"unchecked", "rawtypes"})
   public List<IdentityLink> execute(CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = Context
-      .getRequiredCommandContext()
+      .getCommandContext()
       .getProcessDefinitionManager()
       .findLatestProcessDefinitionById(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -28,13 +29,14 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 import org.operaton.bpm.engine.task.IdentityLink;
 import org.operaton.bpm.engine.task.IdentityLinkType;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Joram Barrez
  * @author Falko Menge
  */
-public class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>> {
+public @NullMarked class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>> {
   protected String taskId;
 
   public GetIdentityLinksForTaskCmd(String taskId) {
@@ -48,6 +50,7 @@ public class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>> {
     TaskManager taskManager = commandContext.getTaskManager();
     TaskEntity task = taskManager.findTaskById(taskId);
     ensureNotNull("Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkGetIdentityLink(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetJobExceptionStacktraceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetJobExceptionStacktraceCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,7 +27,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Frederik Heremans
  */
-public class GetJobExceptionStacktraceCmd implements Command<String> {
+public @NullMarked class GetJobExceptionStacktraceCmd implements Command<String> {
   private final String jobId;
 
   public GetJobExceptionStacktraceCmd(String jobId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetNextIdBlockCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetNextIdBlockCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.db.IdBlock;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyEntity;
 /**
  * @author Tom Baeyens
  */
-public class GetNextIdBlockCmd implements Command<IdBlock> {
+public @NullMarked class GetNextIdBlockCmd implements Command<IdBlock> {
 
   protected int idBlockSize;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetOperatonFormDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetOperatonFormDefinitionCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.OperatonFormRef;
 import org.operaton.bpm.engine.impl.form.entity.OperatonFormDefinitionManager;
@@ -25,7 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.OperatonFormDefinitionEntity;
 import org.operaton.bpm.engine.repository.OperatonFormDefinition;
 
-public class GetOperatonFormDefinitionCmd implements Command<OperatonFormDefinition> {
+public @NullMarked class GetOperatonFormDefinitionCmd implements Command<OperatonFormDefinition> {
 
   protected OperatonFormRef operatonFormRef;
   protected String deploymentId;
@@ -36,7 +38,7 @@ public class GetOperatonFormDefinitionCmd implements Command<OperatonFormDefinit
   }
 
   @Override
-  public OperatonFormDefinition execute(CommandContext commandContext) {
+  public @Nullable OperatonFormDefinition execute(CommandContext commandContext) {
     String binding = operatonFormRef.getBinding();
     String key = operatonFormRef.getKey();
     OperatonFormDefinitionEntity definition = null;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetPasswordPolicyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetPasswordPolicyCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.identity.PasswordPolicy;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Miklas Boskamp
  */
-public class GetPasswordPolicyCmd implements Command<PasswordPolicy> {
+public @NullMarked class GetPasswordPolicyCmd implements Command<PasswordPolicy> {
   @Override
   public @Nullable PasswordPolicy execute(CommandContext commandContext) {
     ProcessEngineConfigurationImpl processEngineConfiguration = commandContext.getProcessEngineConfiguration();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessApplicationForDeploymentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessApplicationForDeploymentCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.application.ProcessApplicationReference;
@@ -28,7 +29,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * @author Daniel Meyer
  *
  */
-public class GetProcessApplicationForDeploymentCmd implements Command<String> {
+public @NullMarked class GetProcessApplicationForDeploymentCmd implements Command<String> {
 
   protected String deploymentId;
 
@@ -40,7 +41,7 @@ public class GetProcessApplicationForDeploymentCmd implements Command<String> {
   public @Nullable String execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkReadProcessApplicationForDeployment);
 
-    ProcessApplicationReference reference = Context.getProcessEngineConfiguration()
+    ProcessApplicationReference reference = Context.getRequiredProcessEngineConfiguration()
       .getProcessApplicationManager()
       .getProcessApplicationForDeployment(deploymentId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessApplicationForDeploymentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessApplicationForDeploymentCmd.java
@@ -41,7 +41,7 @@ public @NullMarked class GetProcessApplicationForDeploymentCmd implements Comman
   public @Nullable String execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkReadProcessApplicationForDeployment);
 
-    ProcessApplicationReference reference = Context.getRequiredProcessEngineConfiguration()
+    ProcessApplicationReference reference = Context.getProcessEngineConfiguration()
       .getProcessApplicationManager()
       .getProcessApplicationForDeployment(deploymentId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessInstanceAttachmentsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessInstanceAttachmentsCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.task.Attachment;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.task.Attachment;
 /**
  * @author Tom Baeyens
  */
-public class GetProcessInstanceAttachmentsCmd implements Command<List<Attachment>> {
+public @NullMarked class GetProcessInstanceAttachmentsCmd implements Command<List<Attachment>> {
   protected String processInstanceId;
 
   public GetProcessInstanceAttachmentsCmd(String taskId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessInstanceCommentsCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetProcessInstanceCommentsCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.task.Comment;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.task.Comment;
 /**
  * @author Tom Baeyens
  */
-public class GetProcessInstanceCommentsCmd implements Command<List<Comment>> {
+public @NullMarked class GetProcessInstanceCommentsCmd implements Command<List<Comment>> {
   protected String processInstanceId;
 
   public GetProcessInstanceCommentsCmd(String processInstanceId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetPropertiesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetPropertiesCmd.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -28,7 +29,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyEntity;
 /**
  * @author Tom Baeyens
  */
-public class GetPropertiesCmd implements Command<Map<String, String>> {
+public @NullMarked class GetPropertiesCmd implements Command<Map<String, String>> {
   @Override
   @SuppressWarnings("unchecked")
   public Map<String, String> execute(CommandContext commandContext) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedStartFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedStartFormCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ScriptEvaluationException;
@@ -37,7 +38,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public class GetRenderedStartFormCmd implements Command<Object> {
+public @NullMarked class GetRenderedStartFormCmd implements Command<Object> {
   protected String processDefinitionId;
   protected String formEngineName;
   private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
@@ -49,7 +50,7 @@ public class GetRenderedStartFormCmd implements Command<Object> {
 
   @Override
   public @Nullable Object execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
     ensureNotNull("Process Definition '%s' not found".formatted(processDefinitionId), "processDefinition", processDefinition);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedStartFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedStartFormCmd.java
@@ -50,7 +50,7 @@ public @NullMarked class GetRenderedStartFormCmd implements Command<Object> {
 
   @Override
   public @Nullable Object execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
     ensureNotNull("Process Definition '%s' not found".formatted(processDefinitionId), "processDefinition", processDefinition);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedTaskFormCmd.java
@@ -20,6 +20,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.form.TaskFormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.form.engine.FormEngine;
 import org.operaton.bpm.engine.impl.form.handler.TaskFormHandler;
@@ -28,6 +29,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -47,8 +49,10 @@ public class GetRenderedTaskFormCmd  implements Command<Object> {
     TaskManager taskManager = commandContext.getTaskManager();
     TaskEntity task = taskManager.findTaskById(taskId);
     ensureNotNull("Task '%s' not found".formatted(taskId), "task", task);
+    requireNonNull(task);
 
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    ProcessEngineConfigurationImpl processEngineConfiguration = commandContext.getProcessEngineConfiguration();
+    for(CommandChecker checker : processEngineConfiguration.getCommandCheckers()) {
       checker.checkReadTaskVariable(task);
     }
     ensureNotNull("Task form definition for '%s' not found".formatted(taskId), "task.getTaskDefinition()", task.getTaskDefinition());
@@ -58,8 +62,7 @@ public class GetRenderedTaskFormCmd  implements Command<Object> {
       return null;
     }
 
-    FormEngine formEngine = Context
-      .getProcessEngineConfiguration()
+    FormEngine formEngine = processEngineConfiguration
       .getFormEngines()
       .get(formEngineName);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedTaskFormCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.form.TaskFormData;
@@ -35,7 +36,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class GetRenderedTaskFormCmd  implements Command<Object> {
+public @NullMarked class GetRenderedTaskFormCmd implements Command<Object> {
   protected String taskId;
   protected String formEngineName;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetRenderedTaskFormCmd.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.form.TaskFormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.form.engine.FormEngine;
 import org.operaton.bpm.engine.impl.form.handler.TaskFormHandler;
 import org.operaton.bpm.engine.impl.interceptor.Command;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStartFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStartFormCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.form.StartFormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -31,7 +32,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class GetStartFormCmd implements Command<StartFormData> {
+public @NullMarked class GetStartFormCmd implements Command<StartFormData> {
   protected String processDefinitionId;
 
   public GetStartFormCmd(String processDefinitionId) {
@@ -40,7 +41,7 @@ public class GetStartFormCmd implements Command<StartFormData> {
 
   @Override
   public StartFormData execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
     ensureNotNull("No process definition found for id '%s'".formatted(processDefinitionId), "processDefinition", processDefinition);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStartFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStartFormCmd.java
@@ -41,7 +41,7 @@ public @NullMarked class GetStartFormCmd implements Command<StartFormData> {
 
   @Override
   public StartFormData execute(CommandContext commandContext) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     DeploymentCache deploymentCache = processEngineConfiguration.getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
     ensureNotNull("No process definition found for id '%s'".formatted(processDefinitionId), "processDefinition", processDefinition);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStartFormVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStartFormVariablesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.form.FormField;
 import org.operaton.bpm.engine.form.StartFormData;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -31,7 +32,7 @@ import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
  * @author Daniel Meyer
  *
  */
-public class GetStartFormVariablesCmd extends AbstractGetFormVariablesCmd {
+public @NullMarked class GetStartFormVariablesCmd extends AbstractGetFormVariablesCmd {
   public GetStartFormVariablesCmd(String resourceId, Collection<String> formVariableNames, boolean deserializeObjectValues) {
     super(resourceId, formVariableNames, deserializeObjectValues);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStaticCalledProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStaticCalledProcessDefinitionCmd.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.impl.bpmn.behavior.CallActivityBehavior;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
@@ -39,7 +40,7 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 
 import static org.operaton.bpm.engine.impl.ProcessEngineLogger.CMD_LOGGER;
 
-public class GetStaticCalledProcessDefinitionCmd implements Command<Collection<CalledProcessDefinition>> {
+public @NullMarked class GetStaticCalledProcessDefinitionCmd implements Command<Collection<CalledProcessDefinition>> {
 
   protected String processDefinitionId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStaticCalledProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetStaticCalledProcessDefinitionCmd.java
@@ -38,6 +38,7 @@ import org.operaton.bpm.engine.impl.util.CallableElementUtil;
 import org.operaton.bpm.engine.repository.CalledProcessDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.ProcessEngineLogger.CMD_LOGGER;
 
 public @NullMarked class GetStaticCalledProcessDefinitionCmd implements Command<Collection<CalledProcessDefinition>> {
@@ -68,6 +69,7 @@ public @NullMarked class GetStaticCalledProcessDefinitionCmd implements Command<
   @Override
   public Collection<CalledProcessDefinition> execute(CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = new GetDeployedProcessDefinitionCmd(processDefinitionId, true).execute(commandContext);
+    requireNonNull(processDefinition);
 
     List<ActivityImpl> callActivities = findCallActivitiesInProcess(processDefinition);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetSubTasksCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetSubTasksCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.TaskQueryImpl;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.task.Task;
 /**
  * @author Tom Baeyens
  */
-public class GetSubTasksCmd implements Command<List<Task>> {
+public @NullMarked class GetSubTasksCmd implements Command<List<Task>> {
   protected String parentTaskId;
 
   public GetSubTasksCmd(String parentTaskId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTableCountCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTableCountCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Tom Baeyens
  */
-public class GetTableCountCmd implements Command<Map<String,Long>> {
+public @NullMarked class GetTableCountCmd implements Command<Map<String,Long>> {
   @Override
   public Map<String, Long> execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkReadTableCount);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTableMetaDataCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTableMetaDataCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -26,7 +27,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Joram Barrez
  */
-public class GetTableMetaDataCmd implements Command<TableMetaData> {
+public @NullMarked class GetTableMetaDataCmd implements Command<TableMetaData> {
   protected String tableName;
 
   public GetTableMetaDataCmd(String tableName) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTableNameCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTableNameCmd.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-public class GetTableNameCmd implements Command<String> {
+public @NullMarked class GetTableNameCmd implements Command<String> {
   private final Class<?> entityClass;
 
   public GetTableNameCmd(Class< ? > entityClass) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskAttachmentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskAttachmentCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.task.Attachment;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.task.Attachment;
 /**
  * @author kristin.polenz@camunda.com
  */
-public class GetTaskAttachmentCmd implements Command<Attachment> {
+public @NullMarked class GetTaskAttachmentCmd implements Command<Attachment> {
   protected String attachmentId;
   protected String taskId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskAttachmentContentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskAttachmentContentCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 
 import org.jspecify.annotations.Nullable;
@@ -29,7 +30,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 /**
  * @author kristin.polenz@camunda.com
  */
-public class GetTaskAttachmentContentCmd implements Command<InputStream> {
+public @NullMarked class GetTaskAttachmentContentCmd implements Command<InputStream> {
   protected String attachmentId;
   protected String taskId;
 
@@ -57,6 +58,9 @@ public class GetTaskAttachmentContentCmd implements Command<InputStream> {
         .getDbEntityManager()
         .selectById(ByteArrayEntity.class, contentId);
 
+    if (byteArray == null) {
+      return null;
+    }
     byte[] bytes = byteArray.getBytes();
 
     return new ByteArrayInputStream(bytes);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.form.TaskFormData;
@@ -31,7 +32,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class GetTaskFormCmd implements Command<TaskFormData> {
+public @NullMarked class GetTaskFormCmd implements Command<TaskFormData> {
   protected String taskId;
 
   public GetTaskFormCmd(String taskId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormCmd.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -44,6 +45,7 @@ public @NullMarked class GetTaskFormCmd implements Command<TaskFormData> {
     TaskManager taskManager = commandContext.getTaskManager();
     TaskEntity task = taskManager.findTaskById(taskId);
     ensureNotNull("No task found for taskId '%s'".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkReadTaskVariable(task);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormVariablesCmd.java
@@ -30,6 +30,7 @@ import org.operaton.bpm.engine.impl.task.TaskDefinition;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -47,6 +48,7 @@ public @NullMarked class GetTaskFormVariablesCmd extends AbstractGetFormVariable
     TaskEntity task = taskManager.findTaskById(resourceId);
 
     ensureNotNull(BadUserRequestException.class, "Cannot find task with id '%s'.".formatted(resourceId), "task", task);
+    requireNonNull(task);
 
     checkGetTaskFormVariables(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskFormVariablesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.FormField;
 import org.operaton.bpm.engine.form.TaskFormData;
@@ -35,7 +36,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Daniel Meyer
  *
  */
-public class GetTaskFormVariablesCmd extends AbstractGetFormVariablesCmd {
+public @NullMarked class GetTaskFormVariablesCmd extends AbstractGetFormVariablesCmd {
   public GetTaskFormVariablesCmd(String taskId, Collection<String> variableNames, boolean deserializeObjectValues) {
     super(taskId, variableNames, deserializeObjectValues);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -27,7 +29,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class GetTaskVariableCmd implements Command<Object> {
+public @NullMarked class GetTaskVariableCmd implements Command<Object> {
   protected String taskId;
   protected String variableName;
   protected boolean isLocal;
@@ -39,12 +41,12 @@ public class GetTaskVariableCmd implements Command<Object> {
   }
 
   @Override
-  public Object execute(CommandContext commandContext) {
+  public @Nullable Object execute(CommandContext commandContext) {
     ensureNotNull("taskId", taskId);
     ensureNotNull("variableName", variableName);
 
     TaskEntity task = Context
-      .getCommandContext()
+      .getRequiredCommandContext()
       .getTaskManager()
       .findTaskById(taskId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmd.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -51,6 +52,7 @@ public @NullMarked class GetTaskVariableCmd implements Command<Object> {
       .findTaskById(taskId);
 
     ensureNotNull("task %s doesn't exist".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkGetTaskVariable(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmd.java
@@ -46,7 +46,7 @@ public @NullMarked class GetTaskVariableCmd implements Command<Object> {
     ensureNotNull("variableName", variableName);
 
     TaskEntity task = Context
-      .getRequiredCommandContext()
+      .getCommandContext()
       .getTaskManager()
       .findTaskById(taskId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmdTyped.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmdTyped.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -28,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Daniel Meyer
  */
-public class GetTaskVariableCmdTyped implements Command<TypedValue> {
+public @NullMarked class GetTaskVariableCmdTyped implements Command<TypedValue> {
   protected String taskId;
   protected String variableName;
   protected boolean isLocal;
@@ -42,12 +44,12 @@ public class GetTaskVariableCmdTyped implements Command<TypedValue> {
   }
 
   @Override
-  public TypedValue execute(CommandContext commandContext) {
+  public @Nullable TypedValue execute(CommandContext commandContext) {
     ensureNotNull("taskId", taskId);
     ensureNotNull("variableName", variableName);
 
     TaskEntity task = Context
-      .getCommandContext()
+      .getRequiredCommandContext()
       .getTaskManager()
       .findTaskById(taskId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmdTyped.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmdTyped.java
@@ -49,7 +49,7 @@ public @NullMarked class GetTaskVariableCmdTyped implements Command<TypedValue> 
     ensureNotNull("variableName", variableName);
 
     TaskEntity task = Context
-      .getRequiredCommandContext()
+      .getCommandContext()
       .getTaskManager()
       .findTaskById(taskId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmdTyped.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariableCmdTyped.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -54,6 +55,7 @@ public @NullMarked class GetTaskVariableCmdTyped implements Command<TypedValue> 
       .findTaskById(taskId);
 
     ensureNotNull("task %s doesn't exist".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkGetTaskVariableTyped(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariablesCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -31,13 +33,13 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 /**
  * @author Tom Baeyens
  */
-public class GetTaskVariablesCmd implements Command<VariableMap> {
+public @NullMarked class GetTaskVariablesCmd implements Command<VariableMap> {
   protected String taskId;
-  protected Collection<String> variableNames;
+  protected @Nullable Collection<String> variableNames;
   protected boolean isLocal;
   protected boolean deserializeValues;
 
-  public GetTaskVariablesCmd(String taskId, Collection<String> variableNames, boolean isLocal, boolean deserializeValues) {
+  public GetTaskVariablesCmd(String taskId, @Nullable Collection<String> variableNames, boolean isLocal, boolean deserializeValues) {
     this.taskId = taskId;
     this.variableNames = variableNames;
     this.isLocal = isLocal;
@@ -49,7 +51,7 @@ public class GetTaskVariablesCmd implements Command<VariableMap> {
     ensureNotNull("taskId", taskId);
 
     TaskEntity task = Context
-      .getCommandContext()
+      .getRequiredCommandContext()
       .getTaskManager()
       .findTaskById(taskId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariablesCmd.java
@@ -28,6 +28,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -56,6 +57,7 @@ public @NullMarked class GetTaskVariablesCmd implements Command<VariableMap> {
       .findTaskById(taskId);
 
     ensureNotNull("task %s doesn't exist".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     checkGetTaskVariables(task, commandContext);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTaskVariablesCmd.java
@@ -51,7 +51,7 @@ public @NullMarked class GetTaskVariablesCmd implements Command<VariableMap> {
     ensureNotNull("taskId", taskId);
 
     TaskEntity task = Context
-      .getRequiredCommandContext()
+      .getCommandContext()
       .getTaskManager()
       .findTaskById(taskId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTelemetryDataCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTelemetryDataCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -24,15 +25,13 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.telemetry.dto.TelemetryDataImpl;
 
-public class GetTelemetryDataCmd implements Command<TelemetryDataImpl> {
-
-  ProcessEngineConfigurationImpl configuration;
+public @NullMarked class GetTelemetryDataCmd implements Command<TelemetryDataImpl> {
 
   @Override
   public TelemetryDataImpl execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkReadDiagnosticsData);
 
-    configuration = commandContext.getProcessEngineConfiguration();
+    var configuration = commandContext.getProcessEngineConfiguration();
 
     DiagnosticsCollector diagnosticsCollector = configuration.getDiagnosticsCollector();
     if (diagnosticsCollector != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTelemetryDataCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTelemetryDataCmd.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.impl.cmd;
 import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
-import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.diagnostics.DiagnosticsCollector;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTopicNamesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetTopicNamesCmd.java
@@ -19,11 +19,12 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ExternalTaskQueryImpl;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
-public class GetTopicNamesCmd implements Command<List<String>> {
+public @NullMarked class GetTopicNamesCmd implements Command<List<String>> {
 
   protected ExternalTaskQueryImpl externalTaskQuery = new ExternalTaskQueryImpl();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUniqueTaskWorkerCountCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUniqueTaskWorkerCountCmd.java
@@ -18,10 +18,11 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Date;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
-public class GetUniqueTaskWorkerCountCmd implements Command<Long> {
+public @NullMarked class GetUniqueTaskWorkerCountCmd implements Command<Long> {
   protected Date startTime;
   protected Date endTime;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserAccountCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserAccountCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.identity.Account;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -23,7 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 /**
  * @author Tom Baeyens
  */
-public class GetUserAccountCmd implements Command<Account> {
+public @NullMarked class GetUserAccountCmd implements Command<Account> {
   protected String userId;
   protected String userPassword;
   protected String accountName;
@@ -35,7 +37,7 @@ public class GetUserAccountCmd implements Command<Account> {
   }
 
   @Override
-  public Account execute(CommandContext commandContext) {
+  public @Nullable Account execute(CommandContext commandContext) {
     return commandContext
       .getIdentityInfoManager()
       .findUserAccountByUserIdAndKey(userId, accountName);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserInfoCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserInfoCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.IdentityInfoEntity;
 /**
  * @author Tom Baeyens
  */
-public class GetUserInfoCmd implements Command<String> {
+public @NullMarked class GetUserInfoCmd implements Command<String> {
   protected String userId;
   protected String key;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserInfoKeysCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserInfoKeysCmd.java
@@ -18,13 +18,14 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 /**
  * @author Tom Baeyens
  */
-public class GetUserInfoKeysCmd implements Command<List<String>> {
+public @NullMarked class GetUserInfoKeysCmd implements Command<List<String>> {
   protected String userId;
   protected String userInfoType;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserPictureCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetUserPictureCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.identity.Picture;
@@ -30,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Daniel Meyer
  * @author Tom Baeyens
  */
-public class GetUserPictureCmd implements Command<Picture> {
+public @NullMarked class GetUserPictureCmd implements Command<Picture> {
   protected String userId;
 
   public GetUserPictureCmd(String userId) {
@@ -49,7 +50,7 @@ public class GetUserPictureCmd implements Command<Picture> {
       if (pictureByteArrayId != null) {
         ByteArrayEntity byteArray = commandContext.getDbEntityManager()
           .selectById(ByteArrayEntity.class, pictureByteArrayId);
-        return new Picture(byteArray.getBytes(), byteArray.getName());
+        return byteArray != null ? new Picture(byteArray.getBytes(), byteArray.getName()) : null;
       }
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleExternalTaskBpmnErrorCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleExternalTaskBpmnErrorCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
@@ -26,13 +28,13 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  *
  * @author Christopher Zell
  */
-public class HandleExternalTaskBpmnErrorCmd extends HandleExternalTaskCmd {
+public @NullMarked class HandleExternalTaskBpmnErrorCmd extends HandleExternalTaskCmd {
   /**
    * The error code of the corresponding bpmn error.
    */
   protected String errorCode;
-  protected String errorMessage;
-  protected Map<String, Object> variables;
+  protected @Nullable String errorMessage;
+  protected @Nullable Map<String, Object> variables;
 
   public HandleExternalTaskBpmnErrorCmd(String externalTaskId, String workerId, String errorCode) {
     super(externalTaskId, workerId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleExternalTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleExternalTaskCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.BadUserRequestException;
@@ -31,7 +32,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public abstract class HandleExternalTaskCmd extends ExternalTaskCmd {
+public abstract @NullMarked class HandleExternalTaskCmd extends ExternalTaskCmd {
 
   /**
    * The reported worker id.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleExternalTaskFailureCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleExternalTaskFailureCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
@@ -26,7 +27,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  * @author Christopher Zell
  * @author Askar Akhmerov
  */
-public class HandleExternalTaskFailureCmd extends HandleExternalTaskCmd {
+public @NullMarked class HandleExternalTaskFailureCmd extends HandleExternalTaskCmd {
 
   protected String errorMessage;
   protected String errorDetails;
@@ -37,13 +38,6 @@ public class HandleExternalTaskFailureCmd extends HandleExternalTaskCmd {
 
   /**
    * Overloaded constructor to support short and full error messages
-   *
-   * @param externalTaskId
-   * @param workerId
-   * @param errorMessage
-   * @param errorDetails
-   * @param retries
-   * @param retryDuration
    */
   public HandleExternalTaskFailureCmd(String externalTaskId, String workerId,
                                       String errorMessage, String errorDetails,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleTaskBpmnErrorCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleTaskBpmnErrorCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -27,17 +28,18 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * Command to handle a task BPMN error.
  */
-public class HandleTaskBpmnErrorCmd implements Command<Void> {
+public @NullMarked class HandleTaskBpmnErrorCmd implements Command<Void> {
   protected String taskId;
   protected String errorCode;
-  protected String errorMessage;
-  protected Map<String, Object> variables;
+  protected @Nullable String errorMessage;
+  protected @Nullable Map<String, Object> variables;
 
   public HandleTaskBpmnErrorCmd(String taskId, String errorCode) {
     this.taskId = taskId;
@@ -63,6 +65,7 @@ public class HandleTaskBpmnErrorCmd implements Command<Void> {
 
     TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
     ensureNotNull(NotFoundException.class,"Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkTaskWork(task);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleTaskEscalationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HandleTaskEscalationCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -27,16 +28,17 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * Command to handle a task escalation.
  */
-public class HandleTaskEscalationCmd implements Command<Void> {
+public @NullMarked class HandleTaskEscalationCmd implements Command<Void> {
   protected String taskId;
   protected String escalationCode;
-  protected Map<String, Object> variables;
+  protected @Nullable Map<String, Object> variables;
 
   public HandleTaskEscalationCmd(String taskId, String escalationCode) {
     this.taskId = taskId;
@@ -59,6 +61,7 @@ public class HandleTaskEscalationCmd implements Command<Void> {
 
     TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
     ensureNotNull(NotFoundException.class,"Cannot find task with id %s".formatted(taskId), "task", task);
+    requireNonNull(task);
 
     for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkTaskWork(task);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HistoryCleanupCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HistoryCleanupCmd.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.ListIterator;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -45,7 +46,7 @@ import org.operaton.bpm.engine.runtime.Job;
 /**
  * @author Svetlana Dorokhova
  */
-public class HistoryCleanupCmd implements Command<Job> {
+public @NullMarked class HistoryCleanupCmd implements Command<Job> {
 
   private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/IsIdentityServiceReadOnlyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/IsIdentityServiceReadOnlyCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -24,7 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * @author Daniel Meyer
  *
  */
-public class IsIdentityServiceReadOnlyCmd implements Command<Boolean> {
+public @NullMarked class IsIdentityServiceReadOnlyCmd implements Command<Boolean> {
 
   @Override
   public Boolean execute(CommandContext commandContext) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/IsTelemetryEnabledCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/IsTelemetryEnabledCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * Please remove any usages of the command.
  */
 @Deprecated(since = "1.0")
-public class IsTelemetryEnabledCmd implements Command<Boolean> {
+public @NullMarked class IsTelemetryEnabledCmd implements Command<Boolean> {
 
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.OptimisticLockingException;
 import org.operaton.bpm.engine.impl.cfg.TransactionContext;
 import org.operaton.bpm.engine.impl.cfg.TransactionState;
@@ -35,14 +36,14 @@ public abstract class JobRetryCmd implements Command<Object> {
   protected String jobId;
   protected Throwable exception;
 
-  protected JobRetryCmd(String jobId, Throwable exception) {
+  protected JobRetryCmd(String jobId, @Nullable Throwable exception) {
     this.jobId = jobId;
     this.exception = exception;
   }
 
   protected JobEntity getJob() {
     return Context
-        .getCommandContext()
+        .getRequiredCommandContext()
         .getJobManager()
         .findJobById(jobId);
   }
@@ -69,7 +70,7 @@ public abstract class JobRetryCmd implements Command<Object> {
   }
 
   protected void notifyAcquisition(CommandContext commandContext) {
-    JobExecutor jobExecutor = Context.getProcessEngineConfiguration().getJobExecutor();
+    JobExecutor jobExecutor = Context.getRequiredProcessEngineConfiguration().getJobExecutor();
     MessageAddedNotification messageAddedNotification = new MessageAddedNotification(jobExecutor);
     TransactionContext transactionContext = commandContext.getTransactionContext();
     transactionContext.addTransactionListener(TransactionState.COMMITTED, messageAddedNotification);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.OptimisticLockingException;
 import org.operaton.bpm.engine.impl.cfg.TransactionContext;
@@ -31,10 +32,10 @@ import org.operaton.bpm.engine.impl.util.ExceptionUtil;
 /**
  * @author Roman Smirnov
  */
-public abstract class JobRetryCmd implements Command<Object> {
+public abstract @NullMarked class JobRetryCmd implements Command<Object> {
 
   protected String jobId;
-  protected Throwable exception;
+  protected @Nullable Throwable exception;
 
   protected JobRetryCmd(String jobId, @Nullable Throwable exception) {
     this.jobId = jobId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
@@ -43,7 +43,7 @@ public abstract class JobRetryCmd implements Command<Object> {
 
   protected JobEntity getJob() {
     return Context
-        .getRequiredCommandContext()
+        .getCommandContext()
         .getJobManager()
         .findJobById(jobId);
   }
@@ -70,7 +70,7 @@ public abstract class JobRetryCmd implements Command<Object> {
   }
 
   protected void notifyAcquisition(CommandContext commandContext) {
-    JobExecutor jobExecutor = Context.getRequiredProcessEngineConfiguration().getJobExecutor();
+    JobExecutor jobExecutor = Context.getProcessEngineConfiguration().getJobExecutor();
     MessageAddedNotification messageAddedNotification = new MessageAddedNotification(jobExecutor);
     TransactionContext transactionContext = commandContext.getTransactionContext();
     transactionContext.addTransactionListener(TransactionState.COMMITTED, messageAddedNotification);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/JobRetryCmd.java
@@ -19,20 +19,25 @@ package org.operaton.bpm.engine.impl.cmd;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.OptimisticLockingException;
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.TransactionContext;
 import org.operaton.bpm.engine.impl.cfg.TransactionState;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+import org.operaton.bpm.engine.impl.jobexecutor.JobExecutorLogger;
 import org.operaton.bpm.engine.impl.jobexecutor.MessageAddedNotification;
 import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.util.ExceptionUtil;
+
+import java.util.Optional;
 
 /**
  * @author Roman Smirnov
  */
 public abstract @NullMarked class JobRetryCmd implements Command<Object> {
+  protected static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
 
   protected String jobId;
   protected @Nullable Throwable exception;
@@ -42,11 +47,15 @@ public abstract @NullMarked class JobRetryCmd implements Command<Object> {
     this.exception = exception;
   }
 
-  protected JobEntity getJob() {
-    return Context
-        .getCommandContext()
-        .getJobManager()
-        .findJobById(jobId);
+  protected Optional<JobEntity> getJob() {
+    JobEntity job = Context
+            .getCommandContext()
+            .getJobManager()
+            .findJobById(jobId);
+    if (job == null) {
+      LOG.debugFailedJobNotFound(jobId);
+    }
+    return Optional.ofNullable(job);
   }
 
   protected void logException(JobEntity job) {
@@ -63,6 +72,9 @@ public abstract @NullMarked class JobRetryCmd implements Command<Object> {
   }
 
   protected String getExceptionStacktrace() {
+    if (exception == null) {
+      return "";
+    }
     return ExceptionUtil.getExceptionStacktrace(exception);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/LockExternalTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/LockExternalTaskCmd.java
@@ -18,12 +18,13 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Date;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
-public class LockExternalTaskCmd extends HandleExternalTaskCmd {
+public @NullMarked class LockExternalTaskCmd extends HandleExternalTaskCmd {
 
   protected long lockDuration;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/MessageEventReceivedCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/MessageEventReceivedCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 
 import org.jspecify.annotations.Nullable;
@@ -36,21 +37,21 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNumberOfElement
  * @author Daniel Meyer
  * @author Joram Barrez
  */
-public class MessageEventReceivedCmd implements Command<Void> {
+public @NullMarked class MessageEventReceivedCmd implements Command<Void> {
   protected final String executionId;
-  protected final Map<String, Object> processVariables;
-  protected final Map<String, Object> processVariablesLocal;
-  protected final Map<String, Object> processVariablesToTriggeredScope;
-  protected final String messageName;
+  protected final @Nullable Map<String, Object> processVariables;
+  protected final @Nullable Map<String, Object> processVariablesLocal;
+  protected final @Nullable Map<String, Object> processVariablesToTriggeredScope;
+  protected final @Nullable String messageName;
   protected boolean exclusive;
 
-  public MessageEventReceivedCmd(String messageName, String executionId, Map<String, Object> processVariables) {
+  public MessageEventReceivedCmd(@Nullable String messageName, String executionId, @Nullable Map<String, Object> processVariables) {
     this(messageName, executionId, processVariables, null, null);
   }
 
-  public MessageEventReceivedCmd(String messageName, String executionId, Map<String, Object> processVariables,
-                                                                         Map<String, Object> processVariablesLocal,
-                                                                         Map<String, Object> processVariablesToTriggeredScope) {
+  public MessageEventReceivedCmd(@Nullable String messageName, String executionId, @Nullable Map<String, Object> processVariables,
+                                                                         @Nullable Map<String, Object> processVariablesLocal,
+                                                                         @Nullable Map<String, Object> processVariablesToTriggeredScope) {
     this.executionId = executionId;
     this.messageName = messageName;
     this.processVariables = processVariables;
@@ -58,9 +59,9 @@ public class MessageEventReceivedCmd implements Command<Void> {
     this.processVariablesToTriggeredScope = processVariablesToTriggeredScope;
   }
 
-  public MessageEventReceivedCmd(String messageName, String executionId, Map<String, Object> processVariables,
-                                                                         Map<String, Object> processVariablesLocal,
-                                                                         Map<String, Object> processVariablesToTriggeredScope,
+  public MessageEventReceivedCmd(@Nullable String messageName, String executionId, @Nullable Map<String, Object> processVariables,
+                                                                         @Nullable Map<String, Object> processVariablesLocal,
+                                                                         @Nullable Map<String, Object> processVariablesToTriggeredScope,
                                                                          boolean exclusive) {
     this(messageName, executionId, processVariables, processVariablesLocal, processVariablesToTriggeredScope);
     this.exclusive = exclusive;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ModifyProcessInstanceAsyncCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ModifyProcessInstanceAsyncCmd.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collections;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.BatchPermissions;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
@@ -35,11 +37,13 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionManager;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Yana Vasileva
  *
  */
-public class ModifyProcessInstanceAsyncCmd implements Command<Batch> {
+public @NullMarked class ModifyProcessInstanceAsyncCmd implements Command<Batch> {
 
   private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
@@ -57,6 +61,7 @@ public class ModifyProcessInstanceAsyncCmd implements Command<Batch> {
     ExecutionEntity processInstance = executionManager.findExecutionById(processInstanceId);
 
     ensureProcessInstanceExists(processInstanceId, processInstance);
+    requireNonNull(processInstance);
 
     String processDefinitionId = processInstance.getProcessDefinitionId();
     String tenantId = processInstance.getTenantId();
@@ -76,7 +81,7 @@ public class ModifyProcessInstanceAsyncCmd implements Command<Batch> {
   }
 
   protected void ensureProcessInstanceExists(String processInstanceId,
-                                             ExecutionEntity processInstance) {
+                                             @Nullable ExecutionEntity processInstance) {
     if (processInstance == null) {
       throw LOG.processInstanceDoesNotExist(processInstanceId);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ModifyProcessInstanceAsyncCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ModifyProcessInstanceAsyncCmd.java
@@ -69,6 +69,7 @@ public @NullMarked class ModifyProcessInstanceAsyncCmd implements Command<Batch>
     String deploymentId = commandContext.getProcessEngineConfiguration().getDeploymentCache()
       .findDeployedProcessDefinitionById(processDefinitionId)
       .getDeploymentId();
+     requireNonNull(deploymentId, "a deployed process definition must be associated with a deployment");
 
     return new BatchBuilder(commandContext)
         .type(Batch.TYPE_PROCESS_INSTANCE_MODIFICATION)

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/PatchExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/PatchExecutionVariablesCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collection;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
@@ -29,7 +30,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
  * @author Thorben Lindhauer
  *
  */
-public class PatchExecutionVariablesCmd extends AbstractPatchVariablesCmd {
+public @NullMarked class PatchExecutionVariablesCmd extends AbstractPatchVariablesCmd {
   public PatchExecutionVariablesCmd(String executionId, Map<String, ? extends Object> modifications, Collection<String> deletions, boolean isLocal) {
     super(executionId, modifications, deletions, isLocal);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/PatchTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/PatchTaskVariablesCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collection;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
@@ -29,7 +30,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
  * @author kristin.polenz@camunda.com
  *
  */
-public class PatchTaskVariablesCmd extends AbstractPatchVariablesCmd {
+public @NullMarked class PatchTaskVariablesCmd extends AbstractPatchVariablesCmd {
   public PatchTaskVariablesCmd(String taskId, Map<String, ? extends Object> modifications, Collection<String> deletions, boolean isLocal) {
     super(taskId, modifications, deletions, isLocal);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RegisterProcessApplicationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RegisterProcessApplicationCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collections;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.application.ProcessApplicationRegistration;
 import org.operaton.bpm.engine.impl.application.ProcessApplicationManager;
@@ -34,7 +35,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * @author Daniel Meyer
  *
  */
-public class RegisterProcessApplicationCmd implements Command<ProcessApplicationRegistration> {
+public @NullMarked class RegisterProcessApplicationCmd implements Command<ProcessApplicationRegistration> {
 
   protected ProcessApplicationReference reference;
   protected Set<String> deploymentsToRegister;
@@ -53,7 +54,7 @@ public class RegisterProcessApplicationCmd implements Command<ProcessApplication
   public ProcessApplicationRegistration execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkRegisterProcessApplication);
 
-    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
     final ProcessApplicationManager processApplicationManager = processEngineConfiguration.getProcessApplicationManager();
 
     return processApplicationManager.registerProcessApplicationForDeployments(deploymentsToRegister, reference);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RegisterProcessApplicationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RegisterProcessApplicationCmd.java
@@ -54,7 +54,7 @@ public @NullMarked class RegisterProcessApplicationCmd implements Command<Proces
   public ProcessApplicationRegistration execute(CommandContext commandContext) {
     commandContext.getAuthorizationManager().checkOperatonAdminOrPermission(CommandChecker::checkRegisterProcessApplication);
 
-    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getRequiredProcessEngineConfiguration();
+    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     final ProcessApplicationManager processApplicationManager = processEngineConfiguration.getProcessApplicationManager();
 
     return processApplicationManager.registerProcessApplicationForDeployments(deploymentsToRegister, reference);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveExecutionVariablesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -29,7 +30,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author roman.smirnov
  * @author Joram Barrez
  */
-public class RemoveExecutionVariablesCmd extends AbstractRemoveVariableCmd {
+public @NullMarked class RemoveExecutionVariablesCmd extends AbstractRemoveVariableCmd {
   public RemoveExecutionVariablesCmd(String executionId, Collection<String> variableNames, boolean isLocal) {
     super(executionId, variableNames, isLocal);
   }
@@ -38,7 +39,7 @@ public class RemoveExecutionVariablesCmd extends AbstractRemoveVariableCmd {
   protected ExecutionEntity getEntity() {
     ensureNotNull("executionId", entityId);
 
-    ExecutionEntity execution = commandContext
+    ExecutionEntity execution = getCommandContext()
       .getExecutionManager()
       .findExecutionById(entityId);
 
@@ -57,11 +58,11 @@ public class RemoveExecutionVariablesCmd extends AbstractRemoveVariableCmd {
   @Override
   protected void logVariableOperation(AbstractVariableScope scope) {
     ExecutionEntity execution = (ExecutionEntity) scope;
-    commandContext.getOperationLogManager().logVariableOperation(getLogEntryOperation(), execution.getId(), null, PropertyChange.EMPTY_CHANGE);
+    getCommandContext().getOperationLogManager().logVariableOperation(getLogEntryOperation(), execution.getId(), null, PropertyChange.EMPTY_CHANGE);
   }
 
   protected void checkRemoveExecutionVariables(ExecutionEntity execution) {
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    for(CommandChecker checker : getCommandContext().getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkUpdateProcessInstanceVariables(execution);
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveExecutionVariablesCmd.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 
+ import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -44,6 +45,7 @@ public @NullMarked class RemoveExecutionVariablesCmd extends AbstractRemoveVaria
       .findExecutionById(entityId);
 
     ensureNotNull("execution %s doesn't exist".formatted(entityId), "execution", execution);
+    requireNonNull(execution);
 
     checkRemoveExecutionVariables(execution);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveTaskVariablesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -30,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author roman.smirnov
  * @author Joram Barrez
  */
-public class RemoveTaskVariablesCmd extends AbstractRemoveVariableCmd {
+public @NullMarked class RemoveTaskVariablesCmd extends AbstractRemoveVariableCmd {
   public RemoveTaskVariablesCmd(String taskId, Collection<String> variableNames, boolean isLocal) {
     super(taskId, variableNames, isLocal);
   }
@@ -39,7 +40,7 @@ public class RemoveTaskVariablesCmd extends AbstractRemoveVariableCmd {
   protected TaskEntity getEntity() {
     ensureNotNull("taskId", entityId);
 
-    TaskEntity task = commandContext
+    TaskEntity task = getCommandContext()
       .getTaskManager()
       .findTaskById(entityId);
 
@@ -58,11 +59,11 @@ public class RemoveTaskVariablesCmd extends AbstractRemoveVariableCmd {
   @Override
   protected void logVariableOperation(AbstractVariableScope scope) {
     TaskEntity task = (TaskEntity) scope;
-    commandContext.getOperationLogManager().logVariableOperation(getLogEntryOperation(), null, task.getId(), PropertyChange.EMPTY_CHANGE);
+    getCommandContext().getOperationLogManager().logVariableOperation(getLogEntryOperation(), null, task.getId(), PropertyChange.EMPTY_CHANGE);
   }
 
   protected void checkRemoveTaskVariables(TaskEntity task) {
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    for(CommandChecker checker : getCommandContext().getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkUpdateTaskVariable(task);
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RemoveTaskVariablesCmd.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -45,6 +46,7 @@ public @NullMarked class RemoveTaskVariablesCmd extends AbstractRemoveVariableCm
       .findTaskById(entityId);
 
     ensureNotNull("Cannot find task with id %s".formatted(entityId), "task", task);
+    requireNonNull(task);
 
     checkRemoveTaskVariables(task);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ResolveTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ResolveTaskCmd.java
@@ -18,14 +18,16 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
  * @author Tom Baeyens
  */
-public class ResolveTaskCmd extends CompleteTaskCmd {
-  public ResolveTaskCmd(String taskId, Map<String, Object> variables) {
+public @NullMarked class ResolveTaskCmd extends CompleteTaskCmd {
+  public ResolveTaskCmd(String taskId, @Nullable Map<String, Object> variables) {
     super(taskId, variables, false, false);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveFilterCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveFilterCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
 /**
  * @author Sebastian Menski
  */
-public class SaveFilterCmd implements Command<Filter> {
+public @NullMarked class SaveFilterCmd implements Command<Filter> {
   protected Filter filter;
 
   public SaveFilterCmd(Filter filter) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveGroupCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveGroupCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -27,7 +29,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureWhitelistedReso
 /**
  * @author Joram Barrez
  */
-public class SaveGroupCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class SaveGroupCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected Group group;
 
   public SaveGroupCmd(Group group) {
@@ -35,7 +37,7 @@ public class SaveGroupCmd extends AbstractWritableIdentityServiceCmd<Void> imple
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("group", group);
     ensureWhitelistedResourceId(commandContext, "Group", group.getId());
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveTenantCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveTenantCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.identity.Tenant;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -24,7 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureWhitelistedResourceId;
 
-public class SaveTenantCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class SaveTenantCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected Tenant tenant;
 
   public SaveTenantCmd(Tenant tenant) {
@@ -32,7 +34,7 @@ public class SaveTenantCmd extends AbstractWritableIdentityServiceCmd<Void> impl
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("tenant", tenant);
     ensureWhitelistedResourceId(commandContext, "Tenant", tenant.getId());
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveUserCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SaveUserCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.identity.User;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
@@ -29,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureWhitelistedReso
 /**
  * @author Joram Barrez
  */
-public class SaveUserCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
+public @NullMarked class SaveUserCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void> {
   protected User user;
   protected boolean skipPasswordPolicy;
 
@@ -43,7 +45,7 @@ public class SaveUserCmd extends AbstractWritableIdentityServiceCmd<Void> implem
   }
 
   @Override
-  protected Void executeCmd(CommandContext commandContext) {
+  protected @Nullable Void executeCmd(CommandContext commandContext) {
     ensureNotNull("user", user);
     ensureWhitelistedResourceId(commandContext, "User", user.getId());
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExecutionVariablesCmd.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -29,7 +31,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
+public @NullMarked class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
   protected boolean failIfNotExists = true;
 
   public SetExecutionVariablesCmd(String executionId,
@@ -53,10 +55,10 @@ public class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
   }
 
   @Override
-  protected ExecutionEntity getEntity() {
+  protected @Nullable ExecutionEntity getEntity() {
     ensureNotNull("executionId", entityId);
 
-    ExecutionEntity execution = commandContext
+    ExecutionEntity execution = getCommandContext()
       .getExecutionManager()
       .findExecutionById(entityId);
 
@@ -72,19 +74,19 @@ public class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
   }
 
   @Override
-  protected ExecutionEntity getContextExecution() {
+  protected @Nullable ExecutionEntity getContextExecution() {
     return getEntity();
   }
 
   @Override
   protected void logVariableOperation(AbstractVariableScope scope) {
     ExecutionEntity execution = (ExecutionEntity) scope;
-    commandContext.getOperationLogManager().logVariableOperation(getLogEntryOperation(), execution.getId(),
+    getCommandContext().getOperationLogManager().logVariableOperation(getLogEntryOperation(), execution.getId(),
         null, PropertyChange.EMPTY_CHANGE);
   }
 
   protected void checkSetExecutionVariables(ExecutionEntity execution) {
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    for(CommandChecker checker : getCommandContext().getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkUpdateProcessInstanceVariables(execution);
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExternalTaskPriorityCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExternalTaskPriorityCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
@@ -28,7 +29,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public class SetExternalTaskPriorityCmd extends ExternalTaskCmd {
+public @NullMarked class SetExternalTaskPriorityCmd extends ExternalTaskCmd {
 
   /**
    * The priority that should set on the external task.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExternalTaskRetriesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExternalTaskRetriesCmd.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.cmd;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
@@ -29,7 +31,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
  * @author Thorben Lindhauer
  * @author Christopher Zell
  */
-public class SetExternalTaskRetriesCmd extends ExternalTaskCmd {
+public @NullMarked class SetExternalTaskRetriesCmd extends ExternalTaskCmd {
 
   protected int retries;
   protected boolean shouldWriteUserOperationLog;
@@ -51,7 +53,7 @@ public class SetExternalTaskRetriesCmd extends ExternalTaskCmd {
   }
 
   @Override
-  protected String getUserOperationLogOperationType() {
+  protected @Nullable String getUserOperationLogOperationType() {
     if (shouldWriteUserOperationLog) {
       return UserOperationLogEntry.OPERATION_TYPE_SET_EXTERNAL_TASK_RETRIES;
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetJobsRetriesBatchCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetJobsRetriesBatchCmd.java
@@ -20,6 +20,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.JobQueryImpl;
 import org.operaton.bpm.engine.impl.batch.BatchElementConfiguration;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -29,12 +31,12 @@ import org.operaton.commons.utils.CollectionUtil;
 /**
  * @author Askar Akhmerov
  */
-public class SetJobsRetriesBatchCmd extends AbstractSetJobsRetriesBatchCmd {
+public @NullMarked class SetJobsRetriesBatchCmd extends AbstractSetJobsRetriesBatchCmd {
 
   protected List<String> ids;
   protected JobQuery jobQuery;
 
-  public SetJobsRetriesBatchCmd(List<String> ids, JobQuery jobQuery, int retries, Date dueDate, boolean isDueDateSet) {
+  public SetJobsRetriesBatchCmd(List<String> ids, JobQuery jobQuery, int retries, @Nullable Date dueDate, boolean isDueDateSet) {
     this.jobQuery = jobQuery;
     this.ids = ids;
     this.retries = retries;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskDescriptionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskDescriptionCmd.java
@@ -17,6 +17,8 @@
 
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -24,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 /**
  * Command that changes the description of a task.
  */
-public class SetTaskDescriptionCmd extends AbstractSetTaskPropertyCmd<String> {
+public @NullMarked class SetTaskDescriptionCmd extends AbstractSetTaskPropertyCmd<String> {
 
   /**
    * Public Constructor.
@@ -43,7 +45,7 @@ public class SetTaskDescriptionCmd extends AbstractSetTaskPropertyCmd<String> {
   }
 
   @Override
-  protected void executeSetOperation(TaskEntity task, String value) {
+  protected void executeSetOperation(TaskEntity task, @Nullable String value) {
     task.setDescription(value);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskDueDateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskDueDateCmd.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Date;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -26,7 +28,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 /**
  * Command to change task priority to a new value.
  */
-public class SetTaskDueDateCmd extends AbstractSetTaskPropertyCmd<Date> {
+public @NullMarked class SetTaskDueDateCmd extends AbstractSetTaskPropertyCmd<Date> {
 
   /**
    * Public Constructor.
@@ -45,7 +47,7 @@ public class SetTaskDueDateCmd extends AbstractSetTaskPropertyCmd<Date> {
   }
 
   @Override
-  protected void executeSetOperation(TaskEntity task, Date value) {
+  protected void executeSetOperation(TaskEntity task, @Nullable Date value) {
     task.setDueDate(value);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskFollowUpDateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskFollowUpDateCmd.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Date;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -26,7 +28,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 /**
  * Command to change task followUpDate to a new value.
  */
-public class SetTaskFollowUpDateCmd extends AbstractSetTaskPropertyCmd<Date> {
+public @NullMarked class SetTaskFollowUpDateCmd extends AbstractSetTaskPropertyCmd<Date> {
 
   /**
    * Constructor to create a SetTaskFollowUpDateCmd.
@@ -45,7 +47,7 @@ public class SetTaskFollowUpDateCmd extends AbstractSetTaskPropertyCmd<Date> {
   }
 
   @Override
-  protected void executeSetOperation(TaskEntity task, Date value) {
+  protected void executeSetOperation(TaskEntity task, @Nullable Date value) {
     task.setFollowUpDate(value);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskNameCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskNameCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -23,7 +25,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 /**
  * Command to change a Task's name to a new value.
  */
-public class SetTaskNameCmd extends AbstractSetTaskPropertyCmd<String> {
+public @NullMarked class SetTaskNameCmd extends AbstractSetTaskPropertyCmd<String> {
 
   /**
    * Public Constructor.
@@ -42,7 +44,7 @@ public class SetTaskNameCmd extends AbstractSetTaskPropertyCmd<String> {
   }
 
   @Override
-  protected void executeSetOperation(TaskEntity task, String value) {
+  protected void executeSetOperation(TaskEntity task, @Nullable String value) {
     task.setName(value);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskOwnerCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskOwnerCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -24,7 +25,7 @@ import org.operaton.bpm.engine.task.IdentityLinkType;
 /**
  * @author Danny Gräf
  */
-public class SetTaskOwnerCmd extends AbstractAddIdentityLinkCmd {
+public @NullMarked class SetTaskOwnerCmd extends AbstractAddIdentityLinkCmd {
   public SetTaskOwnerCmd(String taskId, String userId) {
     super(taskId, userId, null, IdentityLinkType.OWNER);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskPriorityCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskPriorityCmd.java
@@ -16,13 +16,16 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
+import org.operaton.bpm.engine.impl.DefaultPriorityProvider;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
  * Command to change task priority to a new value.
  */
-public class SetTaskPriorityCmd extends AbstractSetTaskPropertyCmd<Integer> {
+public @NullMarked class SetTaskPriorityCmd extends AbstractSetTaskPropertyCmd<Integer> {
 
   /**
    * Public constructor.
@@ -40,7 +43,7 @@ public class SetTaskPriorityCmd extends AbstractSetTaskPropertyCmd<Integer> {
   }
 
   @Override
-  protected void executeSetOperation(TaskEntity task, Integer priority) {
-    task.setPriority(priority);
+  protected void executeSetOperation(TaskEntity task, @Nullable Integer priority) {
+    task.setPriority(priority != null ? priority : (int) DefaultPriorityProvider.DEFAULT_PRIORITY);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskVariablesCmd.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.cmd;
 
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.core.variable.scope.VariableInstanceLifecycleListener;
@@ -32,7 +33,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public class SetTaskVariablesCmd extends AbstractSetVariableCmd implements VariableInstanceLifecycleListener<VariableInstanceEntity> {
+public @NullMarked class SetTaskVariablesCmd extends AbstractSetVariableCmd implements VariableInstanceLifecycleListener<VariableInstanceEntity> {
   protected boolean taskLocalVariablesUpdated;
 
   public SetTaskVariablesCmd(String taskId, Map<String, ? extends Object> variables, boolean isLocal) {
@@ -43,7 +44,7 @@ public class SetTaskVariablesCmd extends AbstractSetVariableCmd implements Varia
   protected TaskEntity getEntity() {
     ensureNotNull("taskId", entityId);
 
-    TaskEntity task =  commandContext
+    TaskEntity task =  getCommandContext()
       .getTaskManager()
       .findTaskById(entityId);
 
@@ -77,12 +78,12 @@ public class SetTaskVariablesCmd extends AbstractSetVariableCmd implements Varia
   @Override
   protected void logVariableOperation(AbstractVariableScope scope) {
     TaskEntity task = (TaskEntity) scope;
-    commandContext.getOperationLogManager().logVariableOperation(getLogEntryOperation(), null, task.getId(),
+    getCommandContext().getOperationLogManager().logVariableOperation(getLogEntryOperation(), null, task.getId(),
       PropertyChange.EMPTY_CHANGE);
   }
 
   protected void checkSetTaskVariables(TaskEntity task) {
-    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+    for(CommandChecker checker : getCommandContext().getProcessEngineConfiguration().getCommandCheckers()) {
       checker.checkUpdateTaskVariable(task);
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskVariablesCmd.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -49,6 +50,7 @@ public @NullMarked class SetTaskVariablesCmd extends AbstractSetVariableCmd impl
       .findTaskById(entityId);
 
     ensureNotNull("task %s doesn't exist".formatted(entityId), "task", task);
+    requireNonNull(task);
 
     checkSetTaskVariables(task);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendBatchCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendBatchCmd.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.batch.BatchEntity;
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.management.UpdateJobDefinitionSuspensionStateBuilderImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 
-public class SuspendBatchCmd extends AbstractSetBatchStateCmd {
+public @NullMarked class SuspendBatchCmd extends AbstractSetBatchStateCmd {
 
   public SuspendBatchCmd(String batchId) {
     super(batchId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendJobCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendJobCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.management.UpdateJobSuspensionStateBuilderImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 /**
  * @author roman.smirnov
  */
-public class SuspendJobCmd extends AbstractSetJobStateCmd {
+public @NullMarked class SuspendJobCmd extends AbstractSetJobStateCmd {
 
   public SuspendJobCmd(UpdateJobSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendJobDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendJobDefinitionCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerSuspendJobDefinitionHandler;
 import org.operaton.bpm.engine.impl.management.UpdateJobDefinitionSuspensionStateBuilderImpl;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 /**
  * @author roman.smirnov
  */
-public class SuspendJobDefinitionCmd extends AbstractSetJobDefinitionStateCmd {
+public @NullMarked class SuspendJobDefinitionCmd extends AbstractSetJobDefinitionStateCmd {
 
   public SuspendJobDefinitionCmd(UpdateJobDefinitionSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendProcessDefinitionCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerSuspendProcessDefinitionHandler;
 import org.operaton.bpm.engine.impl.management.UpdateJobDefinitionSuspensionStateBuilderImpl;
@@ -28,7 +29,7 @@ import org.operaton.bpm.engine.impl.runtime.UpdateProcessInstanceSuspensionState
  * @author Joram Barrez
  * @author roman.smirnov
  */
-public class SuspendProcessDefinitionCmd extends AbstractSetProcessDefinitionStateCmd {
+public @NullMarked class SuspendProcessDefinitionCmd extends AbstractSetProcessDefinitionStateCmd {
 
   public SuspendProcessDefinitionCmd(UpdateProcessDefinitionSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SuspendProcessInstanceCmd.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.impl.management.UpdateJobSuspensionStateBuilderImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.runtime.UpdateProcessInstanceSuspensionState
  *
  * @author Daniel Meyer
  */
-public class SuspendProcessInstanceCmd extends AbstractSetProcessInstanceStateCmd {
+public @NullMarked class SuspendProcessInstanceCmd extends AbstractSetProcessInstanceStateCmd {
 
   public SuspendProcessInstanceCmd(UpdateProcessInstanceSuspensionStateBuilderImpl builder) {
     super(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstanceCancellationCmd.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -23,34 +25,38 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.TransitionInstance;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Thorben Lindhauer
  *
  */
-public class TransitionInstanceCancellationCmd extends AbstractInstanceCancellationCmd {
+public @NullMarked class TransitionInstanceCancellationCmd extends AbstractInstanceCancellationCmd {
 
-  protected String transitionInstanceId;
+  protected @Nullable String transitionInstanceId;
 
-  public TransitionInstanceCancellationCmd(String processInstanceId, String transitionInstanceId) {
+  public TransitionInstanceCancellationCmd(String processInstanceId, @Nullable String transitionInstanceId) {
     super(processInstanceId);
     this.transitionInstanceId = transitionInstanceId;
 
   }
 
-  public String getTransitionInstanceId() {
+  public @Nullable String getTransitionInstanceId() {
     return transitionInstanceId;
   }
 
   @Override
-  protected ExecutionEntity determineSourceInstanceExecution(final CommandContext commandContext) {
+  protected @Nullable ExecutionEntity determineSourceInstanceExecution(final CommandContext commandContext) {
     ActivityInstance instance = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
+    requireNonNull(instance);
+
     TransitionInstance instanceToCancel = findTransitionInstance(instance, transitionInstanceId);
     EnsureUtil.ensureNotNull(NotValidException.class,
         describeFailure("Transition instance '%s' does not exist".formatted(transitionInstanceId)),
         "transitionInstance",
         instanceToCancel);
 
-    return commandContext.getExecutionManager().findExecutionById(instanceToCancel.getExecutionId());
+    return commandContext.getExecutionManager().findExecutionById(requireNonNull(instanceToCancel).getExecutionId());
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstantiationCmd.java
@@ -16,10 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.core.model.CoreModelElement;
+import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.operaton.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.operaton.bpm.engine.impl.pvm.process.TransitionImpl;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Thorben Lindhauer
@@ -46,11 +50,12 @@ public class TransitionInstantiationCmd extends AbstractInstantiationCmd {
   @Override
   protected ScopeImpl getTargetFlowScope(ProcessDefinitionImpl processDefinition) {
     TransitionImpl transition = processDefinition.findTransition(transitionId);
-    return transition.getSource().getFlowScope();
+    ActivityImpl source = requireNonNull(transition.getSource());
+    return source.getFlowScope();
   }
 
   @Override
-  protected CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition) {
+  protected @Nullable CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition) {
     return processDefinition.findTransition(transitionId);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
@@ -20,6 +20,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NonNull;
 import org.operaton.bpm.application.InvocationContext;
 
 import org.jspecify.annotations.Nullable;
@@ -34,7 +35,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.interceptor.CommandInvocationContext;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutorContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
-
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
 /**
  * Holds the context of the current command being executed.
@@ -63,6 +64,18 @@ public final class Context {
     }
     return stack.peek();
   }
+
+  /**
+   * Returns the current command context. If no command context is active, an exception is thrown.
+   *
+   * @return the current command context
+   * @throws IllegalStateException if no command context is active
+   * @since 2.2
+   */
+  public static @NonNull CommandContext getRequiredCommandContext() {
+    return EnsureUtil.ensureActiveCommandContext(getCommandContext());
+  }
+
 
   public static void setCommandContext(CommandContext commandContext) {
     getStack(commandContextThreadLocal).push(commandContext);
@@ -109,6 +122,21 @@ public final class Context {
     return stack.peek();
   }
 
+  /**
+   * Returns the current process engine configuration. If no process engine configuration is active, an exception is thrown.
+   *
+   * @return the current process engine configuration
+   * @throws IllegalStateException if no process engine configuration is active
+   * @since 2.2
+   */
+  public static @NonNull ProcessEngineConfigurationImpl getRequiredProcessEngineConfiguration() {
+    ProcessEngineConfigurationImpl processEngineConfiguration = getProcessEngineConfiguration();
+    if (processEngineConfiguration == null) {
+      throw new IllegalStateException("No process engine configuration active on thread " + Thread.currentThread());
+    }
+    return processEngineConfiguration;
+  }
+
   public static void setProcessEngineConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {
     getStack(processEngineConfigurationStackThreadLocal).push(processEngineConfiguration);
   }
@@ -121,15 +149,15 @@ public final class Context {
    * @deprecated Use {@link #getBpmnExecutionContext()} instead.
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  public static ExecutionContext getExecutionContext() {
+  public static @Nullable ExecutionContext getExecutionContext() {
     return getBpmnExecutionContext();
   }
 
-  public static BpmnExecutionContext getBpmnExecutionContext() {
+  public static @Nullable BpmnExecutionContext getBpmnExecutionContext() {
     return (BpmnExecutionContext) getCoreExecutionContext();
   }
 
-  public static CaseExecutionContext getCaseExecutionContext() {
+  public static @Nullable CaseExecutionContext getCaseExecutionContext() {
     return (CaseExecutionContext) getCoreExecutionContext();
   }
 
@@ -198,11 +226,11 @@ public final class Context {
    * Use {@link #executeWithinProcessApplication(Callable, ProcessApplicationReference, InvocationContext)}
    * instead if an {@link InvocationContext} is available.
    */
-  public static <T> T executeWithinProcessApplication(Callable<T> callback, ProcessApplicationReference processApplicationReference) {
+  public static <T> @Nullable T executeWithinProcessApplication(Callable<T> callback, ProcessApplicationReference processApplicationReference) {
     return executeWithinProcessApplication(callback, processApplicationReference, null);
   }
 
-  public static <T> T executeWithinProcessApplication(Callable<T> callback, ProcessApplicationReference processApplicationReference, InvocationContext invocationContext) {
+  public static <T> @Nullable T executeWithinProcessApplication(Callable<T> callback, ProcessApplicationReference processApplicationReference, InvocationContext invocationContext) {
     String paName = processApplicationReference.getName();
     try {
       ProcessApplicationInterface processApplication = processApplicationReference.getProcessApplication();
@@ -214,7 +242,7 @@ public final class Context {
     }
   }
 
-  private static <T> T executeWrappedCallback(Callable<T> callback, InvocationContext invocationContext,
+  private static <T> @Nullable T executeWrappedCallback(Callable<T> callback, InvocationContext invocationContext,
       ProcessApplicationInterface processApplication) {
     try {
       // wrap callback

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
@@ -59,13 +59,22 @@ public final class Context {
   }
 
   /**
+   * @return {@code true} if a command context is active on the current thread
    * @since 2.2
    */
   public static boolean hasActiveCommandContext() {
-    return getCommandContextWhenAvailable().isPresent();
+    return findCommandContext().isPresent();
   }
 
-  public static Optional<CommandContext> getCommandContextWhenAvailable() {
+  /**
+   * Returns the current command context, if any is active on the current thread.
+   * Use this over {@link #getCommandContext()} when the absence of a command context
+   * is a valid case to be handled rather than an error.
+   *
+   * @return the current command context, or {@link Optional#empty()} if none is active
+   * @since 2.2
+   */
+  public static Optional<CommandContext> findCommandContext() {
     Deque<CommandContext> stack = getStack(commandContextThreadLocal);
     if (stack.isEmpty()) {
       return Optional.empty();
@@ -75,15 +84,16 @@ public final class Context {
 
   /**
    * Returns the current command context. If no command context is active, an exception is thrown.
-   * This is a null-safe version of {@link #getCommandContext()}, which is useful in cases where the command context is
-   * required to be present. This supports the IDE in detecting potential null pointer exceptions at compile time.
+   * This is a null-safe alternative to reading the top of the command context stack directly,
+   * useful in cases where the command context is required to be present. It supports the IDE
+   * in detecting potential null pointer exceptions at compile time. Use {@link #findCommandContext()}
+   * instead if the absence of a command context is expected and should be handled explicitly.
    *
    * @return the current command context
    * @throws IllegalStateException if no command context is active
-   * @since 2.2
    */
   public static @NonNull CommandContext getCommandContext() {
-    return EnsureUtil.ensureActiveCommandContext(getCommandContextWhenAvailable().orElse(null));
+    return EnsureUtil.ensureActiveCommandContext(findCommandContext().orElse(null));
   }
 
 
@@ -124,11 +134,23 @@ public final class Context {
     }
   }
 
+  /**
+   * @return {@code true} if a process engine configuration is active on the current thread
+   * @since 2.2
+   */
   public static boolean hasActiveProcessEngineConfiguration() {
-    return getProcessEngineConfigurationWhenAvailable().isPresent();
+    return findProcessEngineConfiguration().isPresent();
   }
 
-  public static Optional<ProcessEngineConfigurationImpl> getProcessEngineConfigurationWhenAvailable() {
+  /**
+   * Returns the current process engine configuration, if any is active on the current thread.
+   * Use this over {@link #getProcessEngineConfiguration()} when the absence of a process engine
+   * configuration is a valid case to be handled rather than an error.
+   *
+   * @return the current process engine configuration, or {@link Optional#empty()} if none is active
+   * @since 2.2
+   */
+  public static Optional<ProcessEngineConfigurationImpl> findProcessEngineConfiguration() {
     Deque<ProcessEngineConfigurationImpl> stack = getStack(processEngineConfigurationStackThreadLocal);
     if (stack.isEmpty()) {
       return Optional.empty();
@@ -138,15 +160,16 @@ public final class Context {
 
   /**
    * Returns the current process engine configuration. If no process engine configuration is active, an exception is thrown.
-   * This is a null-safe version of {@link #getProcessEngineConfiguration()}, which is useful in cases where the command context is
-   * required to be present. This supports the IDE in detecting potential null pointer exceptions at compile time.
+   * This is a null-safe alternative to reading the top of the process engine configuration stack directly,
+   * useful in cases where the process engine configuration is required to be present. It supports the IDE
+   * in detecting potential null pointer exceptions at compile time. Use {@link #findProcessEngineConfiguration()}
+   * instead if the absence of a process engine configuration is expected and should be handled explicitly.
    *
    * @return the current process engine configuration
    * @throws IllegalStateException if no process engine configuration is active
-   * @since 2.2
    */
   public static @NonNull ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
-    Optional<ProcessEngineConfigurationImpl> processEngineConfiguration = getProcessEngineConfigurationWhenAvailable();
+    Optional<ProcessEngineConfigurationImpl> processEngineConfiguration = findProcessEngineConfiguration();
     if (processEngineConfiguration.isEmpty()) {
       throw new IllegalStateException("No process engine configuration active on thread " + Thread.currentThread());
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.context;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.jspecify.annotations.NonNull;
@@ -57,12 +58,19 @@ public final class Context {
   private Context() {
   }
 
-  public static @Nullable CommandContext getCommandContext() {
+  /**
+   * @since 2.2
+   */
+  public static boolean hasActiveCommandContext() {
+    return getCommandContextWhenAvailable().isPresent();
+  }
+
+  public static Optional<CommandContext> getCommandContextWhenAvailable() {
     Deque<CommandContext> stack = getStack(commandContextThreadLocal);
     if (stack.isEmpty()) {
-      return null;
+      return Optional.empty();
     }
-    return stack.peek();
+    return Optional.of(stack.peek());
   }
 
   /**
@@ -74,12 +82,12 @@ public final class Context {
    * @throws IllegalStateException if no command context is active
    * @since 2.2
    */
-  public static @NonNull CommandContext getRequiredCommandContext() {
-    return EnsureUtil.ensureActiveCommandContext(getCommandContext());
+  public static @NonNull CommandContext getCommandContext() {
+    return EnsureUtil.ensureActiveCommandContext(getCommandContextWhenAvailable().orElse(null));
   }
 
 
-  public static void setCommandContext(CommandContext commandContext) {
+  public static void setCommandContext(@NonNull CommandContext commandContext) {
     getStack(commandContextThreadLocal).push(commandContext);
   }
 
@@ -116,29 +124,33 @@ public final class Context {
     }
   }
 
-  public static @Nullable ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+  public static boolean hasActiveProcessEngineConfiguration() {
+    return getProcessEngineConfigurationWhenAvailable().isPresent();
+  }
+
+  public static Optional<ProcessEngineConfigurationImpl> getProcessEngineConfigurationWhenAvailable() {
     Deque<ProcessEngineConfigurationImpl> stack = getStack(processEngineConfigurationStackThreadLocal);
     if (stack.isEmpty()) {
-      return null;
+      return Optional.empty();
     }
-    return stack.peek();
+    return Optional.of(stack.peek());
   }
 
   /**
    * Returns the current process engine configuration. If no process engine configuration is active, an exception is thrown.
-   * This is a null-safe version of {@link #getRequiredProcessEngineConfiguration()}, which is useful in cases where the command context is
+   * This is a null-safe version of {@link #getProcessEngineConfiguration()}, which is useful in cases where the command context is
    * required to be present. This supports the IDE in detecting potential null pointer exceptions at compile time.
    *
    * @return the current process engine configuration
    * @throws IllegalStateException if no process engine configuration is active
    * @since 2.2
    */
-  public static @NonNull ProcessEngineConfigurationImpl getRequiredProcessEngineConfiguration() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = getProcessEngineConfiguration();
-    if (processEngineConfiguration == null) {
+  public static @NonNull ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+    Optional<ProcessEngineConfigurationImpl> processEngineConfiguration = getProcessEngineConfigurationWhenAvailable();
+    if (processEngineConfiguration.isEmpty()) {
       throw new IllegalStateException("No process engine configuration active on thread " + Thread.currentThread());
     }
-    return processEngineConfiguration;
+    return processEngineConfiguration.get();
   }
 
   public static void setProcessEngineConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
@@ -67,6 +67,8 @@ public final class Context {
 
   /**
    * Returns the current command context. If no command context is active, an exception is thrown.
+   * This is a null-safe version of {@link #getCommandContext()}, which is useful in cases where the command context is
+   * required to be present. This supports the IDE in detecting potential null pointer exceptions at compile time.
    *
    * @return the current command context
    * @throws IllegalStateException if no command context is active
@@ -124,6 +126,8 @@ public final class Context {
 
   /**
    * Returns the current process engine configuration. If no process engine configuration is active, an exception is thrown.
+   * This is a null-safe version of {@link #getRequiredProcessEngineConfiguration()}, which is useful in cases where the command context is
+   * required to be present. This supports the IDE in detecting potential null pointer exceptions at compile time.
    *
    * @return the current process engine configuration
    * @throws IllegalStateException if no process engine configuration is active

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/VariableUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/VariableUtil.java
@@ -51,6 +51,9 @@ public final class VariableUtil {
    * @param value
    */
   public static boolean isJavaSerializationProhibited(TypedValue value) {
+    if (!Context.hasActiveProcessEngineConfiguration()) {
+      return false;
+    }
     ProcessEngineConfigurationImpl processEngineConfiguration =
         Context.getProcessEngineConfiguration();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/DbEntityManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/DbEntityManager.java
@@ -45,6 +45,7 @@ import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.repository.ResourceTypes;
 import org.operaton.commons.utils.CollectionUtil;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.db.entitymanager.cache.DbEntityState.*;
 import static org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperationType.*;
 
@@ -428,8 +429,9 @@ public class DbEntityManager implements Session, EntityLoadListener {
    */
   protected boolean canIgnoreHistoryModificationFailure(DbOperation dbOperation) {
     DbEntity dbEntity = ((DbEntityOperation) dbOperation).getEntity();
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
     return
-        Context.getProcessEngineConfiguration().isSkipHistoryOptimisticLockingExceptions()
+        processEngineConfiguration.isSkipHistoryOptimisticLockingExceptions()
         && (dbEntity instanceof HistoricEntity || isHistoricByteArray(dbEntity));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/DbEntityManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/DbEntityManager.java
@@ -89,7 +89,7 @@ public class DbEntityManager implements Session, EntityLoadListener {
   protected void initializeEntityCache() {
 
     final JobExecutorContext jobExecutorContext = Context.getJobExecutorContext();
-    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.findProcessEngineConfiguration().orElse(null);
 
     if(processEngineConfiguration != null
         && processEngineConfiguration.isDbEntityCacheReuseEnabled()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/el/ProcessEngineJuelElExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/el/ProcessEngineJuelElExpression.java
@@ -21,7 +21,6 @@ import jakarta.el.ValueExpression;
 
 import org.operaton.bpm.dmn.engine.impl.spi.el.ElExpression;
 import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.el.JuelExpressionManager;
 import org.operaton.bpm.engine.variable.context.VariableContext;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/el/ProcessEngineJuelElExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/el/ProcessEngineJuelElExpression.java
@@ -25,6 +25,8 @@ import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.el.JuelExpressionManager;
 import org.operaton.bpm.engine.variable.context.VariableContext;
 
+import static org.operaton.bpm.engine.impl.context.Context.hasActiveCommandContext;
+
 /**
  * @author Daniel Meyer
  *
@@ -41,7 +43,7 @@ public class ProcessEngineJuelElExpression implements ElExpression {
 
   @Override
   public Object getValue(VariableContext variableContext) {
-    if(Context.getCommandContext() == null) {
+    if(!hasActiveCommandContext()) {
       throw new ProcessEngineException("Expression can only be evaluated inside the context of the process engine");
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/CommandContextFunctions.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/CommandContextFunctions.java
@@ -35,13 +35,13 @@ public final class CommandContextFunctions {
   }
 
   public static @Nullable String currentUser() {
-    return Context.getCommandContextWhenAvailable()
+    return Context.findCommandContext()
       .map(CommandContext::getAuthenticatedUserId)
       .orElse(null);
   }
 
   public static List<String> currentUserGroups() {
-    return Context.getCommandContextWhenAvailable()
+    return Context.findCommandContext()
       .map(CommandContext::getAuthenticatedGroupIds)
       .orElse(Collections.emptyList());
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/CommandContextFunctions.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/CommandContextFunctions.java
@@ -35,22 +35,14 @@ public final class CommandContextFunctions {
   }
 
   public static @Nullable String currentUser() {
-    CommandContext commandContext = Context.getCommandContext();
-    if (commandContext != null) {
-      return commandContext.getAuthenticatedUserId();
-    }
-    else {
-      return null;
-    }
+    return Context.getCommandContextWhenAvailable()
+      .map(CommandContext::getAuthenticatedUserId)
+      .orElse(null);
   }
 
   public static List<String> currentUserGroups() {
-    CommandContext commandContext = Context.getCommandContext();
-    if (commandContext != null) {
-      return commandContext.getAuthenticatedGroupIds();
-    }
-    else {
-      return Collections.emptyList();
-    }
+    return Context.getCommandContextWhenAvailable()
+      .map(CommandContext::getAuthenticatedGroupIds)
+      .orElse(Collections.emptyList());
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/CacheAwareHistoryEventProducer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/CacheAwareHistoryEventProducer.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.history.producer;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.DelegateTask;
 import org.operaton.bpm.engine.impl.batch.BatchEntity;
 import org.operaton.bpm.engine.impl.batch.history.HistoricBatchEntity;
@@ -114,16 +115,14 @@ public class CacheAwareHistoryEventProducer extends DefaultHistoryEventProducer 
   }
 
   @Override
-  protected ProcessDefinitionEntity getProcessDefinitionEntity(String processDefinitionId) {
-    CommandContext commandContext = Context.getCommandContext();
-    if (commandContext == null) {
+  protected @Nullable ProcessDefinitionEntity getProcessDefinitionEntity(String processDefinitionId) {
+    if (Context.hasActiveCommandContext()) {
       return null;
     }
 
+    CommandContext commandContext = Context.getCommandContext();
+
     DbEntityManager dbEntityManager = commandContext.getDbEntityManager();
-    if (dbEntityManager == null) {
-      return null;
-    }
 
     ProcessDefinitionEntity cachedEntity = dbEntityManager.getCachedEntity(ProcessDefinitionEntity.class, processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/CacheAwareHistoryEventProducer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/CacheAwareHistoryEventProducer.java
@@ -116,7 +116,7 @@ public class CacheAwareHistoryEventProducer extends DefaultHistoryEventProducer 
 
   @Override
   protected @Nullable ProcessDefinitionEntity getProcessDefinitionEntity(String processDefinitionId) {
-    if (Context.hasActiveCommandContext()) {
+    if (!Context.hasActiveCommandContext()) {
       return null;
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
@@ -1416,15 +1416,11 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
   }
 
   protected ProcessDefinitionEntity getProcessDefinitionEntity(String processDefinitionId) {
+    if (!Context.hasActiveCommandContext()) {
+      return null;
+    }
     CommandContext commandContext = Context.getCommandContext();
-    if (commandContext == null) {
-      return null;
-    }
-
     DbEntityManager dbEntityManager = commandContext.getDbEntityManager();
-    if (dbEntityManager == null) {
-      return null;
-    }
 
     return dbEntityManager.selectById(ProcessDefinitionEntity.class, processDefinitionId);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/identity/ReadOnlyIdentityProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/identity/ReadOnlyIdentityProvider.java
@@ -65,7 +65,7 @@ public interface ReadOnlyIdentityProvider extends Session {
    * @return 'true' if the password matches the
    * @throws IdentityProviderException in case an error occurs
    */
-  boolean checkPassword(String userId, String password);
+  boolean checkPassword(@Nullable String userId, @Nullable String password);
 
   // groups //////////////////////////////////////
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/DbReadOnlyIdentityServiceProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/DbReadOnlyIdentityServiceProvider.java
@@ -30,6 +30,7 @@ import org.operaton.bpm.engine.identity.*;
 import org.operaton.bpm.engine.impl.AbstractQuery;
 import org.operaton.bpm.engine.impl.NativeUserQueryImpl;
 import org.operaton.bpm.engine.impl.UserQueryImpl;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.identity.ReadOnlyIdentityProvider;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -37,7 +38,9 @@ import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.persistence.entity.GroupEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TenantEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.UserEntity;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EncryptionUtil.saltPassword;
 
 /**
@@ -59,7 +62,7 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
 
   @Override
   public UserQuery createUserQuery() {
-    return new DbUserQueryImpl(Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new DbUserQueryImpl(Context.getRequiredProcessEngineConfiguration().getCommandExecutorTxRequired());
   }
 
   @Override
@@ -68,7 +71,7 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
   }
 
   @Override public NativeUserQuery createNativeUserQuery() {
-    return new NativeUserQueryImpl(Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new NativeUserQueryImpl(Context.getRequiredProcessEngineConfiguration().getCommandExecutorTxRequired());
   }
 
   public long findUserCountByQueryCriteria(DbUserQueryImpl query) {
@@ -97,7 +100,8 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
 
   protected boolean matchPassword(String password, UserEntity user) {
     String saltedPassword = saltPassword(password, user.getSalt());
-    return Context.getProcessEngineConfiguration()
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    return processEngineConfiguration
       .getPasswordManager()
       .check(saltedPassword, user.getPassword());
   }
@@ -112,7 +116,8 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
 
   @Override
   public GroupQuery createGroupQuery() {
-    return new DbGroupQueryImpl(Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    return new DbGroupQueryImpl(processEngineConfiguration.getCommandExecutorTxRequired());
   }
 
   @Override
@@ -140,7 +145,8 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
 
   @Override
   public TenantQuery createTenantQuery() {
-    return new DbTenantQueryImpl(Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    ProcessEngineConfigurationImpl processEngineConfiguration = requireNonNull(Context.getProcessEngineConfiguration());
+    return new DbTenantQueryImpl(processEngineConfiguration.getCommandExecutorTxRequired());
   }
 
   @Override
@@ -182,14 +188,18 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
 
   @Override
   protected void configureQuery(@SuppressWarnings("rawtypes") AbstractQuery query, Resource resource) {
-    Context.getCommandContext()
+    CommandContext commandContext = Context.getCommandContext();
+    EnsureUtil.ensureActiveCommandContext(commandContext);
+    commandContext
       .getAuthorizationManager()
       .configureQuery(query, resource);
   }
 
   @Override
   protected void checkAuthorization(Permission permission, Resource resource, String resourceId) {
-    Context.getCommandContext()
+    CommandContext commandContext = Context.getCommandContext();
+    EnsureUtil.ensureActiveCommandContext(commandContext);
+    commandContext
       .getAuthorizationManager()
       .checkAuthorization(permission, resource, resourceId);
  }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/DbReadOnlyIdentityServiceProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/DbReadOnlyIdentityServiceProvider.java
@@ -38,7 +38,6 @@ import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.persistence.entity.GroupEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TenantEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.UserEntity;
-import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
 import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EncryptionUtil.saltPassword;
@@ -189,7 +188,6 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
   @Override
   protected void configureQuery(@SuppressWarnings("rawtypes") AbstractQuery query, Resource resource) {
     CommandContext commandContext = Context.getCommandContext();
-    EnsureUtil.ensureActiveCommandContext(commandContext);
     commandContext
       .getAuthorizationManager()
       .configureQuery(query, resource);
@@ -198,7 +196,6 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
   @Override
   protected void checkAuthorization(Permission permission, Resource resource, String resourceId) {
     CommandContext commandContext = Context.getCommandContext();
-    EnsureUtil.ensureActiveCommandContext(commandContext);
     commandContext
       .getAuthorizationManager()
       .checkAuthorization(permission, resource, resourceId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/DbReadOnlyIdentityServiceProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/DbReadOnlyIdentityServiceProvider.java
@@ -62,7 +62,7 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
 
   @Override
   public UserQuery createUserQuery() {
-    return new DbUserQueryImpl(Context.getRequiredProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new DbUserQueryImpl(Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
   }
 
   @Override
@@ -71,7 +71,7 @@ public class DbReadOnlyIdentityServiceProvider extends AbstractManager implement
   }
 
   @Override public NativeUserQuery createNativeUserQuery() {
-    return new NativeUserQueryImpl(Context.getRequiredProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new NativeUserQueryImpl(Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
   }
 
   public long findUserCountByQueryCriteria(DbUserQueryImpl query) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/Command.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/Command.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.interceptor;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -23,6 +24,6 @@ import org.jspecify.annotations.Nullable;
  */
 public interface Command<T> {
 
-  @Nullable T execute(CommandContext commandContext);
+  @Nullable T execute(@NonNull CommandContext commandContext);
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContext.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.application.InvocationContext;
 
 import org.jspecify.annotations.Nullable;
@@ -56,6 +58,7 @@ import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.operaton.bpm.engine.impl.jobexecutor.FailedJobCommandFactory;
 import org.operaton.bpm.engine.impl.optimize.OptimizeManager;
 import org.operaton.bpm.engine.impl.persistence.entity.*;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 import static java.util.Collections.emptyList;
@@ -65,7 +68,7 @@ import static java.util.Collections.emptyList;
  * @author Agim Emruli
  * @author Daniel Meyer
  */
-public class CommandContext {
+public @NullMarked class CommandContext {
 
   private static final ContextLogger LOG = ProcessEngineLogger.CONTEXT_LOGGER;
 
@@ -81,11 +84,11 @@ public class CommandContext {
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected FailedJobCommandFactory failedJobCommandFactory;
 
-  protected JobEntity currentJob;
+  protected @Nullable JobEntity currentJob;
 
   protected List<CommandContextListener> commandContextListeners = new LinkedList<>();
 
-  protected String operationId;
+  protected @Nullable String operationId;
 
   public CommandContext(ProcessEngineConfigurationImpl processEngineConfiguration) {
     this(processEngineConfiguration, processEngineConfiguration.getTransactionContextFactory());
@@ -124,7 +127,7 @@ public class CommandContext {
     return processEngineConfiguration;
   }
 
-  protected ProcessApplicationReference getTargetProcessApplication(CaseExecutionEntity execution) {
+  protected @Nullable ProcessApplicationReference getTargetProcessApplication(CaseExecutionEntity execution) {
     return ProcessApplicationContextUtil.getTargetProcessApplication(execution);
   }
 
@@ -499,13 +502,13 @@ public class CommandContext {
     return identityService.getCurrentAuthentication();
   }
 
-  public <T> T runWithoutAuthorization(Callable<T> runnable) {
-    CommandContext commandContext = Context.getCommandContext();
+  public <T> @Nullable T runWithoutAuthorization(Callable<T> runnable) {
+    CommandContext commandContext = EnsureUtil.ensureActiveCommandContext(Context.getCommandContext());
     return runWithoutAuthorization(runnable, commandContext);
   }
 
-  public <T> T runWithoutAuthorization(Command<T> command) {
-    CommandContext commandContext = Context.getCommandContext();
+  public <T> @Nullable T runWithoutAuthorization(Command<T> command) {
+    CommandContext commandContext = EnsureUtil.ensureActiveCommandContext(Context.getCommandContext());
     return runWithoutAuthorization(() -> command.execute(commandContext), commandContext);
   }
 
@@ -593,7 +596,7 @@ public class CommandContext {
     return tenantCheckEnabled;
   }
 
-  public JobEntity getCurrentJob() {
+  public @Nullable JobEntity getCurrentJob() {
     return currentJob;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContext.java
@@ -57,7 +57,6 @@ import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.operaton.bpm.engine.impl.jobexecutor.FailedJobCommandFactory;
 import org.operaton.bpm.engine.impl.optimize.OptimizeManager;
 import org.operaton.bpm.engine.impl.persistence.entity.*;
-import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 import static java.util.Collections.emptyList;
@@ -130,7 +129,7 @@ public @NullMarked class CommandContext {
     return ProcessApplicationContextUtil.getTargetProcessApplication(execution);
   }
 
-  protected boolean requiresContextSwitch(ProcessApplicationReference processApplicationReference) {
+  protected boolean requiresContextSwitch(@Nullable ProcessApplicationReference processApplicationReference) {
     return ProcessApplicationContextUtil.requiresContextSwitch(processApplicationReference);
   }
 
@@ -502,12 +501,12 @@ public @NullMarked class CommandContext {
   }
 
   public <T> @Nullable T runWithoutAuthorization(Callable<T> runnable) {
-    CommandContext commandContext = EnsureUtil.ensureActiveCommandContext(Context.getCommandContext());
+    CommandContext commandContext = Context.getCommandContext();
     return runWithoutAuthorization(runnable, commandContext);
   }
 
   public <T> @Nullable T runWithoutAuthorization(Command<T> command) {
-    CommandContext commandContext = EnsureUtil.ensureActiveCommandContext(Context.getCommandContext());
+    CommandContext commandContext = Context.getCommandContext();
     return runWithoutAuthorization(() -> command.execute(commandContext), commandContext);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContext.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.application.InvocationContext;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContextInterceptor.java
@@ -26,6 +26,8 @@ import org.operaton.bpm.engine.impl.cmd.CommandLogger;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.context.ProcessEngineContextImpl;
 
+import java.util.Optional;
+
 /**
  * <p>Interceptor used for opening the {@link CommandContext} and {@link CommandInvocationContext}.</p>
  *
@@ -84,9 +86,9 @@ public class CommandContextInterceptor extends CommandInterceptor {
 
     if(!alwaysOpenNew) {
       // check whether we can reuse the command context
-      CommandContext existingCommandContext = Context.getCommandContext();
-      if(existingCommandContext != null && isFromSameEngine(existingCommandContext)) {
-        context = existingCommandContext;
+      Optional<CommandContext> existingCommandContext = Context.getCommandContextWhenAvailable();
+      if(existingCommandContext.isPresent() && isFromSameEngine(existingCommandContext.get())) {
+        context = existingCommandContext.get();
       }
     }
 
@@ -102,10 +104,8 @@ public class CommandContextInterceptor extends CommandInterceptor {
       if(openNew) {
         LOG.debugOpeningNewCommandContext();
         context = commandContextFactory.createCommandContext();
-
       } else {
         LOG.debugReusingExistingCommandContext();
-
       }
 
       Context.setCommandContext(context);
@@ -116,7 +116,6 @@ public class CommandContextInterceptor extends CommandInterceptor {
 
     } catch (Throwable t) {
       commandInvocationContext.trySetThrowable(t);
-
     } finally {
       try {
         if (openNew) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/CommandContextInterceptor.java
@@ -86,7 +86,7 @@ public class CommandContextInterceptor extends CommandInterceptor {
 
     if(!alwaysOpenNew) {
       // check whether we can reuse the command context
-      Optional<CommandContext> existingCommandContext = Context.getCommandContextWhenAvailable();
+      Optional<CommandContext> existingCommandContext = Context.findCommandContext();
       if(existingCommandContext.isPresent() && isFromSameEngine(existingCommandContext.get())) {
         context = existingCommandContext.get();
       }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerActivateProcessDefinitionHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerActivateProcessDefinitionHandler.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.jobexecutor;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cmd.AbstractSetProcessDefinitionStateCmd;
 import org.operaton.bpm.engine.impl.cmd.ActivateProcessDefinitionCmd;
 
@@ -23,6 +24,7 @@ import org.operaton.bpm.engine.impl.cmd.ActivateProcessDefinitionCmd;
  * @author Joram Barrez
  * @author roman.smirnov
  */
+@NullMarked
 public class TimerActivateProcessDefinitionHandler extends TimerChangeProcessDefinitionSuspensionStateJobHandler {
 
   public static final String TYPE = "activate-processdefinition";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeProcessDefinitionSuspensionStateJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeProcessDefinitionSuspensionStateJobHandler.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.jobexecutor;
 
 import com.google.gson.JsonObject;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cmd.AbstractSetProcessDefinitionStateCmd;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -30,6 +32,7 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
  * @author Joram Barrez
  * @author roman.smirnov
  */
+@NullMarked
 public abstract class TimerChangeProcessDefinitionSuspensionStateJobHandler implements JobHandler<ProcessDefinitionSuspensionStateConfiguration> {
 
   protected static final String JOB_HANDLER_CFG_BY = "by";
@@ -57,12 +60,12 @@ public abstract class TimerChangeProcessDefinitionSuspensionStateJobHandler impl
 
   public static class ProcessDefinitionSuspensionStateConfiguration implements JobHandlerConfiguration {
 
-    protected String processDefinitionKey;
-    protected String processDefinitionId;
+    protected @Nullable String processDefinitionKey;
+    protected @Nullable String processDefinitionId;
     protected boolean includeProcessInstances;
-    protected String tenantId;
+    protected @Nullable String tenantId;
     protected boolean isTenantIdSet;
-    protected String by;
+    protected @Nullable String by;
 
     @Override
     public String toCanonicalString() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerSuspendProcessDefinitionHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerSuspendProcessDefinitionHandler.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.jobexecutor;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cmd.AbstractSetProcessDefinitionStateCmd;
 import org.operaton.bpm.engine.impl.cmd.SuspendProcessDefinitionCmd;
 
@@ -23,6 +24,7 @@ import org.operaton.bpm.engine.impl.cmd.SuspendProcessDefinitionCmd;
  * @author Joram Barrez
  * @author roman.smirnov
  */
+@NullMarked
 public class TimerSuspendProcessDefinitionHandler extends TimerChangeProcessDefinitionSuspensionStateJobHandler {
 
   public static final String TYPE = "suspend-processdefinition";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/oplog/UserOperationLogContextEntryBuilder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/oplog/UserOperationLogContextEntryBuilder.java
@@ -137,12 +137,18 @@ public class UserOperationLogContextEntryBuilder {
     return this;
   }
 
-  public UserOperationLogContextEntryBuilder inContextOf(HistoricTaskInstance task, List<PropertyChange> propertyChanges) {
+  public UserOperationLogContextEntryBuilder inContextOf(@Nullable HistoricTaskInstance task, List<PropertyChange> propertyChanges) {
 
     if ((propertyChanges == null || propertyChanges.isEmpty()) && OPERATION_TYPE_CREATE.equals(entry.getOperationType())) {
       propertyChanges = List.of(PropertyChange.EMPTY_CHANGE);
     }
     entry.setPropertyChanges(propertyChanges);
+
+    if (task == null) {
+      // the task no longer exists, e.g. when deleting an unexisting historic task instance;
+      // the operation is still logged, just without any task context
+      return this;
+    }
 
     entry.setProcessDefinitionKey(task.getProcessDefinitionKey());
     entry.setProcessDefinitionId(task.getProcessDefinitionId());

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -150,7 +150,7 @@ public class AuthorizationManager extends AbstractManager {
     return new PermissionCheckBuilder();
   }
 
-  public Authorization createNewAuthorization(int type) {
+  public @NonNull Authorization createNewAuthorization(int type) {
     checkAuthorization(CREATE, AUTHORIZATION, null);
     return new AuthorizationEntity(type);
   }
@@ -300,7 +300,7 @@ public class AuthorizationManager extends AbstractManager {
     Boolean isRevokeAuthCheckEnabled = this.isRevokeAuthCheckUsed;
 
     if(isRevokeAuthCheckEnabled == null) {
-      String configuredMode = Context.getProcessEngineConfiguration().getAuthorizationCheckRevokes();
+      String configuredMode = Context.getRequiredProcessEngineConfiguration().getAuthorizationCheckRevokes();
       if(configuredMode != null) {
         configuredMode = configuredMode.toLowerCase();
       }
@@ -550,8 +550,7 @@ public class AuthorizationManager extends AbstractManager {
   public boolean isOperatonAdmin(Authentication authentication) {
     List<String> groupIds = authentication.getGroupIds();
     if (groupIds != null) {
-      CommandContext commandContext = Context.getCommandContext();
-      List<String> adminGroups = commandContext.getProcessEngineConfiguration().getAdminGroups();
+      List<String> adminGroups = Context.getRequiredProcessEngineConfiguration().getAdminGroups();
       for (String adminGroup : adminGroups) {
         if (groupIds.contains(adminGroup)) {
           return true;
@@ -561,8 +560,7 @@ public class AuthorizationManager extends AbstractManager {
 
     String userId = authentication.getUserId();
     if (userId != null) {
-      CommandContext commandContext = Context.getCommandContext();
-      List<String> adminUsers = commandContext.getProcessEngineConfiguration().getAdminUsers();
+      List<String> adminUsers = Context.getRequiredProcessEngineConfiguration().getAdminUsers();
       return adminUsers != null && adminUsers.contains(userId);
     }
 
@@ -1149,7 +1147,7 @@ public class AuthorizationManager extends AbstractManager {
   protected boolean isAuthCheckExecuted() {
 
     Authentication currentAuthentication = getCurrentAuthentication();
-    CommandContext commandContext = Context.getCommandContext();
+    CommandContext commandContext = Context.getRequiredCommandContext();
 
     return isAuthorizationEnabled()
         && commandContext.isAuthorizationCheckEnabled()
@@ -1159,11 +1157,11 @@ public class AuthorizationManager extends AbstractManager {
   }
 
   public boolean isEnsureSpecificVariablePermission() {
-    return Context.getProcessEngineConfiguration().isEnforceSpecificVariablePermission();
+    return Context.getRequiredProcessEngineConfiguration().isEnforceSpecificVariablePermission();
   }
 
   protected boolean isHistoricInstancePermissionsEnabled() {
-    return Context.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
+    return Context.getRequiredProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 
   public DbOperation addRemovalTimeToAuthorizationsByRootProcessInstanceId(String rootProcessInstanceId,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -300,7 +300,7 @@ public class AuthorizationManager extends AbstractManager {
     Boolean isRevokeAuthCheckEnabled = this.isRevokeAuthCheckUsed;
 
     if(isRevokeAuthCheckEnabled == null) {
-      String configuredMode = Context.getRequiredProcessEngineConfiguration().getAuthorizationCheckRevokes();
+      String configuredMode = Context.getProcessEngineConfiguration().getAuthorizationCheckRevokes();
       if(configuredMode != null) {
         configuredMode = configuredMode.toLowerCase();
       }
@@ -550,7 +550,7 @@ public class AuthorizationManager extends AbstractManager {
   public boolean isOperatonAdmin(Authentication authentication) {
     List<String> groupIds = authentication.getGroupIds();
     if (groupIds != null) {
-      List<String> adminGroups = Context.getRequiredProcessEngineConfiguration().getAdminGroups();
+      List<String> adminGroups = Context.getProcessEngineConfiguration().getAdminGroups();
       for (String adminGroup : adminGroups) {
         if (groupIds.contains(adminGroup)) {
           return true;
@@ -560,7 +560,7 @@ public class AuthorizationManager extends AbstractManager {
 
     String userId = authentication.getUserId();
     if (userId != null) {
-      List<String> adminUsers = Context.getRequiredProcessEngineConfiguration().getAdminUsers();
+      List<String> adminUsers = Context.getProcessEngineConfiguration().getAdminUsers();
       return adminUsers != null && adminUsers.contains(userId);
     }
 
@@ -1147,7 +1147,7 @@ public class AuthorizationManager extends AbstractManager {
   protected boolean isAuthCheckExecuted() {
 
     Authentication currentAuthentication = getCurrentAuthentication();
-    CommandContext commandContext = Context.getRequiredCommandContext();
+    CommandContext commandContext = Context.getCommandContext();
 
     return isAuthorizationEnabled()
         && commandContext.isAuthorizationCheckEnabled()
@@ -1157,11 +1157,11 @@ public class AuthorizationManager extends AbstractManager {
   }
 
   public boolean isEnsureSpecificVariablePermission() {
-    return Context.getRequiredProcessEngineConfiguration().isEnforceSpecificVariablePermission();
+    return Context.getProcessEngineConfiguration().isEnforceSpecificVariablePermission();
   }
 
   protected boolean isHistoricInstancePermissionsEnabled() {
-    return Context.getRequiredProcessEngineConfiguration().isEnableHistoricInstancePermissions();
+    return Context.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 
   public DbOperation addRemovalTimeToAuthorizationsByRootProcessInstanceId(String rootProcessInstanceId,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -709,7 +709,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
         ensureExecutionTreeInitialized();
 
       } else {
-        this.executions = Context.getCommandContext().getExecutionManager().findChildExecutionsByParentExecutionId(id);
+        this.executions = Context.getRequiredCommandContext().getExecutionManager().findChildExecutionsByParentExecutionId(id);
       }
 
     }
@@ -919,7 +919,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
   }
 
   @Override
-  public @NonNull ExecutionEntity getSuperExecution() {
+  public @Nullable ExecutionEntity getSuperExecution() {
     ensureSuperExecutionInitialized();
     return superExecution;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -483,12 +483,12 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   @Override
   public void fireHistoricProcessStartEvent() {
-    ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
-    if (configuration == null) {
+    var configuration = Context.findProcessEngineConfiguration();
+    if (configuration.isEmpty()) {
       return;
     }
 
-    HistoryLevel historyLevel = configuration.getHistoryLevel();
+    HistoryLevel historyLevel = configuration.get().getHistoryLevel();
     if (historyLevel.isHistoryEventProduced(HistoryEventTypes.PROCESS_INSTANCE_START, processInstance)) {
       HistoryEventProcessor.processHistoryEvents(new HistoryEventProcessor.HistoryEventCreator() {
         @Override
@@ -1319,9 +1319,6 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
    *          the list of all variables that are linked to executions which are
    *          part of this process instance If null, variables are not
    *          initialized and are lazy loaded on demand
-   * @param jobs
-   * @param tasks
-   * @param incidents
    */
   public void restoreProcessInstance(Collection<ExecutionEntity> executions,
       Collection<EventSubscriptionEntity> eventSubscriptions, Collection<VariableInstanceEntity> variables,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -708,7 +708,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
         ensureExecutionTreeInitialized();
 
       } else {
-        this.executions = Context.getRequiredCommandContext().getExecutionManager().findChildExecutionsByParentExecutionId(id);
+        this.executions = Context.getCommandContext().getExecutionManager().findChildExecutionsByParentExecutionId(id);
       }
 
     }
@@ -895,7 +895,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
         ensureExecutionTreeInitialized();
 
       } else {
-        parent = Context.getRequiredCommandContext().getExecutionManager().findExecutionById(parentId);
+        parent = Context.getCommandContext().getExecutionManager().findExecutionById(parentId);
       }
     }
   }
@@ -942,7 +942,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSuperExecutionInitialized() {
     if (superExecution == null && superExecutionId != null) {
-      superExecution = Context.getRequiredCommandContext().getExecutionManager().findExecutionById(superExecutionId);
+      superExecution = Context.getCommandContext().getExecutionManager().findExecutionById(superExecutionId);
     }
   }
 
@@ -960,7 +960,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSubProcessInstanceInitialized() {
     if (shouldQueryForSubprocessInstance && subProcessInstance == null) {
-      subProcessInstance = Context.getRequiredCommandContext().getExecutionManager().findSubProcessInstanceBySuperExecutionId(id);
+      subProcessInstance = Context.getCommandContext().getExecutionManager().findSubProcessInstanceBySuperExecutionId(id);
     }
   }
 
@@ -1003,7 +1003,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSuperCaseExecutionInitialized() {
     if (superCaseExecution == null && superCaseExecutionId != null) {
-      superCaseExecution = Context.getRequiredCommandContext().getCaseExecutionManager().findCaseExecutionById(superCaseExecutionId);
+      superCaseExecution = Context.getCommandContext().getCaseExecutionManager().findCaseExecutionById(superCaseExecutionId);
     }
   }
 
@@ -1024,7 +1024,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSubCaseInstanceInitialized() {
     if (shouldQueryForSubCaseInstance && subCaseInstance == null) {
-      subCaseInstance = Context.getRequiredCommandContext().getCaseExecutionManager().findSubCaseInstanceBySuperExecutionId(id);
+      subCaseInstance = Context.getCommandContext().getCaseExecutionManager().findSubCaseInstanceBySuperExecutionId(id);
     }
   }
 
@@ -1043,7 +1043,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
     removeEventSubscriptions();
 
     // finally delete this execution
-    Context.getRequiredCommandContext().getExecutionManager().deleteExecution(this);
+    Context.getCommandContext().getExecutionManager().deleteExecution(this);
   }
 
   protected void removeEventSubscriptionsExceptCompensation() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.persistence.entity;
 
 import java.util.*;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngine;
@@ -896,7 +895,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
         ensureExecutionTreeInitialized();
 
       } else {
-        parent = Context.getCommandContext().getExecutionManager().findExecutionById(parentId);
+        parent = Context.getRequiredCommandContext().getExecutionManager().findExecutionById(parentId);
       }
     }
   }
@@ -943,7 +942,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSuperExecutionInitialized() {
     if (superExecution == null && superExecutionId != null) {
-      superExecution = Context.getCommandContext().getExecutionManager().findExecutionById(superExecutionId);
+      superExecution = Context.getRequiredCommandContext().getExecutionManager().findExecutionById(superExecutionId);
     }
   }
 
@@ -961,7 +960,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSubProcessInstanceInitialized() {
     if (shouldQueryForSubprocessInstance && subProcessInstance == null) {
-      subProcessInstance = Context.getCommandContext().getExecutionManager().findSubProcessInstanceBySuperExecutionId(id);
+      subProcessInstance = Context.getRequiredCommandContext().getExecutionManager().findSubProcessInstanceBySuperExecutionId(id);
     }
   }
 
@@ -1004,7 +1003,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSuperCaseExecutionInitialized() {
     if (superCaseExecution == null && superCaseExecutionId != null) {
-      superCaseExecution = Context.getCommandContext().getCaseExecutionManager().findCaseExecutionById(superCaseExecutionId);
+      superCaseExecution = Context.getRequiredCommandContext().getCaseExecutionManager().findCaseExecutionById(superCaseExecutionId);
     }
   }
 
@@ -1025,7 +1024,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected void ensureSubCaseInstanceInitialized() {
     if (shouldQueryForSubCaseInstance && subCaseInstance == null) {
-      subCaseInstance = Context.getCommandContext().getCaseExecutionManager().findSubCaseInstanceBySuperExecutionId(id);
+      subCaseInstance = Context.getRequiredCommandContext().getCaseExecutionManager().findSubCaseInstanceBySuperExecutionId(id);
     }
   }
 
@@ -1044,7 +1043,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
     removeEventSubscriptions();
 
     // finally delete this execution
-    Context.getCommandContext().getExecutionManager().deleteExecution(this);
+    Context.getRequiredCommandContext().getExecutionManager().deleteExecution(this);
   }
 
   protected void removeEventSubscriptionsExceptCompensation() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionManager.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.impl.AbstractQuery;
 import org.operaton.bpm.engine.impl.ExecutionQueryImpl;
@@ -113,7 +114,7 @@ public class ExecutionManager extends AbstractManager {
     return getDbEntityManager().selectList("selectExecutionsByProcessInstanceId", processInstanceId);
   }
 
-  public ExecutionEntity findExecutionById(String executionId) {
+  public @Nullable ExecutionEntity findExecutionById(String executionId) {
     return getDbEntityManager().selectById(ExecutionEntity.class, executionId);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ProcessDefinitionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ProcessDefinitionManager.java
@@ -112,7 +112,7 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
     }
   }
 
-  public ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
+  public @Nullable ProcessDefinitionEntity findLatestProcessDefinitionById(String processDefinitionId) {
     return getDbEntityManager().selectById(ProcessDefinitionEntity.class, processDefinitionId);
   }
 
@@ -134,15 +134,15 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
     return (ProcessDefinitionEntity) getDbEntityManager().selectOne("selectProcessDefinitionByDeploymentAndKey", parameters);
   }
 
-  public ProcessDefinitionEntity findProcessDefinitionByKeyVersionAndTenantId(String processDefinitionKey, Integer processDefinitionVersion, String tenantId) {
+  public @Nullable ProcessDefinitionEntity findProcessDefinitionByKeyVersionAndTenantId(String processDefinitionKey, Integer processDefinitionVersion, String tenantId) {
     return findProcessDefinitionByKeyVersionOrVersionTag(processDefinitionKey, processDefinitionVersion, null, tenantId);
   }
 
-  public ProcessDefinitionEntity findProcessDefinitionByKeyVersionTagAndTenantId(String processDefinitionKey, String processDefinitionVersionTag, String tenantId) {
+  public @Nullable ProcessDefinitionEntity findProcessDefinitionByKeyVersionTagAndTenantId(String processDefinitionKey, String processDefinitionVersionTag, String tenantId) {
     return findProcessDefinitionByKeyVersionOrVersionTag(processDefinitionKey, null, processDefinitionVersionTag, tenantId);
   }
 
-  protected ProcessDefinitionEntity findProcessDefinitionByKeyVersionOrVersionTag(String processDefinitionKey, Integer processDefinitionVersion, String processDefinitionVersionTag,
+  protected @Nullable ProcessDefinitionEntity findProcessDefinitionByKeyVersionOrVersionTag(String processDefinitionKey, Integer processDefinitionVersion, String processDefinitionVersionTag,
       String tenantId) {
     Map<String, Object> parameters = new HashMap<>();
     if (processDefinitionVersion != null) {
@@ -376,7 +376,7 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
 
     // remove process definition from cache:
     Context
-      .getProcessEngineConfiguration()
+      .getRequiredProcessEngineConfiguration()
       .getDeploymentCache()
       .removeProcessDefinition(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ProcessDefinitionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ProcessDefinitionManager.java
@@ -376,7 +376,7 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
 
     // remove process definition from cache:
     Context
-      .getRequiredProcessEngineConfiguration()
+      .getProcessEngineConfiguration()
       .getDeploymentCache()
       .removeProcessDefinition(processDefinitionId);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/PropertyChange.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/PropertyChange.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.persistence.entity;
 
 import java.util.Date;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contains data about a property change.
@@ -34,12 +35,12 @@ public class PropertyChange {
   protected String propertyName;
 
   /** the original value */
-  protected Object orgValue;
+  protected @Nullable Object orgValue;
 
   /** the new value */
-  protected Object newValue;
+  protected @Nullable Object newValue;
 
-  public PropertyChange(String propertyName, Object orgValue, Object newValue) {
+  public PropertyChange(String propertyName, @Nullable Object orgValue, @Nullable Object newValue) {
     this.propertyName = propertyName;
     this.orgValue = orgValue;
     this.newValue = newValue;
@@ -53,31 +54,31 @@ public class PropertyChange {
     this.propertyName = propertyName;
   }
 
-  public Object getOrgValue() {
+  public @Nullable Object getOrgValue() {
     return orgValue;
   }
 
-  public void setOrgValue(Object orgValue) {
+  public void setOrgValue(@Nullable Object orgValue) {
     this.orgValue = orgValue;
   }
 
-  public Object getNewValue() {
+  public @Nullable Object getNewValue() {
     return newValue;
   }
 
-  public void setNewValue(Object newValue) {
+  public void setNewValue(@Nullable Object newValue) {
     this.newValue = newValue;
   }
 
-  public String getNewValueString() {
+  public @Nullable String getNewValueString() {
     return valueAsString(newValue);
   }
 
-  public String getOrgValueString() {
+  public @Nullable String getOrgValueString() {
     return valueAsString(orgValue);
   }
 
-  protected String valueAsString(Object value) {
+  protected @Nullable String valueAsString(@Nullable Object value) {
     if(value == null) {
       return null;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -913,18 +913,19 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     propertyChanged(ASSIGNEE, oldAssignee, assignee);
     this.assignee = assignee;
 
+    if (!Context.hasActiveCommandContext()) {
+      // if there is no command context, then it means that the user is calling the
+      // setAssignee outside a service method. E.g. while creating a new task.
+      return;
+    }
     CommandContext commandContext = Context.getCommandContext();
-    // if there is no command context, then it means that the user is calling the
-    // setAssignee outside a service method. E.g. while creating a new task.
-    if (commandContext != null) {
-      if (commandContext.getDbEntityManager().contains(this)) {
-        fireAssigneeAuthorizationProvider(oldAssignee, assignee);
-        fireHistoricIdentityLinks();
-      }
-      if (commandContext.getProcessEngineConfiguration().isTaskMetricsEnabled() && assignee != null && !assignee.equals(oldAssignee)) {
-        // assignee has changed and is not null, so mark a new task worker
-        commandContext.getMeterLogManager().insert(new TaskMeterLogEntity(assignee, timestamp));
-      }
+    if (commandContext.getDbEntityManager().contains(this)) {
+      fireAssigneeAuthorizationProvider(oldAssignee, assignee);
+      fireHistoricIdentityLinks();
+    }
+    if (commandContext.getProcessEngineConfiguration().isTaskMetricsEnabled() && assignee != null && !assignee.equals(oldAssignee)) {
+      // assignee has changed and is not null, so mark a new task worker
+      commandContext.getMeterLogManager().insert(new TaskMeterLogEntity(assignee, timestamp));
     }
   }
 
@@ -942,10 +943,14 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     propertyChanged(OWNER, oldOwner, owner);
     this.owner = owner;
 
+    if (!Context.hasActiveCommandContext()) {
+      // if there is no command context, then it means that the user is calling the
+      // setOwner outside a service method. E.g. while creating a new task.
+      return;
+    }
+
     CommandContext commandContext = Context.getCommandContext();
-    // if there is no command context, then it means that the user is calling the
-    // setOwner outside a service method. E.g. while creating a new task.
-    if (commandContext != null && commandContext.getDbEntityManager().contains(this)) {
+    if (commandContext.getDbEntityManager().contains(this)) {
       fireOwnerAuthorizationProvider(oldOwner, owner);
       this.fireHistoricIdentityLinks();
     }
@@ -1183,10 +1188,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
     switch (state) {
     case STATE_CREATED:
-      CommandContext commandContext = Context.getCommandContext();
-      if (commandContext != null) {
-        commandContext.getHistoricTaskInstanceManager().createHistoricTask(this);
-      }
+      Context.getCommandContextWhenAvailable().ifPresent(commandContext -> commandContext.getHistoricTaskInstanceManager().createHistoricTask(this));
       return fireEvent(TaskListener.EVENTNAME_CREATE) && fireAssignmentEvent();
 
     case STATE_COMPLETED:
@@ -1641,10 +1643,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   }
 
   protected void registerCommandContextCloseListener() {
-    CommandContext commandContext = Context.getCommandContext();
-    if (commandContext != null) {
-      commandContext.registerCommandContextListener(this);
-    }
+    Context.getCommandContextWhenAvailable().ifPresent(commandContext -> commandContext.registerCommandContextListener(this));
   }
 
   public Map<String, PropertyChange> getPropertyChanges() {
@@ -1657,8 +1656,8 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
       propertyChanged(DELETE, false, true);
     }
 
-    final CommandContext commandContext = Context.getCommandContext();
-    if (commandContext != null) {
+    if (Context.hasActiveCommandContext()) {
+      final CommandContext commandContext = Context.getCommandContext();
       List<PropertyChange> values = new ArrayList<>(propertyChanges.values());
       commandContext.getOperationLogManager().logTaskOperations(operation, this, values);
       fireHistoricIdentityLinks();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -892,7 +892,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   }
 
   @Override
-  public void setDescription(String description) {
+  public void setDescription(@Nullable String description) {
     registerCommandContextCloseListener();
     propertyChanged(DESCRIPTION, this.description, description);
     this.description = description;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -694,7 +694,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     return caseExecutionId;
   }
 
-  public void setCaseExecutionId(String caseExecutionId) {
+  public void setCaseExecutionId(@Nullable String caseExecutionId) {
     this.caseExecutionId = caseExecutionId;
   }
 
@@ -725,7 +725,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     return caseDefinitionId;
   }
 
-  public void setCaseDefinitionId(String caseDefinitionId) {
+  public void setCaseDefinitionId(@Nullable String caseDefinitionId) {
     this.caseDefinitionId = caseDefinitionId;
   }
 
@@ -1188,7 +1188,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
     switch (state) {
     case STATE_CREATED:
-      Context.getCommandContextWhenAvailable().ifPresent(commandContext -> commandContext.getHistoricTaskInstanceManager().createHistoricTask(this));
+      Context.findCommandContext().ifPresent(commandContext -> commandContext.getHistoricTaskInstanceManager().createHistoricTask(this));
       return fireEvent(TaskListener.EVENTNAME_CREATE) && fireAssignmentEvent();
 
     case STATE_COMPLETED:
@@ -1490,7 +1490,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     return operatonFormRef;
   }
 
-  public void setProcessDefinitionId(String processDefinitionId) {
+  public void setProcessDefinitionId(@Nullable String processDefinitionId) {
     this.processDefinitionId = processDefinitionId;
   }
 
@@ -1524,7 +1524,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     this.eventName = eventName;
   }
 
-  public void setExecutionId(String executionId) {
+  public void setExecutionId(@Nullable String executionId) {
     this.executionId = executionId;
   }
 
@@ -1539,7 +1539,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     this.processInstance = processInstance;
   }
 
-  public void setProcessInstanceId(String processInstanceId) {
+  public void setProcessInstanceId(@Nullable String processInstanceId) {
     this.processInstanceId = processInstanceId;
   }
 
@@ -1643,7 +1643,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   }
 
   protected void registerCommandContextCloseListener() {
-    Context.getCommandContextWhenAvailable().ifPresent(commandContext -> commandContext.registerCommandContextListener(this));
+    Context.findCommandContext().ifPresent(commandContext -> commandContext.registerCommandContextListener(this));
   }
 
   public Map<String, PropertyChange> getPropertyChanges() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskManager.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.TaskQueryImpl;
@@ -106,7 +107,7 @@ public class TaskManager extends AbstractManager {
     }
   }
 
-  public TaskEntity findTaskById(String id) {
+  public @Nullable TaskEntity findTaskById(String id) {
     ensureNotNull("Invalid task id", "id", id);
     return getDbEntityManager().selectById(TaskEntity.class, id);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -67,7 +67,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   private static final String PROP_TENANT_ID = "tenantId";
   private static final String PROP_USER_ID = "userId";
 
-  public UserOperationLogEntry findOperationLogById(String entryId) {
+  public @Nullable UserOperationLogEntry findOperationLogById(String entryId) {
     return getDbEntityManager().selectById(UserOperationLogEntryEventEntity.class, entryId);
   }
 
@@ -241,7 +241,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
     }
   }
 
-  public void logTaskOperations(String operation, HistoricTaskInstance historicTask, List<PropertyChange> propertyChanges) {
+  public void logTaskOperations(String operation, @Nullable HistoricTaskInstance historicTask, List<PropertyChange> propertyChanges) {
     if (isUserOperationLogEnabled()) {
       UserOperationLogContext context = new UserOperationLogContext();
       UserOperationLogContextEntryBuilder entryBuilder =
@@ -271,11 +271,11 @@ public class UserOperationLogManager extends AbstractHistoricManager {
     logProcessInstanceOperation(operation, null, null, null, propertyChanges);
   }
 
-  public void logProcessInstanceOperation(String operation, String processInstanceId, String processDefinitionId, String processDefinitionKey, List<PropertyChange> propertyChanges) {
+  public void logProcessInstanceOperation(String operation, @Nullable String processInstanceId, @Nullable String processDefinitionId, @Nullable String processDefinitionKey, List<PropertyChange> propertyChanges) {
     logProcessInstanceOperation(operation, processInstanceId, processDefinitionId, processDefinitionKey, propertyChanges, null);
   }
 
-  public void logProcessInstanceOperation(String operation, @Nullable String processInstanceId, @Nullable String processDefinitionId, String processDefinitionKey, List<PropertyChange> propertyChanges, @Nullable String annotation) {
+  public void logProcessInstanceOperation(String operation, @Nullable String processInstanceId, @Nullable String processDefinitionId, @Nullable String processDefinitionKey, List<PropertyChange> propertyChanges, @Nullable String annotation) {
     if (isUserOperationLogEnabled()) {
 
       UserOperationLogContext context = new UserOperationLogContext();
@@ -331,7 +331,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
           .category(UserOperationLogEntry.CATEGORY_OPERATOR);
 
       if (processDefinitionId != null) {
-        ProcessDefinitionEntity definition = getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId);
+        ProcessDefinitionEntity definition = requireNonNull(getProcessDefinitionManager().findLatestProcessDefinitionById(processDefinitionId));
         entryBuilder.inContextOf(definition);
       }
 
@@ -804,7 +804,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected String getPermissionStringList(AuthorizationEntity authorization) {
-    Permission[] permissionsForResource = Context.getProcessEngineConfiguration().getPermissionProvider().getPermissionsForResource(authorization.getResourceType());
+    Permission[] permissionsForResource = Context.getRequiredProcessEngineConfiguration().getPermissionProvider().getPermissionsForResource(authorization.getResourceType());
     Permission[] permissions = authorization.getPermissions(permissionsForResource);
     String[] namesForPermissions = PermissionConverter.getNamesForPermissions(authorization, permissions);
     if (namesForPermissions.length == 0) {
@@ -814,7 +814,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected String getResourceName(int resourceType) {
-    return Context.getProcessEngineConfiguration().getPermissionProvider().getNameForResource(resourceType);
+    return Context.getRequiredProcessEngineConfiguration().getPermissionProvider().getNameForResource(resourceType);
   }
 
   public boolean isUserOperationLogEnabled() {
@@ -824,7 +824,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected boolean isHistoryEventProduced() {
-    HistoryLevel historyLevel = Context.getProcessEngineConfiguration().getHistoryLevel();
+    HistoryLevel historyLevel = Context.getRequiredProcessEngineConfiguration().getHistoryLevel();
     return historyLevel.isHistoryEventProduced(HistoryEventTypes.USER_OPERATION_LOG, null);
   }
 
@@ -834,8 +834,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected String getAuthenticatedUserId() {
-    CommandContext commandContext = Context.getCommandContext();
-    return commandContext.getAuthenticatedUserId();
+    return Context.getRequiredCommandContext().getAuthenticatedUserId();
   }
 
   protected void fireUserOperationLog(final UserOperationLogContext context) {
@@ -852,16 +851,14 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected boolean writeUserOperationLogOnlyWithLoggedInUser() {
-    CommandContext commandContext = requireNonNull(Context.getCommandContext());
-    return commandContext.isRestrictUserOperationLogToAuthenticatedUsers();
+    return Context.getRequiredCommandContext().isRestrictUserOperationLogToAuthenticatedUsers();
   }
 
   protected boolean isUserOperationLogEnabledOnCommandContext() {
-    CommandContext commandContext = requireNonNull(Context.getCommandContext());
-    return commandContext.isUserOperationLogEnabled();
+    return Context.getRequiredCommandContext().isUserOperationLogEnabled();
   }
 
-  protected String getOperationType(IdentityOperationResult operationResult) {
+  protected @Nullable String getOperationType(IdentityOperationResult operationResult) {
     return switch (operationResult.getOperation()) {
       case IdentityOperationResult.OPERATION_CREATE -> UserOperationLogEntry.OPERATION_TYPE_CREATE;
       case IdentityOperationResult.OPERATION_UPDATE -> UserOperationLogEntry.OPERATION_TYPE_UPDATE;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -804,7 +804,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected String getPermissionStringList(AuthorizationEntity authorization) {
-    Permission[] permissionsForResource = Context.getRequiredProcessEngineConfiguration().getPermissionProvider().getPermissionsForResource(authorization.getResourceType());
+    Permission[] permissionsForResource = Context.getProcessEngineConfiguration().getPermissionProvider().getPermissionsForResource(authorization.getResourceType());
     Permission[] permissions = authorization.getPermissions(permissionsForResource);
     String[] namesForPermissions = PermissionConverter.getNamesForPermissions(authorization, permissions);
     if (namesForPermissions.length == 0) {
@@ -814,7 +814,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected String getResourceName(int resourceType) {
-    return Context.getRequiredProcessEngineConfiguration().getPermissionProvider().getNameForResource(resourceType);
+    return Context.getProcessEngineConfiguration().getPermissionProvider().getNameForResource(resourceType);
   }
 
   public boolean isUserOperationLogEnabled() {
@@ -824,7 +824,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected boolean isHistoryEventProduced() {
-    HistoryLevel historyLevel = Context.getRequiredProcessEngineConfiguration().getHistoryLevel();
+    HistoryLevel historyLevel = Context.getProcessEngineConfiguration().getHistoryLevel();
     return historyLevel.isHistoryEventProduced(HistoryEventTypes.USER_OPERATION_LOG, null);
   }
 
@@ -834,7 +834,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected String getAuthenticatedUserId() {
-    return Context.getRequiredCommandContext().getAuthenticatedUserId();
+    return Context.getCommandContext().getAuthenticatedUserId();
   }
 
   protected void fireUserOperationLog(final UserOperationLogContext context) {
@@ -851,11 +851,11 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   protected boolean writeUserOperationLogOnlyWithLoggedInUser() {
-    return Context.getRequiredCommandContext().isRestrictUserOperationLogToAuthenticatedUsers();
+    return Context.getCommandContext().isRestrictUserOperationLogToAuthenticatedUsers();
   }
 
   protected boolean isUserOperationLogEnabledOnCommandContext() {
-    return Context.getRequiredCommandContext().isUserOperationLogEnabled();
+    return Context.getCommandContext().isUserOperationLogEnabled();
   }
 
   protected @Nullable String getOperationType(IdentityOperationResult operationResult) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -43,7 +43,6 @@ import org.operaton.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.operaton.bpm.engine.impl.history.event.UserOperationLogEntryEventEntity;
 import org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer;
 import org.operaton.bpm.engine.impl.identity.IdentityOperationResult;
-import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.oplog.UserOperationLogContext;
 import org.operaton.bpm.engine.impl.oplog.UserOperationLogContextEntryBuilder;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/ByteArrayField.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/ByteArrayField.java
@@ -26,6 +26,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.Nameable;
 import org.operaton.bpm.engine.impl.variable.serializer.ValueFields;
 import org.operaton.bpm.engine.repository.ResourceType;
 
+import static org.operaton.bpm.engine.impl.context.Context.hasActiveCommandContext;
+
 /**
  * A byte array value field what load and save {@link ByteArrayEntity}. It can
  * be used in an entity which implements {@link ValueFields}.
@@ -77,7 +79,7 @@ public class ByteArrayField {
   protected ByteArrayEntity getByteArrayEntity() {
 
     // no lazy fetching outside of command context
-    if (byteArrayValue == null && byteArrayId != null && Context.getCommandContext() != null) {
+    if (byteArrayValue == null && byteArrayId != null && hasActiveCommandContext()) {
         byteArrayValue = Context
             .getCommandContext()
             .getDbEntityManager()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -42,6 +42,8 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.SerializableValue;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
+import static org.operaton.bpm.engine.impl.context.Context.hasActiveCommandContext;
+
 /**
  * A field what provide a typed version of a value. It can
  * be used in an entity which implements {@link ValueFields}.
@@ -84,7 +86,7 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
   }
 
   public TypedValue getTypedValue(boolean deserializeValue, boolean asTransientValue) {
-    if (Context.getCommandContext() != null) {
+    if (hasActiveCommandContext()) {
       // in some circumstances we must invalidate the cached value instead of returning it
 
       if ((cachedValue instanceof SerializableValue serializableValue)
@@ -213,7 +215,7 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
   }
 
   public static VariableSerializers getSerializers() {
-    if (Context.getCommandContext() != null) {
+    if (hasActiveCommandContext()) {
       VariableSerializers variableSerializers = Context.getProcessEngineConfiguration().getVariableSerializers();
       VariableSerializers paSerializers = getCurrentPaSerializers();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -231,39 +231,36 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
   }
 
   public static @Nullable TypedValueSerializer<?> getFallbackSerializer(String serializerName) {
-    if (Context.getProcessEngineConfiguration() != null) {
-      VariableSerializerFactory fallbackSerializerFactory = Context.getProcessEngineConfiguration().getFallbackSerializerFactory();
-      if (fallbackSerializerFactory != null) {
-        return fallbackSerializerFactory.getSerializer(serializerName);
+    var processEngineConfiguration = Context.findProcessEngineConfiguration()
+        .orElseThrow(LOG::serializerOutOfContextException);
+
+    VariableSerializerFactory fallbackSerializerFactory = processEngineConfiguration.getFallbackSerializerFactory();
+    if (fallbackSerializerFactory != null) {
+      return fallbackSerializerFactory.getSerializer(serializerName);
+    }
+    else {
+      return null;
+    }
+  }
+
+  protected static @Nullable VariableSerializers getCurrentPaSerializers() {
+    ProcessApplicationReference processApplicationReference = Context.getCurrentProcessApplication();
+    if (processApplicationReference == null) {
+      return null;
+    }
+
+    try {
+      ProcessApplicationInterface processApplicationInterface = processApplicationReference.getProcessApplication();
+
+      ProcessApplicationInterface rawPa = processApplicationInterface.getRawObject();
+      if (rawPa instanceof AbstractProcessApplication abstractProcessApplication) {
+        return abstractProcessApplication.getVariableSerializers();
       }
       else {
         return null;
       }
-    }
-    else {
-      throw LOG.serializerOutOfContextException();
-    }
-  }
-
-  protected static VariableSerializers getCurrentPaSerializers() {
-    if (Context.getCurrentProcessApplication() != null) {
-      ProcessApplicationReference processApplicationReference = Context.getCurrentProcessApplication();
-      try {
-        ProcessApplicationInterface processApplicationInterface = processApplicationReference.getProcessApplication();
-
-        ProcessApplicationInterface rawPa = processApplicationInterface.getRawObject();
-        if (rawPa instanceof AbstractProcessApplication abstractProcessApplication) {
-          return abstractProcessApplication.getVariableSerializers();
-        }
-        else {
-          return null;
-        }
-      } catch (ProcessApplicationUnavailableException e) {
-        throw LOG.cannotDeterminePaDataformats(e);
-      }
-    }
-    else {
-      return null;
+    } catch (ProcessApplicationUnavailableException e) {
+      throw LOG.cannotDeterminePaDataformats(e);
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationDeleteCascadeFireActivityEnd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationDeleteCascadeFireActivityEnd.java
@@ -75,14 +75,16 @@ public class PvmAtomicOperationDeleteCascadeFireActivityEnd extends PvmAtomicOpe
 
     } else {
       if (execution.isScope()) {
-        ProcessEngineConfigurationImpl engineConfiguration = Context.getProcessEngineConfiguration();
+        boolean isSkipOutputMappingOnCanceledActivities = Context.getProcessEngineConfigurationWhenAvailable()
+            .map(ProcessEngineConfigurationImpl::isSkipOutputMappingOnCanceledActivities)
+            .orElse(false);
 
         // execution was canceled and output mapping for activity is marked as skippable
         boolean alwaysSkipIoMappings =
             execution instanceof ExecutionEntity &&
             !execution.isProcessInstanceExecution() &&
             execution.isCanceled() &&
-            engineConfiguration.isSkipOutputMappingOnCanceledActivities();
+            isSkipOutputMappingOnCanceledActivities;
 
         execution.destroy(alwaysSkipIoMappings);
       }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationDeleteCascadeFireActivityEnd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationDeleteCascadeFireActivityEnd.java
@@ -75,7 +75,7 @@ public class PvmAtomicOperationDeleteCascadeFireActivityEnd extends PvmAtomicOpe
 
     } else {
       if (execution.isScope()) {
-        boolean isSkipOutputMappingOnCanceledActivities = Context.getProcessEngineConfigurationWhenAvailable()
+        boolean isSkipOutputMappingOnCanceledActivities = Context.findProcessEngineConfiguration()
             .map(ProcessEngineConfigurationImpl::isSkipOutputMappingOnCanceledActivities)
             .orElse(false);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/CorrelationHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/CorrelationHandler.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.runtime;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
 /**
@@ -25,7 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  * @author Daniel Meyer
  * @author Michael Scholz
  */
-public interface CorrelationHandler {
+public @NullMarked interface CorrelationHandler {
 
   /**
    * Correlate the given message to either a waiting execution or a process
@@ -37,7 +39,7 @@ public interface CorrelationHandler {
    * @return the matched correlation target or <code>null</code> if the message
    *         could not be correlated.
    */
-  CorrelationHandlerResult correlateMessage(CommandContext commandContext, String messageName, CorrelationSet correlationSet);
+  @Nullable CorrelationHandlerResult correlateMessage(CommandContext commandContext, String messageName, CorrelationSet correlationSet);
 
   /**
    * Correlate the given message to all waiting executions and all process

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/DefaultCorrelationHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/DefaultCorrelationHandler.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ExecutionQueryImpl;
 
 import org.jspecify.annotations.Nullable;
@@ -42,7 +43,7 @@ import org.operaton.bpm.engine.runtime.Execution;
  * @author Daniel Meyer
  * @author Michael Scholz
  */
-public class DefaultCorrelationHandler implements CorrelationHandler {
+public @NullMarked class DefaultCorrelationHandler implements CorrelationHandler {
 
   private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
@@ -89,7 +90,7 @@ public class DefaultCorrelationHandler implements CorrelationHandler {
     return results;
   }
 
-  protected List<CorrelationHandlerResult> correlateMessageToExecutions(CommandContext commandContext, String messageName, CorrelationSet correlationSet) {
+  protected List<CorrelationHandlerResult> correlateMessageToExecutions(CommandContext commandContext, @Nullable String messageName, CorrelationSet correlationSet) {
 
     ExecutionQueryImpl query = new ExecutionQueryImpl();
 
@@ -137,7 +138,7 @@ public class DefaultCorrelationHandler implements CorrelationHandler {
   }
 
   @Override
-  public List<CorrelationHandlerResult> correlateStartMessages(CommandContext commandContext, String messageName, CorrelationSet correlationSet) {
+  public List<CorrelationHandlerResult> correlateStartMessages(CommandContext commandContext, @Nullable String messageName, CorrelationSet correlationSet) {
     if (messageName == null) {
       // ignore empty message name
       return Collections.emptyList();
@@ -195,7 +196,7 @@ public class DefaultCorrelationHandler implements CorrelationHandler {
     }
   }
 
-  protected CorrelationHandlerResult correlateStartMessageByProcessDefinitionId(CommandContext commandContext, String messageName, String processDefinitionId) {
+  protected @Nullable CorrelationHandlerResult correlateStartMessageByProcessDefinitionId(CommandContext commandContext, String messageName, String processDefinitionId) {
     DeploymentCache deploymentCache = commandContext.getProcessEngineConfiguration().getDeploymentCache();
     ProcessDefinitionEntity processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
     // only an active process definition will be returned
@@ -209,7 +210,7 @@ public class DefaultCorrelationHandler implements CorrelationHandler {
     return null;
   }
 
-  protected String findStartActivityIdByMessage(ProcessDefinitionEntity processDefinition, String messageName) {
+  protected @Nullable String findStartActivityIdByMessage(ProcessDefinitionEntity processDefinition, String messageName) {
     for (EventSubscriptionDeclaration declaration : EventSubscriptionDeclaration.getDeclarationsForScope(processDefinition).values()) {
       if (isMessageStartEventWithName(declaration, messageName)) {
         return declaration.getActivityId();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
@@ -95,11 +95,9 @@ public class ScriptBindings implements Bindings {
   }
 
   protected boolean isAutoStoreScriptVariablesEnabled() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
-    if(processEngineConfiguration != null) {
-      return processEngineConfiguration.isAutoStoreScriptVariables();
-    }
-    return false;
+    return Context.getProcessEngineConfigurationWhenAvailable()
+      .map(ProcessEngineConfigurationImpl::isAutoStoreScriptVariables)
+      .orElse(false);
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
 
+import org.jspecify.annotations.NonNull;
 import org.operaton.bpm.engine.delegate.VariableScope;
 
 import org.jspecify.annotations.Nullable;
@@ -95,7 +96,7 @@ public class ScriptBindings implements Bindings {
   }
 
   protected boolean isAutoStoreScriptVariablesEnabled() {
-    return Context.getProcessEngineConfigurationWhenAvailable()
+    return Context.findProcessEngineConfiguration()
       .map(ProcessEngineConfigurationImpl::isAutoStoreScriptVariables)
       .orElse(false);
   }
@@ -141,12 +142,12 @@ public class ScriptBindings implements Bindings {
   }
 
   @Override
-  public Set<java.util.Map.Entry<String, Object>> entrySet() {
+  public @NonNull Set<java.util.Map.Entry<String, Object>> entrySet() {
     return calculateBindingMap().entrySet();
   }
 
   @Override
-  public Set<String> keySet() {
+  public @NonNull Set<String> keySet() {
     return calculateBindingMap().keySet();
   }
 
@@ -156,7 +157,7 @@ public class ScriptBindings implements Bindings {
   }
 
   @Override
-  public Collection<Object> values() {
+  public @NonNull Collection<Object> values() {
     return calculateBindingMap().values();
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -32,33 +33,38 @@ import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Sebastian Menski
  * @author Roman Smirnov
  */
-public final class EnsureUtil {
+public final @NullMarked class EnsureUtil {
+
+  private static final String LAMBDA_STACK_SIGNATURE = "lambda$";
 
   private EnsureUtil() {
   }
 
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
-  public static void ensureNotNull(String variableName, Object value) {
+  public static void ensureNotNull(String variableName, @Nullable Object value) {
     ensureNotNull("", variableName, value);
   }
 
-  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String variableName, Object value) {
+  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String variableName, @Nullable Object value) {
     ensureNotNull(exceptionClass, null, variableName, value);
   }
 
-  public static void ensureNotNull(String message, String variableName, Object value) {
+  public static void ensureNotNull(String message, String variableName, @Nullable Object value) {
     ensureNotNull(NullValueException.class, message, variableName, value);
   }
 
-  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Object value) {
+  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, @Nullable Object value) {
     if (value == null) {
       throw generateException(exceptionClass, message, variableName, "is null");
     }
+    requireNonNull(value); // to help static null analysis
   }
 
   public static void ensureNull(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, @Nullable Object value) {
@@ -95,7 +101,7 @@ public final class EnsureUtil {
     ensureNotNull(exceptionClass, message, variableName, (Object[]) values);
   }
 
-  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Object... values) {
+  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Object... values) {
     if(values == null) {
       throw generateException(exceptionClass, message, variableName, "is null");
     }
@@ -118,7 +124,7 @@ public final class EnsureUtil {
     ensureNotEmpty(ProcessEngineException.class, message, variableName, value);
   }
 
-  public static void ensureNotEmpty(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, String value) {
+  public static void ensureNotEmpty(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, String value) {
     ensureNotNull(exceptionClass, message, variableName, value);
     if (value.trim().isEmpty()) {
       throw generateException(exceptionClass, message, variableName, "is empty");
@@ -141,7 +147,7 @@ public final class EnsureUtil {
   }
 
   @SuppressWarnings("rawtypes")
-  public static void ensureNotEmpty(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Collection collection) {
+  public static void ensureNotEmpty(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Collection collection) {
     ensureNotNull(exceptionClass, message, variableName, collection);
     if (collection.isEmpty()) {
       throw generateException(exceptionClass, message, variableName, "is empty");
@@ -172,7 +178,7 @@ public final class EnsureUtil {
   }
 
   @SuppressWarnings("rawtypes")
-  public static void ensureNotEmpty(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Map map) {
+  public static void ensureNotEmpty(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Map map) {
     ensureNotNull(exceptionClass, message, variableName, map);
     if (map.isEmpty()) {
       throw generateException(exceptionClass, message, variableName, "is empty");
@@ -201,7 +207,7 @@ public final class EnsureUtil {
     ensurePositive(ProcessEngineException.class, message, variableName, value);
   }
 
-  public static void ensurePositive(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Long value) {
+  public static void ensurePositive(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Long value) {
     ensureNotNull(exceptionClass, variableName, value);
     if (value <= 0) {
       throw generateException(exceptionClass, message, variableName, "is not greater than 0");
@@ -240,7 +246,7 @@ public final class EnsureUtil {
     ensureInstanceOf(ProcessEngineException.class, message, variableName, value, expectedClass);
   }
 
-  public static void ensureInstanceOf(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Object value, Class<?> expectedClass) {
+  public static void ensureInstanceOf(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Object value, Class<?> expectedClass) {
     ensureNotNull(exceptionClass, message, variableName, value);
     Class<?> valueClass = value.getClass();
     if (!expectedClass.isAssignableFrom(valueClass)) {
@@ -260,18 +266,18 @@ public final class EnsureUtil {
     ensureOnlyOneNotNull(exceptionClass, message, (Object[]) values);
   }
 
-  public static void ensureOnlyOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, Object... values) {
+  public static void ensureOnlyOneNotNull(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, Object... values) {
     boolean oneNotNull = false;
     for (Object value : values) {
       if (value != null) {
         if (oneNotNull) {
-          throw generateException(exceptionClass, null, null, message);
+          throw generateException(exceptionClass, message, null, null);
         }
         oneNotNull = true;
       }
     }
     if (!oneNotNull) {
-      throw generateException(exceptionClass, null, null, message);
+      throw generateException(exceptionClass, message, null, null);
     }
   }
 
@@ -287,7 +293,7 @@ public final class EnsureUtil {
     ensureAtLeastOneNotNull(exceptionClass, message, (Object[]) values);
   }
 
-  public static void ensureAtLeastOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, Object... values) {
+  public static void ensureAtLeastOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, @Nullable Object... values) {
     for (Object value : values) {
       if (value != null) {
         return;
@@ -300,7 +306,7 @@ public final class EnsureUtil {
     ensureAtLeastOneNotEmpty(ProcessEngineException.class, message, values);
   }
 
-  public static void ensureAtLeastOneNotEmpty(Class<? extends ProcessEngineException> exceptionClass, String message, String... values) {
+  public static void ensureAtLeastOneNotEmpty(Class<? extends ProcessEngineException> exceptionClass, String message, @Nullable String... values) {
     for (String value : values) {
       if (value != null && !value.isEmpty()) {
         return;
@@ -313,7 +319,7 @@ public final class EnsureUtil {
     ensureNotContainsEmptyString((String) null, variableName, values);
   }
 
-  public static void ensureNotContainsEmptyString(String message, String variableName, Collection<String> values) {
+  public static void ensureNotContainsEmptyString(@Nullable String message, String variableName, Collection<String> values) {
     ensureNotContainsEmptyString(NotValidException.class, message, variableName, values);
   }
 
@@ -321,7 +327,7 @@ public final class EnsureUtil {
     ensureNotContainsEmptyString(exceptionClass, null, variableName, values);
   }
 
-  public static void ensureNotContainsEmptyString(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Collection<String> values) {
+  public static void ensureNotContainsEmptyString(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Collection<String> values) {
     ensureNotNull(exceptionClass, message, variableName, values);
     for (String value : values) {
       if (value.isEmpty()) {
@@ -334,7 +340,7 @@ public final class EnsureUtil {
     ensureNotContainsNull((String) null, variableName, values);
   }
 
-  public static void ensureNotContainsNull(String message, String variableName, Collection<?> values) {
+  public static void ensureNotContainsNull(@Nullable String message, String variableName, Collection<?> values) {
     ensureNotContainsNull(NullValueException.class, message, variableName, values);
   }
 
@@ -342,7 +348,7 @@ public final class EnsureUtil {
     ensureNotContainsNull(exceptionClass, null, variableName, values);
   }
 
-  public static void ensureNotContainsNull(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Collection<?> values) {
+  public static void ensureNotContainsNull(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Collection<?> values) {
     ensureNotNull(exceptionClass, message, variableName, values.toArray(new Object[values.size()]));
   }
 
@@ -412,7 +418,7 @@ public final class EnsureUtil {
     ensureTrue(message, !value);
   }
 
-  protected static String determineResourceWhitelistPattern(ProcessEngineConfiguration processEngineConfiguration, String resourceType) {
+  static String determineResourceWhitelistPattern(ProcessEngineConfiguration processEngineConfiguration, String resourceType) {
     String resourcePattern = null;
 
     if ("User".equals(resourceType)) {
@@ -434,7 +440,7 @@ public final class EnsureUtil {
     return processEngineConfiguration.getGeneralResourceWhitelistPattern();
   }
 
-  protected static <T extends ProcessEngineException> T generateException(Class<T> exceptionClass, String message, String variableName, String description) {
+  static <T extends ProcessEngineException> T generateException(Class<T> exceptionClass, @Nullable String message, @Nullable String variableName, @Nullable String description) {
     String formattedMessage = formatMessage(message, variableName, description);
 
     try {
@@ -449,13 +455,13 @@ public final class EnsureUtil {
 
   }
 
-  protected static String formatMessage(String message, String variableName, String description) {
+  static String formatMessage(@Nullable String message, @Nullable String variableName, @Nullable String description) {
     String messageElement = formatMessageElement(message, ": ");
     String variableElement = formatMessageElement(variableName, " ");
     return "%s%s%s".formatted(messageElement, variableElement, description);
   }
 
-  protected static String formatMessageElement(String element, String delimiter) {
+  static String formatMessageElement(@Nullable String element, String delimiter) {
     if (element != null && !element.isEmpty()) {
       return element.concat(delimiter);
     }
@@ -464,9 +470,38 @@ public final class EnsureUtil {
     }
   }
 
-  public static void ensureActiveCommandContext(String operation) {
-    if(Context.getCommandContext() == null) {
+  public static CommandContext ensureActiveCommandContext(String operation) {
+    CommandContext commandContext = Context.getCommandContext();
+    if (commandContext == null) {
       throw LOG.notInsideCommandContext(operation);
     }
+    return requireNonNull(commandContext);
   }
+
+  public static CommandContext ensureActiveCommandContext(@Nullable CommandContext commandContext) {
+    if (commandContext == null) {
+      throw LOG.notInsideCommandContext(getCallerOperation());
+    }
+    return commandContext;
+  }
+
+  private static String getCallerOperation() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    if (stackTrace.length > 3) {
+      StackTraceElement caller = stackTrace[3];
+      String className = caller.getClassName();
+      String simpleClassName = className.substring(className.lastIndexOf('.') + 1);
+      return simpleClassName + "#" + unwrapLambdaMethodName(caller.getMethodName());
+    }
+    return "unknown operation";
+  }
+
+  private static String unwrapLambdaMethodName(String methodName) {
+    if (methodName.startsWith(LAMBDA_STACK_SIGNATURE)) {
+      int end = methodName.indexOf('$', LAMBDA_STACK_SIGNATURE.length());
+      return end > 0 ? methodName.substring(LAMBDA_STACK_SIGNATURE.length(), end) : methodName;
+    }
+    return methodName;
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -101,7 +102,7 @@ public final @NullMarked class EnsureUtil {
     ensureNotNull(exceptionClass, message, variableName, (Object[]) values);
   }
 
-  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, Object... values) {
+  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, @Nullable String message, String variableName, @Nullable Object @Nullable... values) {
     if(values == null) {
       throw generateException(exceptionClass, message, variableName, "is null");
     }
@@ -289,7 +290,7 @@ public final @NullMarked class EnsureUtil {
     ensureAtLeastOneNotNull(NullValueException.class, message, values);
   }
 
-  public static void ensureAtLeastOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String... values) {
+  public static void ensureAtLeastOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, @Nullable String... values) {
     ensureAtLeastOneNotNull(exceptionClass, message, (Object[]) values);
   }
 
@@ -471,7 +472,7 @@ public final @NullMarked class EnsureUtil {
   }
 
   public static CommandContext ensureActiveCommandContext(String operation) {
-    return Context.getCommandContextWhenAvailable().orElseThrow(() -> LOG.notInsideCommandContext(operation));
+    return Context.findCommandContext().orElseThrow(() -> LOG.notInsideCommandContext(operation));
   }
 
   public static CommandContext ensureActiveCommandContext(@Nullable CommandContext commandContext) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
@@ -471,11 +471,7 @@ public final @NullMarked class EnsureUtil {
   }
 
   public static CommandContext ensureActiveCommandContext(String operation) {
-    CommandContext commandContext = Context.getCommandContext();
-    if (commandContext == null) {
-      throw LOG.notInsideCommandContext(operation);
-    }
-    return requireNonNull(commandContext);
+    return Context.getCommandContextWhenAvailable().orElseThrow(() -> LOG.notInsideCommandContext(operation));
   }
 
   public static CommandContext ensureActiveCommandContext(@Nullable CommandContext commandContext) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
@@ -414,10 +414,10 @@ public final class ReflectUtil {
   }
 
   private static ClassLoader getCustomClassLoader() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
-    if(processEngineConfiguration != null) {
-      final ClassLoader classLoader = processEngineConfiguration.getClassLoader();
-      if(classLoader != null) {
+    Optional<ProcessEngineConfigurationImpl> processEngineConfiguration = Context.getProcessEngineConfigurationWhenAvailable();
+    if(processEngineConfiguration.isPresent()) {
+      final ClassLoader classLoader = processEngineConfiguration.get().getClassLoader();
+      if (classLoader != null) {
         return classLoader;
       }
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
@@ -329,7 +329,7 @@ public final class ReflectUtil {
         if(method.getName().equals(setterName)) {
           Class<?>[] paramTypes = method.getParameterTypes();
 
-          if(paramTypes != null && paramTypes.length == 1) {
+          if(paramTypes.length == 1) {
             candidates.add(method);
             parameterTypes.add(paramTypes[0]);
           }
@@ -414,7 +414,7 @@ public final class ReflectUtil {
   }
 
   private static ClassLoader getCustomClassLoader() {
-    Optional<ProcessEngineConfigurationImpl> processEngineConfiguration = Context.getProcessEngineConfigurationWhenAvailable();
+    Optional<ProcessEngineConfigurationImpl> processEngineConfiguration = Context.findProcessEngineConfiguration();
     if(processEngineConfiguration.isPresent()) {
       final ClassLoader classLoader = processEngineConfiguration.get().getClassLoader();
       if (classLoader != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceTypeUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceTypeUtil.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.util;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
 
 import org.jspecify.annotations.Nullable;
@@ -26,6 +27,7 @@ import org.operaton.bpm.engine.authorization.*;
 
 import static org.operaton.bpm.engine.authorization.Resources.*;
 
+@NullMarked
 public final class ResourceTypeUtil {
 
   private ResourceTypeUtil() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ScriptUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ScriptUtil.java
@@ -202,13 +202,9 @@ public final class ScriptUtil {
    * Returns the configured script factory in the context or a new one.
    */
   public static ScriptFactory getScriptFactory() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
-    if (processEngineConfiguration != null) {
-      return processEngineConfiguration.getScriptFactory();
-    }
-    else {
-      return new ScriptFactory();
-    }
+    return Context.findProcessEngineConfiguration()
+      .map(ProcessEngineConfigurationImpl::getScriptFactory)
+      .orElse(new ScriptFactory());
   }
 
   private static void ensureScriptLanguageNotEmpty(String language) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/xml/Parser.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/xml/Parser.java
@@ -83,12 +83,9 @@ public abstract class Parser {
   }
 
   public Boolean isEnableXxeProcessing() {
-    ProcessEngineConfigurationImpl engineConfig = Context.getProcessEngineConfiguration();
-    if (engineConfig != null) {
-      return engineConfig.isEnableXxeProcessing();
-    } else {  // can be null if implementation is called outside command context
-      return false;
-    }
+    return Context.findProcessEngineConfiguration()
+      .map(ProcessEngineConfigurationImpl::isEnableXxeProcessing)
+      .orElse(false);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/EnsureUtilTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/EnsureUtilTest.java
@@ -14,28 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.operaton.bpm.engine.impl.cmd;
+package org.operaton.bpm.engine.impl.util;
 
-import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
-import org.operaton.bpm.engine.impl.interceptor.Command;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
-/**
- * @author Tom Baeyens
- */
-public @NullMarked class CheckPassword implements Command<Boolean> {
-  @Nullable String userId;
-  @Nullable String password;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-  public CheckPassword(@Nullable String userId, @Nullable String password) {
-    this.userId = userId;
-    this.password = password;
+class EnsureUtilTest {
+  @Test
+  void ensureActiveCommandContext_logsOperation_whenCommandContextIsNull() {
+    CommandContext commandContext = null;
+    assertThatThrownBy(() -> EnsureUtil.ensureActiveCommandContext(commandContext))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Operation EnsureUtilTest#ensureActiveCommandContext_logsOperation_whenCommandContextIsNull requires active command context.");
   }
-
-  @Override
-  public Boolean execute(CommandContext commandContext) {
-    return commandContext.getReadOnlyIdentityProvider().checkPassword(userId, password);
-  }
-
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.test.api.authorization.history;
 
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -282,9 +284,10 @@ class AuthorizationUserOperationLogTest extends AuthorizationTest {
     assertThat(query.count()).isZero();
   }
 
+  @NullMarked
   public static class TestPermissionProvider extends DefaultPermissionProvider {
     @Override
-    public String getNameForResource(int resourceType) {
+    public @Nullable String getNameForResource(int resourceType) {
       for (Resource resource : TestResource.values()) {
         if (resourceType == resource.resourceType()) {
           return resource.resourceName();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -1519,6 +1519,15 @@ class FormServiceTest {
       .hasMessageContaining("Task id cannot be null: taskId is null");
   }
 
+  @Test
+  void testGetDeployedTaskFormWithUnknownTaskId() {
+    // must report the missing task instead of failing with a NullPointerException
+    // while running the authorization checks on the non-existing task
+    assertThatThrownBy(() -> formService.getDeployedTaskForm("unknownTaskId"))
+      .isInstanceOf(ProcessEngineException.class)
+      .isNotInstanceOf(NullPointerException.class);
+  }
+
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/form/DeployedFormsProcess.bpmn20.xml",
       "org/operaton/bpm/engine/test/api/form/task.html"})
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskLockingTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.concurrency;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -138,7 +139,7 @@ class CompetingExternalTaskLockingTest extends ConcurrencyTestCase {
     }
   }
 
-  private static class ControllableLockExternalTaskCmd extends LockExternalTaskCmd {
+  private static @NullMarked class ControllableLockExternalTaskCmd extends LockExternalTaskCmd {
 
     protected final ThreadControl monitor;
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskInstanceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.operaton.bpm.engine.CaseService;
 import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RepositoryService;
@@ -62,6 +63,7 @@ class HistoricTaskInstanceTest {
   ProcessEngineConfigurationImpl processEngineConfiguration;
   RuntimeService runtimeService;
   TaskService taskService;
+  IdentityService identityService;
   HistoryService historyService;
   RepositoryService repositoryService;
   CaseService caseService;
@@ -143,6 +145,18 @@ class HistoricTaskInstanceTest {
   void testDeleteHistoricTaskInstance() {
     // deleting unexisting historic task instance should be silently ignored
     assertThatCode(() -> historyService.deleteHistoricTaskInstance("unexistingId")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void testDeleteHistoricTaskInstanceWithAuthenticatedUser() {
+    // the user operation log is only written for an authenticated user; deleting an unexisting
+    // historic task instance must still be silently ignored instead of failing to log it
+    identityService.setAuthenticatedUserId("kermit");
+    try {
+      assertThatCode(() -> historyService.deleteHistoricTaskInstance("unexistingId")).doesNotThrowAnyException();
+    } finally {
+      identityService.clearAuthentication();
+    }
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquireJobCmdUnitTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquireJobCmdUnitTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.operaton.bpm.engine.impl.Page;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.AcquireJobsCmd;
 import org.operaton.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -37,15 +38,15 @@ import static org.mockito.Mockito.when;
 
 class AcquireJobCmdUnitTest {
 
-  protected static final String PROCESS_INSTANCE_ID_1 = "pi_1";
-  protected static final String PROCESS_INSTANCE_ID_2 = "pi_2";
+  static final String PROCESS_INSTANCE_ID_1 = "pi_1";
+  static final String PROCESS_INSTANCE_ID_2 = "pi_2";
 
-  protected static final String JOB_ID_1 = "job_1";
-  protected static final String JOB_ID_2 = "job_2";
+  static final String JOB_ID_1 = "job_1";
+  static final String JOB_ID_2 = "job_2";
 
-  protected AcquireJobsCmd acquireJobsCmd;
-  protected JobManager jobManager;
-  protected CommandContext commandContext;
+  AcquireJobsCmd acquireJobsCmd;
+  JobManager jobManager;
+  CommandContext commandContext;
 
   @BeforeEach
   void initCommand() {
@@ -63,6 +64,9 @@ class AcquireJobCmdUnitTest {
 
     jobManager = mock(JobManager.class);
     when(commandContext.getJobManager()).thenReturn(jobManager);
+
+    var processEngineConfiguration = mock(ProcessEngineConfigurationImpl.class);
+    when(commandContext.getProcessEngineConfiguration()).thenReturn(processEngineConfiguration);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ControllableCommandContext.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ControllableCommandContext.java
@@ -16,11 +16,13 @@
  */
 package org.operaton.bpm.engine.test.jobexecutor;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.interceptor.CommandInvocationContext;
 import org.operaton.bpm.engine.test.concurrency.ConcurrencyTestHelper;
 
+@NullMarked
 public class ControllableCommandContext extends CommandContext {
 
   protected ConcurrencyTestHelper.ThreadControl executionThread;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/FailedJobListenerWithRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/FailedJobListenerWithRetriesTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.time.DateUtils;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -144,7 +146,7 @@ public class FailedJobListenerWithRetriesTest {
     }
   }
 
-  public class OLEFoxJobRetryCmd extends DefaultJobRetryCmd {
+  public @NullMarked class OLEFoxJobRetryCmd extends DefaultJobRetryCmd {
 
     private int countRuns;
 
@@ -153,7 +155,7 @@ public class FailedJobListenerWithRetriesTest {
     }
 
     @Override
-    public Object execute(CommandContext commandContext) {
+    public @Nullable Object execute(CommandContext commandContext) {
       Job job = getJob();
       //on last attempt the incident will be created, we imitate OLE
       if (job.getRetries() == 1) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/FailedJobListenerWithRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/FailedJobListenerWithRetriesTest.java
@@ -156,7 +156,7 @@ public class FailedJobListenerWithRetriesTest {
 
     @Override
     public @Nullable Object execute(CommandContext commandContext) {
-      Job job = getJob();
+      Job job = getJob().orElseThrow();
       //on last attempt the incident will be created, we imitate OLE
       if (job.getRetries() == 1) {
         countRuns++;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/interceptor/CommandContextInterceptorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/interceptor/CommandContextInterceptorTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.standalone.interceptor;
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -56,7 +57,7 @@ class CommandContextInterceptorTest {
       throw new IllegalStateException("here i come!");
     })).isInstanceOf(IllegalStateException.class);
 
-    assertThat(Context.getCommandContext()).isNull();
+    assertThat(Context.hasActiveCommandContext()).isFalse();
   }
 
   @Test
@@ -129,7 +130,7 @@ class CommandContextInterceptorTest {
     assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
   }
 
-  protected class ExceptionThrowingCmd implements Command<Void> {
+  protected @NullMarked class ExceptionThrowingCmd implements Command<Void> {
 
     protected boolean executed;
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/ModelInstance.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/ModelInstance.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.model.xml;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.model.xml.impl.instance.ModelElementInstanceImpl;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/ModelInstance.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/ModelInstance.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.model.xml;
 
 import java.util.Collection;
 
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.model.xml.impl.instance.ModelElementInstanceImpl;

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/steps/SignalTestRunListener.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/steps/SignalTestRunListener.java
@@ -28,8 +28,8 @@ public class SignalTestRunListener implements ExecutionListener {
   @Override
   public void notify(final DelegateExecution execution) {
     final String runId = (String) execution.getVariable(PerfTestConstants.RUN_ID);
-    CommandContext commandContext = Context.getCommandContext();
-    if (runId != null && commandContext != null) {
+    if (runId != null && Context.hasActiveCommandContext()) {
+      CommandContext commandContext = Context.getCommandContext();
       commandContext.getTransactionContext()
         // signal run after the transaction was committed
         .addTransactionListener(TransactionState.COMMITTED, commandContext1 -> PerfTestRunner.signalRun(runId));


### PR DESCRIPTION
This change adds nullability annotations to internal engine API with a focus on command implementations.

**Note**:
The contract of the internal `org.operaton.bpm.engine.impl.context.Context#getCommandContext()` and `org.operaton.bpm.engine.impl.context.Context#getProcessEngineConfiguration()` has been changed to guarantee that non-null references are returned at runtime. Code that must assume that the initialization of the engine's `CommandContext` and `ProcessEngineConfiguration` could be uninitalized must check with `hasActiveCommandContext` or `findCommandContext` rsp. `hasActiveProcessEngineConfiguration` or `findProcessEngineConfiguration`.
All engine's usages have been refactored.
Client code usually don't use this internal API directly.

related to https://github.com/operaton/operaton/issues/2353
