### PR TITLE
fix(webapps): Correct broken documentation links in neo web apps

### DIFF
--- a/webapps-neo/frontend/src/components/TaskForm.jsx
+++ b/webapps-neo/frontend/src/components/TaskForm.jsx
@@ -122,7 +122,7 @@ const EMBEDDED_APP = "embedded:app:";
 const EMBEDDED_DEPLOYMENT = "embedded:deployment:";
 
 const FORM_JS_MIGRATION_DOCS =
-  "https://docs.operaton.org/documentation/user-guide/task-forms/";
+  "https://docs.operaton.org/docs/documentation/user-guide/task-forms/";
 
 const EmbeddedHtmlTaskForm = ({ task, formKey }) => {
   const state = useContext(AppState),

--- a/webapps-neo/frontend/src/pages/Processes.jsx
+++ b/webapps-neo/frontend/src/pages/Processes.jsx
@@ -826,7 +826,7 @@ const DefinitionsEmpty = () => {
       <p>{t("processes.empty.heading")}</p>
       <a href="/deployments">{t("processes.empty.upload")}</a>
       <a
-        href="https://docs.operaton.org/manual/latest/installation/full/tomcat/manual/"
+        href="https://docs.operaton.org/docs/documentation/user-guide/process-engine/deployments"
         target="_blank"
         rel="noreferrer"
       >

--- a/webapps-neo/frontend/src/pages/StartProcessList.jsx
+++ b/webapps-neo/frontend/src/pages/StartProcessList.jsx
@@ -25,7 +25,7 @@ const is_legacy_start_key = (key) =>
   (key.startsWith(EMBEDDED_APP_PREFIX) ||
     key.startsWith(EMBEDDED_DEPLOYMENT_PREFIX))
 const FORM_JS_MIGRATION_DOCS =
-  'https://docs.operaton.org/documentation/user-guide/task-forms/'
+  'https://docs.operaton.org/docs/documentation/user-guide/task-forms/'
 
 const StartProcessList = () => {
   const


### PR DESCRIPTION
## What

Fixes three documentation links in `webapps-neo` that returned HTTP 404:

- **TaskForm.jsx** and **StartProcessList.jsx** — the "How to migrate" link
  for legacy embedded forms was missing the `docs/` path segment.
- **Processes.jsx** — the "How to deploy" link on the empty processes page
  still pointed at the removed `/manual/latest/…` install path.

## Fix

- add the missing `docs/` segment →
  `https://docs.operaton.org/docs/documentation/user-guide/task-forms/`
- repoint the deploy link →
  `https://docs.operaton.org/docs/documentation/user-guide/process-engine/deployments`

All three corrected URLs return HTTP 200.

related to #3553
