### PR TITLE
fix(webapps): Improve German UI translations in neo web apps

### DIFF
--- a/webapps-neo/frontend/public/locales/de-DE/translation.json
+++ b/webapps-neo/frontend/public/locales/de-DE/translation.json
@@ -33,7 +33,7 @@
     "select-page": "Seite auswählen",
     "activate": "Aktivieren",
     "load-more": "Mehr laden",
-    "breadcrumb": "Brotkrümelnavigation",
+    "breadcrumb": "Navigationspfad",
     "confirmation": "Bestätigung"
   },
   "nav": {
@@ -41,7 +41,7 @@
     "processes": "Prozesse",
     "decisions": "Entscheidungen",
     "deployments": "Deployments",
-    "batches": "Stapelverarbeitung",
+    "batches": "Batches",
     "migrations": "Migrationen",
     "admin": "Admin",
     "help": "Hilfe",
@@ -102,18 +102,18 @@
     "greeting": "Hallo",
     "open-tasks": "offene Aufgaben",
     "deployed-definitions": "deployte Definitionen",
-    "incident": "Inzident",
-    "incidents": "Inzidente",
+    "incident": "Incident",
+    "incidents": "Incidents",
     "decision-definitions": "Entscheidungsdefinitionen",
     "deployments": "Deployments",
-    "open-incidents": "Offene Inzidente",
-    "no-incidents": "Keine Inzidente",
+    "open-incidents": "Offene Incidents",
+    "no-incidents": "Keine Incidents",
     "process": "Prozess",
     "count": "Anzahl",
     "recent-tasks": "Aktuelle Aufgaben",
     "see-all-tasks": "Alle Aufgaben anzeigen",
     "no-open-tasks": "Keine offenen Aufgaben.",
-    "assignee": "Verantwortlich",
+    "assignee": "Bearbeiter",
     "created": "Erstellt",
     "unnamed": "Unbenannt",
     "process-definitions": "Prozessdefinitionen",
@@ -122,7 +122,7 @@
     "instances": "Instanzen"
   },
   "tasks": {
-    "title": "Aufgaben Liste",
+    "title": "Aufgabenliste",
     "start-process-label": "Prozess starten",
     "current-filter": "Filter",
     "all-tasks": "Alle Aufgaben",
@@ -139,8 +139,8 @@
     "claim": "Beanspruchen",
     "unclaim": "Freigeben",
     "you": "Sie",
-    "reset-assignee": "Verantwortlichen zurücksetzen",
-    "assignee-menu": "Zuständigkeits-Aktionen",
+    "reset-assignee": "Bearbeiter zurücksetzen",
+    "assignee-menu": "Bearbeiter-Aktionen",
     "comment": "Kommentar",
     "comment-add": "Kommentar hinzufügen",
     "comment-none": "Noch keine Kommentare.",
@@ -148,10 +148,10 @@
     "task-list": {
       "table-headings": {
         "task-name": "Aufgabe",
-        "process-definition": "Prozess Definition",
-        "process-version": "Prozess Version",
+        "process-definition": "Prozessdefinition",
+        "process-version": "Prozessversion",
         "created-on": "Erstellt am",
-        "assignee": "Verantwortlich",
+        "assignee": "Bearbeiter",
         "priority": "Priorität",
         "due-in": "Fällig in"
       }
@@ -246,7 +246,7 @@
       "due-date": "Fälligkeitsdatum",
       "follow-up-date": "Wiedervorlage",
       "task-name": "Aufgabenname",
-      "assignee": "Verantwortlich",
+      "assignee": "Bearbeiter",
       "process-variable": "Prozessvariable",
       "execution-variable": "Ausführungsvariable",
       "task-variable": "Aufgabenvariable",
@@ -311,18 +311,18 @@
     "instance-id": "Instanz-ID",
     "change-instance": "Instanz wechseln",
     "col-abbr": {
-      "incidents": "Inzid.",
+      "incidents": "Incid.",
       "instances": "Inst.",
       "version": "Ver.",
       "tenant-id": "Mandant"
     },
     "tabs": {
       "instances": "Instanzen",
-      "incidents": "Inzidente",
+      "incidents": "Incidents",
       "called-definitions": "Aufgerufene Definitionen",
       "jobs": "Jobs",
       "variables": "Variablen",
-      "instance-incidents": "Instanz-Inzidente",
+      "instance-incidents": "Instanz-Incidents",
       "called-instances": "Aufgerufene Instanzen",
       "user-tasks": "Benutzeraufgaben",
       "external-tasks": "Externe Aufgaben",
@@ -333,7 +333,7 @@
       "details": "Definitionsdetails",
       "definitions": "Definitionen",
       "instances": "Instanzen",
-      "incidents": "Inzidente",
+      "incidents": "Incidents",
       "called-definitions": "Aufgerufene Definitionen",
       "jobs": "Jobs"
     },
@@ -424,7 +424,7 @@
         "startTime": "Startzeit",
         "instanceId": "Instanz-ID",
         "definitionKey": "Definitionsschlüssel",
-        "businessKey": "Business Key",
+        "businessKey": "Geschäftsschlüssel",
         "tenantId": "Mandanten-ID"
       },
       "filter_keys": {
@@ -463,7 +463,7 @@
       "error-details": "Fehlerdetails"
     },
     "activity-history": {
-      "empty": "Keine Aktivitätshistorie für diese Instanz.",
+      "empty": "Kein Aktivitätsverlauf für diese Instanz.",
       "canceled": "Abgebrochen"
     },
     "audit": {
@@ -564,7 +564,7 @@
     }
   },
   "batches": {
-    "title": "Stapelverarbeitung",
+    "title": "Batches",
     "select-batch": "Wählen Sie einen Batch aus, um seine Details anzuzeigen.",
     "empty": "Derzeit laufen keine Batches.",
     "refresh": "Aktualisieren",
@@ -578,8 +578,8 @@
     "created-by": "Erstellt von",
     "state": "Status",
     "running": "Läuft",
-    "suspended": "Ausgesetzt",
-    "suspend": "Aussetzen",
+    "suspended": "Angehalten",
+    "suspend": "Anhalten",
     "resume": "Fortsetzen",
     "delete": "Löschen",
     "confirm-delete": "Diesen Batch löschen und seine verbleibenden Jobs abbrechen?",
@@ -660,10 +660,10 @@
       "suspended": "Angehalten",
       "root-instances-only": "Nur Stamminstanzen",
       "leaf-instances-only": "Nur Blattinstanzen",
-      "with-incidents-only": "Nur mit Inzidenten",
-      "incident-id": "Inzident-ID",
-      "incident-type": "Inzidenttyp",
-      "incident-message": "Inzidentnachricht",
+      "with-incidents-only": "Nur mit Incidents",
+      "incident-id": "Incident-ID",
+      "incident-type": "Incident-Typ",
+      "incident-message": "Incident-Nachricht",
       "tenant-id": "Mandanten-ID",
       "activity-id": "Aktivitäts-ID",
       "without-tenant-id": "Ohne Mandanten-ID"
@@ -765,7 +765,7 @@
     "authorization-resources": {
       "application": "Anwendung",
       "authorization": "Autorisierung",
-      "batch": "Stapel",
+      "batch": "Batch",
       "decision-definition": "Entscheidungsdefinition",
       "decision-requirements-definition": "Entscheidungsanforderungsdefinition",
       "deployment": "Deployment",
@@ -852,7 +852,7 @@
     "zoom-out": "Verkleinern",
     "fit": "Ansicht anpassen",
     "show-instances": "Laufende Instanzen für diese Aktivität anzeigen",
-    "show-incidents": "Inzidente für diese Aktivität anzeigen",
+    "show-incidents": "Incidents für diese Aktivität anzeigen",
     "show-called-activity": "Aufgerufene Aktivität (Unterprozess) anzeigen",
     "modify": {
       "drag-hint": "Auf eine andere Aktivität ziehen, um den Token zu verschieben",

--- a/webapps-neo/frontend/public/locales/de-DE/translation.json
+++ b/webapps-neo/frontend/public/locales/de-DE/translation.json
@@ -463,7 +463,7 @@
       "error-details": "Fehlerdetails"
     },
     "activity-history": {
-      "empty": "Kein Aktivitätsverlauf für diese Instanz.",
+      "empty": "Keine Aktivitätshistorie für diese Instanz.",
       "canceled": "Abgebrochen"
     },
     "audit": {


### PR DESCRIPTION
## What

Fixes correctness and consistency issues in the German (`de-DE`) UI translations
of `webapps-neo` — 29 strings in `public/locales/de-DE/translation.json`.

## Changes

- **`Inzident` → `Incident`** (13 strings) — "Inzident" is not a real German
  word; "Incident" is the established Operaton term (consistent with Job / Batch
  / Deployment).
- **Compound spelling** — `Aufgaben Liste` → `Aufgabenliste`,
  `Prozess Definition` → `Prozessdefinition`, `Prozess Version` → `Prozessversion`.
- **`Batch`** — unified (`Stapelverarbeitung` / `Stapel` → `Batch`).
- **`Suspend` / `Suspended`** — unified to `Anhalten` / `Angehalten`; the batch
  view was the outlier.
- **`Business Key`** — translated the one sort option that kept English →
  `Geschäftsschlüssel`.
- **Terminology** — `Assignee` → `Bearbeiter` (Camunda-standard; `Owner` stays
  `Besitzer`); activity-history label aligned to `Verlauf`; `Breadcrumb` ARIA
  label → `Navigationspfad`.

related to #3555
