### PR TITLE
fix(webapps): Map browser locale to region translation file in neo

### DIFF
--- a/webapps-neo/frontend/src/helper/i18n.js
+++ b/webapps-neo/frontend/src/helper/i18n.js
@@ -8,6 +8,13 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 // have a look at the Quick start guide
 // for passing in lng and translations on init
 
+// Translation files are region-specific (see /public/locales), but browsers
+// report language-only codes like `de`. Map the detected code to a region file.
+const SUPPORTED_LNGS = ['de-DE', 'en-US', 'es-ES', 'fr-FR', 'nl-NL'];
+const REGION_BY_LANG = Object.fromEntries(
+  SUPPORTED_LNGS.map((lng) => [lng.split('-')[0], lng])
+);
+
 i18n
   // load translation using http -> see /public/locales (i.e. https://github.com/i18next/react-i18next/tree/master/example/react/public/locales)
   // learn more: https://github.com/i18next/i18next-http-backend
@@ -22,6 +29,15 @@ i18n
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
     fallbackLng: 'en-US',
+    supportedLngs: SUPPORTED_LNGS,
+    // Only load the resolved language (+ fallback); never the language-only
+    // `/locales/de/…` or `/dev/…`, which 404'd / failed JSON parse on startup.
+    load: 'currentOnly',
+    detection: {
+      // e.g. `de`, `de-AT` → `de-DE`; unknown codes fall through to fallbackLng.
+      convertDetectedLanguage: (lng) =>
+        REGION_BY_LANG[lng.split('-')[0].toLowerCase()] ?? lng,
+    },
     debug: true,
 
     interpolation: {


### PR DESCRIPTION
## What

Fixes the startup i18n error in `webapps-neo` when the browser reports a
language-only locale (e.g. `de`): the app requested
`/locales/de/translation.json`, which 404'd and was logged as a JSON parse
error. Only region-specific files (`de-DE`, `en-US`, …) are shipped.

## Fix (`src/helper/i18n.js`)

- **`convertDetectedLanguage`** maps the detected code to the region file:
  `de`, `de-AT` → `de-DE`; unknown codes fall through to `fallbackLng`.
- **`load: 'currentOnly'`** stops i18next from also requesting the language-only
  (`de`) and `dev` variants.
- The language→region map is derived from a single `SUPPORTED_LNGS` list.

Verified in the browser: `?lng=de` now loads `de-DE` with no 404 and no
`rejecting language code` warnings.

related to #3557
