### PR TITLE
feat(ci): Add worflow to update Node.js & npm

### DIFF
--- a/.devenv/scripts/README.md
+++ b/.devenv/scripts/README.md
@@ -212,6 +212,31 @@ Show help:
 
 If an invalid cleanup value is specified, the script prints an error and exits.
 
+## `update-nodejs-version.sh`
+
+Updates the Node.js and npm versions used by the build. The versions are maintained as the properties `version.nodejs` and
+`version.npm` in `parent/pom.xml`, from where the frontend-maven-plugin picks them up. The script sets them to the latest Node.js
+LTS release and to the npm version bundled with that release. If the Node.js major version changes, the hardcoded `node-version`
+inputs of `.github/workflows/build.yml` and `.github/workflows/pr-build.yml` are updated as well.
+
+The script is run by the [Update Node.js](../../.github/workflows/update-nodejs.yml) workflow, but can also be executed manually
+from the root of the repository:
+
+```bash
+.devenv/scripts/maintenance/update-nodejs-version.sh
+```
+
+### Options
+
+- `--pin-major`  
+  Stay on the Node.js major version that is currently configured. Used for maintenance branches, which must not jump to a new
+  LTS line.
+- `--index-url=URL`  
+  Override the Node.js release index (default: `https://nodejs.org/dist/index.json`). Only used for testing; `file://` URLs are
+  supported.
+
+When `$GITHUB_OUTPUT` is set, the script writes the outputs `changed`, `major_changed`, `node_version` and `npm_version`.
+
 ## `init-database-version.py` — Database Version Maintenance
 
 This script automates the process of initializing and updating the database version across all supported databases and related files.

--- a/.devenv/scripts/maintenance/update-nodejs-version.sh
+++ b/.devenv/scripts/maintenance/update-nodejs-version.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Copyright 2026 the Operaton contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -------------------------------------------------------------------------------------------------
+#
+# Updates the Node.js and npm versions used by the build.
+#
+# The versions are maintained as the properties <version.nodejs> and <version.npm>
+# in parent/pom.xml, from where the frontend-maven-plugin picks them up. This script
+# sets them to the latest Node.js LTS release and to the npm version bundled with
+# that release. When the Node.js major version changes, the hardcoded node-version
+# inputs of the CI workflows are updated as well, so that the CI toolchain and the
+# Maven build stay in lockstep.
+#
+# Options:
+#   --pin-major       Stay on the Node.js major version that is currently configured.
+#                     Used for maintenance branches, which must not jump to a new LTS line.
+#   --index-url=<url> Override the Node.js release index. Only used for testing.
+#
+# When $GITHUB_OUTPUT is set, the following outputs are written:
+#   changed, node_version, npm_version, major_changed
+#
+set -euo pipefail
+
+INDEX_URL="https://nodejs.org/dist/index.json"
+PIN_MAJOR=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --pin-major)
+      PIN_MAJOR=true
+      ;;
+    --index-url=*)
+      INDEX_URL="${arg#*=}"
+      ;;
+    *)
+      echo "⚠️ Unknown option: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+sed_inplace() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -E "$@"
+  else
+    sed -i -E "$@"
+  fi
+}
+
+emit_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "$1=$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+POM="parent/pom.xml"
+# Workflows that pin the Node.js major version for the CI toolchain. The Node.js
+# version of slack-link-check.yml is unrelated to the build and stays untouched.
+WORKFLOWS=(.github/workflows/build.yml .github/workflows/pr-build.yml)
+
+extract_property() {
+  sed -nE "s|.*<$1>(.+)</$1>.*|\1|p" "$POM" | head -1
+}
+
+CURRENT_NODE=$(extract_property "version.nodejs")
+CURRENT_NPM=$(extract_property "version.npm")
+
+if [ -z "$CURRENT_NODE" ] || [ -z "$CURRENT_NPM" ]; then
+  echo "⚠️ Could not read <version.nodejs>/<version.npm> from $POM. Exiting..." >&2
+  exit 1
+fi
+
+CURRENT_MAJOR="${CURRENT_NODE%%.*}"
+echo "ℹ️ Currently configured: Node.js $CURRENT_NODE, npm $CURRENT_NPM"
+
+echo "🔄 Fetching Node.js release index from $INDEX_URL"
+if [[ "$INDEX_URL" == file://* ]]; then
+  INDEX=$(cat "${INDEX_URL#file://}")
+else
+  INDEX=$(curl -fsSL "$INDEX_URL")
+fi
+
+# The index is ordered newest first, so the first LTS entry is the latest LTS release.
+if [ "$PIN_MAJOR" = true ]; then
+  echo "ℹ️ Restricting the search to the Node.js $CURRENT_MAJOR.x line"
+  RELEASE=$(jq -r --arg major "v${CURRENT_MAJOR}." \
+    'map(select(.lts != false and (.version | startswith($major)))) | .[0] // empty' <<< "$INDEX")
+else
+  RELEASE=$(jq -r 'map(select(.lts != false)) | .[0] // empty' <<< "$INDEX")
+fi
+
+if [ -z "$RELEASE" ]; then
+  echo "⚠️ No matching Node.js LTS release found. Exiting..." >&2
+  exit 1
+fi
+
+LATEST_NODE=$(jq -r '.version | ltrimstr("v")' <<< "$RELEASE")
+LATEST_NPM=$(jq -r '.npm // empty' <<< "$RELEASE")
+
+if [ -z "$LATEST_NPM" ]; then
+  echo "⚠️ Node.js $LATEST_NODE does not declare a bundled npm version. Exiting..." >&2
+  exit 1
+fi
+
+echo "ℹ️ Latest LTS release: Node.js $LATEST_NODE, bundled npm $LATEST_NPM"
+
+if [ "$LATEST_NODE" = "$CURRENT_NODE" ] && [ "$LATEST_NPM" = "$CURRENT_NPM" ]; then
+  echo "✅ Already up to date. Nothing to do."
+  emit_output "changed" "false"
+  emit_output "major_changed" "false"
+  emit_output "node_version" "$LATEST_NODE"
+  emit_output "npm_version" "$LATEST_NPM"
+  exit 0
+fi
+
+echo "🔄 Updating $POM"
+sed_inplace "s|<version.nodejs>[^<]+</version.nodejs>|<version.nodejs>${LATEST_NODE}</version.nodejs>|" "$POM"
+sed_inplace "s|<version.npm>[^<]+</version.npm>|<version.npm>${LATEST_NPM}</version.npm>|" "$POM"
+
+LATEST_MAJOR="${LATEST_NODE%%.*}"
+MAJOR_CHANGED=false
+
+if [ "$LATEST_MAJOR" != "$CURRENT_MAJOR" ]; then
+  MAJOR_CHANGED=true
+  for WORKFLOW in "${WORKFLOWS[@]}"; do
+    echo "🔄 Updating node-version in $WORKFLOW"
+    sed_inplace "s|^([[:space:]]*node-version:[[:space:]]*)${CURRENT_MAJOR}[[:space:]]*$|\1${LATEST_MAJOR}|" "$WORKFLOW"
+  done
+fi
+
+emit_output "changed" "true"
+emit_output "major_changed" "$MAJOR_CHANGED"
+emit_output "node_version" "$LATEST_NODE"
+emit_output "npm_version" "$LATEST_NPM"
+
+echo "✅ Done! Node.js $CURRENT_NODE -> $LATEST_NODE, npm $CURRENT_NPM -> $LATEST_NPM"

--- a/.github/scripts/list-maintained-branches.sh
+++ b/.github/scripts/list-maintained-branches.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2026 the Operaton contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -------------------------------------------------------------------------------------------------
+#
+# Lists the branches that are under maintenance, together with the milestone that pull
+# requests against them should be assigned to.
+#
+# The maintained branches are `main` plus every `release/*` branch that exists on the
+# remote. The milestone is looked up in .github/dependabot.yml, which already maps a
+# target branch to its milestone and is kept current by the Update Dependabot Milestone
+# workflow. Branches without an entry there get no milestone.
+#
+# Options:
+#   --dependabot-file=<path>  Override the Dependabot configuration. Only used for testing.
+#
+# Prints a JSON array of objects with the keys `branch`, `slug`, `maintenance` and
+# `milestone` and, when $GITHUB_OUTPUT is set, writes it as the output `branches`.
+# `maintenance` is false for `main` and true for the release branches.
+#
+set -euo pipefail
+
+DEPENDABOT_FILE=".github/dependabot.yml"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dependabot-file=*)
+      DEPENDABOT_FILE="${arg#*=}"
+      ;;
+    *)
+      echo "⚠️ Unknown option: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+if [ ! -f "$DEPENDABOT_FILE" ]; then
+  echo "⚠️ $DEPENDABOT_FILE not found. Exiting..." >&2
+  exit 1
+fi
+
+BRANCHES=("main")
+while IFS= read -r BRANCH; do
+  [ -n "$BRANCH" ] && BRANCHES+=("$BRANCH")
+done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin/release/ | sed 's|^origin/||' | sort -u)
+
+RESULT="[]"
+
+for BRANCH in "${BRANCHES[@]}"; do
+  MILESTONE=$(yq "[.updates[] | select(.\"target-branch\" == \"$BRANCH\" and has(\"milestone\")) | .milestone] | .[0] // \"\"" "$DEPENDABOT_FILE")
+  if [ "$MILESTONE" = "null" ]; then
+    MILESTONE=""
+  fi
+
+  if [ "$BRANCH" = "main" ]; then
+    MAINTENANCE=false
+  else
+    MAINTENANCE=true
+  fi
+
+  if [ -n "$MILESTONE" ]; then
+    echo "🌿 $BRANCH (maintenance: $MAINTENANCE, milestone: $MILESTONE)"
+  else
+    echo "🌿 $BRANCH (maintenance: $MAINTENANCE, no milestone found in $DEPENDABOT_FILE)"
+  fi
+
+  RESULT=$(jq -c \
+    --arg branch "$BRANCH" \
+    --arg slug "${BRANCH//\//-}" \
+    --argjson maintenance "$MAINTENANCE" \
+    --arg milestone "$MILESTONE" \
+    '. + [{branch: $branch, slug: $slug, maintenance: $maintenance, milestone: $milestone}]' \
+    <<< "$RESULT")
+done
+
+echo "$RESULT"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "branches=$RESULT" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,6 +36,30 @@ serves a specific purpose in the CI/CD pipeline.
 - **Triggers**:
     - Manually triggered via `workflow_dispatch` with a Slack URL input
 
+### Update Node.js
+
+- **Filename**: `update-nodejs.yml`
+- **Description**: Updates the `version.nodejs` and `version.npm` properties in `parent/pom.xml` to the latest Node.js LTS release
+  and the npm version bundled with it, and opens a pull request per maintained branch. Dependabot cannot cover these versions,
+  because they are Maven properties rather than entries of a package manifest.
+- **Triggers**:
+    - Scheduled at 3:00 AM UTC on the 1st and the 15th of a month
+    - Manually triggered via `workflow_dispatch`
+- **Jobs**:
+    - `detect-branches`: Runs `.github/scripts/list-maintained-branches.sh`, which lists `main` plus every `release/*` branch on
+      the remote and looks up the milestone for each in `.github/dependabot.yml`. Branches without an entry there get no milestone.
+      The script is not specific to this workflow and can be reused by other maintenance automation.
+    - `update-nodejs`: Runs `.devenv/scripts/maintenance/update-nodejs-version.sh` per detected branch and opens a pull request if
+      the versions changed.
+- **Branch policy**:
+    - `main` follows the latest LTS release, including a jump to a new LTS line. On such a jump the `node-version` inputs of
+      `build.yml` and `pr-build.yml` are updated as well.
+    - `release/*` branches stay on their current Node.js major version (`--pin-major`), matching the Dependabot policy for
+      maintenance branches.
+    - New release branches are picked up automatically, so no configuration is needed when a branch is created or dropped.
+- **Note**: The pull requests are created with the `GITHUB_TOKEN`, so they do not trigger the PR build automatically. Close and
+  reopen a pull request to run the build.
+
 ### Nightly Trigger
 
 - **Filename**: `nightly-trigger.yml`

--- a/.github/workflows/update-nodejs.yml
+++ b/.github/workflows/update-nodejs.yml
@@ -1,0 +1,92 @@
+name: Update Node.js
+
+# Dependabot cannot update the Node.js and npm versions, because they are maintained as
+# Maven properties in parent/pom.xml rather than in a package manifest. This workflow
+# closes that gap: it checks bi-weekly for a newer Node.js LTS release and opens a pull
+# request per maintained branch.
+
+on:
+  schedule:
+    - cron: "0 3 1,15 * *"    # Runs at 3:00 AM UTC on the 1st and the 15th of a month
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: false
+
+jobs:
+  detect-branches:
+    name: Detect Maintained Branches
+    # ubuntu-latest, because the branch detection needs yq to read the Dependabot configuration
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      branches: ${{ steps.list-branches.outputs.branches }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: List Maintained Branches
+        id: list-branches
+        run: |
+          git fetch --all
+          .github/scripts/list-maintained-branches.sh
+        shell: bash
+
+  update-nodejs:
+    name: "Update Node.js (${{ matrix.branch }})"
+    needs: detect-branches
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect-branches.outputs.branches) }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ matrix.branch }}
+          persist-credentials: false
+
+      - name: Update Node.js Version
+        id: update
+        run: |
+          .devenv/scripts/maintenance/update-nodejs-version.sh ${PIN_MAJOR:+--pin-major}
+        env:
+          # Maintenance branches must not jump to a new LTS line
+          PIN_MAJOR: ${{ matrix.maintenance && 'true' || '' }}
+        shell: bash
+
+      - name: Create Pull Request
+        if: ${{ steps.update.outputs.changed == 'true' }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
+        with:
+          base: ${{ matrix.branch }}
+          branch: "chore/update-nodejs-${{ matrix.slug }}"
+          title: "chore(deps): Update Node.js to ${{ steps.update.outputs.node_version }} and npm to ${{ steps.update.outputs.npm_version }}"
+          commit-message: "chore(deps): Update Node.js to ${{ steps.update.outputs.node_version }} and npm to ${{ steps.update.outputs.npm_version }}"
+          body: |
+            ## Node.js Update
+
+            Updates `version.nodejs` and `version.npm` in [`parent/pom.xml`](https://github.com/operaton/operaton/blob/main/parent/pom.xml)
+            to the latest Node.js LTS release and the npm version bundled with it.
+
+            | | Node.js | npm |
+            |---|---|---|
+            | New | `${{ steps.update.outputs.node_version }}` | `${{ steps.update.outputs.npm_version }}` |
+
+            ${{ steps.update.outputs.major_changed == 'true' && 'The Node.js major version changed, so the `node-version` inputs of `build.yml` and `pr-build.yml` were updated as well.' || '' }}
+
+            Created by the [Update Node.js](https://github.com/operaton/operaton/blob/main/.github/workflows/update-nodejs.yml) workflow.
+          labels: |
+            dependencies:npm
+            scope:ci
+          milestone: ${{ matrix.milestone }}
+          reviewers: kthoms


### PR DESCRIPTION
Adds the workflow `update-nodejs.yml` and supporting shell scripts to automatically update the used Node.js version on maintained branches (main & release/*).

closes #3163