### PR TITLE
feat(webapps-neo): Flesh out the Engine Metrics page with five dashboard widgets

### DIFF
--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -174,6 +174,11 @@
     white-space: nowrap;
   }
 
+  #content.metrics-page .ranking-sub {
+    color: var(--color-text-secondary, #888);
+    font-size: 0.85em;
+  }
+
   #content.metrics-page .ranking-bar-track {
     block-size: 0.6rem;
     background: var(--background-3, #eee);

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -6,6 +6,16 @@
  * its styles predictably win without specificity wars and never leak.
  */
 @layer custom {
+  /* `main` carries no padding of its own; give the page the same breathing room
+     the other pages get (Home uses `p-3`), so content isn't flush to the edges. */
+  #content.metrics-page {
+    padding: var(--spacing-4, 1.5rem);
+  }
+
+  #content.metrics-page h1 {
+    margin-block: 0 var(--spacing-3, 1rem);
+  }
+
   #content.metrics-page .metrics-cards {
     display: flex;
     flex-wrap: wrap;
@@ -26,5 +36,108 @@
     margin-block-start: var(--spacing-2, 0.5rem);
     font-size: 2rem;
     font-weight: 600;
+  }
+
+  #content.metrics-page .metrics-charts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-3, 1rem);
+    margin-block-start: var(--spacing-3, 1rem);
+  }
+
+  #content.metrics-page .metrics-snapshot {
+    flex: 1 1 20rem;
+    padding: var(--spacing-3, 1rem);
+    border: var(--border, 1px solid);
+    border-color: var(--border-color, #ccc);
+    border-radius: var(--border-radius-2, 0.5rem);
+    background: var(--background-2, transparent);
+  }
+
+  #content.metrics-page .snapshot-body {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-4, 1.5rem);
+    margin-block-start: var(--spacing-2, 0.5rem);
+  }
+
+  #content.metrics-page .metrics-donut {
+    inline-size: 9rem;
+    block-size: 9rem;
+    flex: none;
+  }
+
+  #content.metrics-page .donut-track {
+    fill: none;
+    stroke: var(--background-3, #e5e7eb);
+    stroke-width: 4;
+  }
+
+  #content.metrics-page .donut-seg {
+    fill: none;
+    stroke-width: 4;
+    stroke-linecap: butt;
+    transition: stroke-dasharray 0.4s ease;
+  }
+
+  #content.metrics-page .donut-running {
+    stroke: var(--color-primary, #3b82f6);
+  }
+
+  #content.metrics-page .donut-completed {
+    stroke: var(--color-success, #16a34a);
+  }
+
+  #content.metrics-page .donut-center {
+    fill: var(--color-text, currentColor);
+    font-size: 0.55rem;
+    font-weight: 600;
+    text-anchor: middle;
+    dominant-baseline: central;
+  }
+
+  #content.metrics-page .snapshot-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--spacing-2, 0.5rem);
+  }
+
+  #content.metrics-page .snapshot-legend li a {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2, 0.5rem);
+    padding: var(--spacing-1, 0.25rem) var(--spacing-2, 0.5rem);
+    border-radius: var(--border-radius-1, 0.25rem);
+    color: inherit;
+    text-decoration: none;
+  }
+
+  #content.metrics-page .snapshot-legend li a:hover,
+  #content.metrics-page .snapshot-legend li a:focus-visible {
+    background: var(--background-3, #f0f0f0);
+    text-decoration: underline;
+  }
+
+  #content.metrics-page .snapshot-legend b {
+    margin-inline-start: auto;
+    font-variant-numeric: tabular-nums;
+  }
+
+  #content.metrics-page .snapshot-legend .dot {
+    inline-size: 0.75rem;
+    block-size: 0.75rem;
+    border-radius: 50%;
+    flex: none;
+  }
+
+  #content.metrics-page .snapshot-legend .dot-running {
+    background: var(--color-primary, #3b82f6);
+  }
+
+  #content.metrics-page .snapshot-legend .dot-completed {
+    background: var(--color-success, #16a34a);
   }
 }

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -38,6 +38,76 @@
     font-weight: 600;
   }
 
+  #content.metrics-page .metrics-timeseries {
+    margin-block-start: var(--spacing-3, 1rem);
+  }
+
+  #content.metrics-page .metrics-timeseries article {
+    padding: var(--spacing-3, 1rem);
+    border: var(--border, 1px solid);
+    border-color: var(--border-color, #ccc);
+    border-radius: var(--border-radius-2, 0.5rem);
+    background: var(--background-2, transparent);
+  }
+
+  #content.metrics-page .activity-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    block-size: 8rem;
+    margin-block-start: var(--spacing-2, 0.5rem);
+  }
+
+  #content.metrics-page .activity-col {
+    position: relative;
+    flex: 1 1 0;
+    min-inline-size: 0;
+    display: flex;
+    align-items: flex-end;
+    block-size: 100%;
+  }
+
+  #content.metrics-page .activity-tip {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-start: 50%;
+    transform: translateX(-50%);
+    padding: 0.1rem 0.4rem;
+    background: var(--background-1, #fff);
+    border: var(--border, 1px solid);
+    border-color: var(--border-color, #ccc);
+    border-radius: var(--border-radius-1, 0.25rem);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.1s ease;
+    z-index: 2;
+  }
+
+  #content.metrics-page .activity-col:hover .activity-tip,
+  #content.metrics-page .activity-col:focus-within .activity-tip {
+    opacity: 1;
+  }
+
+  #content.metrics-page .activity-bar {
+    inline-size: 100%;
+    min-block-size: 1px;
+    background: var(--color-primary, #3b82f6);
+    border-radius: var(--border-radius-1, 0.25rem) var(--border-radius-1, 0.25rem) 0 0;
+    transition: block-size 0.4s ease;
+  }
+
+  #content.metrics-page .activity-axis {
+    display: flex;
+    justify-content: space-between;
+    margin-block-start: var(--spacing-1, 0.25rem);
+    font-size: 0.85em;
+    color: var(--color-text-secondary, #888);
+    font-variant-numeric: tabular-nums;
+  }
+
   #content.metrics-page .metrics-charts {
     display: flex;
     flex-wrap: wrap;

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -38,16 +38,41 @@
     font-weight: 600;
   }
 
-  #content.metrics-page .metrics-timeseries {
+  /* Staggered bento on a 5-column grid: row 1 is 3/2 (chart | processes),
+     row 2 is 2/3 (snapshot | tasks). Default stretch keeps paired boxes equal
+     height per row. */
+  #content.metrics-page .metrics-bento {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: var(--spacing-3, 1rem);
     margin-block-start: var(--spacing-3, 1rem);
   }
 
-  #content.metrics-page .metrics-timeseries article {
+  #content.metrics-page .metrics-bento > article {
+    min-inline-size: 0;
     padding: var(--spacing-3, 1rem);
     border: var(--border, 1px solid);
     border-color: var(--border-color, #ccc);
     border-radius: var(--border-radius-2, 0.5rem);
     background: var(--background-2, transparent);
+  }
+
+  #content.metrics-page .bento-2 {
+    grid-column: span 2;
+  }
+
+  #content.metrics-page .bento-3 {
+    grid-column: span 3;
+  }
+
+  @media (max-width: 760px) {
+    #content.metrics-page .metrics-bento {
+      grid-template-columns: 1fr;
+    }
+    #content.metrics-page .bento-2,
+    #content.metrics-page .bento-3 {
+      grid-column: 1 / -1;
+    }
   }
 
   #content.metrics-page .activity-chart {
@@ -106,31 +131,6 @@
     font-size: 0.85em;
     color: var(--color-text-secondary, #888);
     font-variant-numeric: tabular-nums;
-  }
-
-  #content.metrics-page .metrics-charts {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-3, 1rem);
-    margin-block-start: var(--spacing-3, 1rem);
-  }
-
-  #content.metrics-page .metrics-snapshot {
-    flex: 1 1 18rem;
-    padding: var(--spacing-3, 1rem);
-    border: var(--border, 1px solid);
-    border-color: var(--border-color, #ccc);
-    border-radius: var(--border-radius-2, 0.5rem);
-    background: var(--background-2, transparent);
-  }
-
-  #content.metrics-page .metrics-ranking {
-    flex: 2 1 24rem;
-    padding: var(--spacing-3, 1rem);
-    border: var(--border, 1px solid);
-    border-color: var(--border-color, #ccc);
-    border-radius: var(--border-radius-2, 0.5rem);
-    background: var(--background-2, transparent);
   }
 
   #content.metrics-page .ranking {

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -46,12 +46,108 @@
   }
 
   #content.metrics-page .metrics-snapshot {
-    flex: 1 1 20rem;
+    flex: 1 1 18rem;
     padding: var(--spacing-3, 1rem);
     border: var(--border, 1px solid);
     border-color: var(--border-color, #ccc);
     border-radius: var(--border-radius-2, 0.5rem);
     background: var(--background-2, transparent);
+  }
+
+  #content.metrics-page .metrics-ranking {
+    flex: 2 1 24rem;
+    padding: var(--spacing-3, 1rem);
+    border: var(--border, 1px solid);
+    border-color: var(--border-color, #ccc);
+    border-radius: var(--border-radius-2, 0.5rem);
+    background: var(--background-2, transparent);
+  }
+
+  #content.metrics-page .ranking {
+    list-style: none;
+    margin: var(--spacing-2, 0.5rem) 0 0;
+    padding: 0;
+    display: grid;
+    gap: var(--spacing-1, 0.25rem);
+    counter-reset: rank;
+  }
+
+  #content.metrics-page .ranking li a {
+    display: grid;
+    /* Fixed rank + meta columns so 4-digit counts like "8888 (8888)" never shift
+       the bar column; the name (ellipsis) and bar share the remaining space. */
+    grid-template-columns: 1.5rem minmax(5rem, 1fr) 2fr 7rem;
+    align-items: center;
+    gap: var(--spacing-2, 0.5rem);
+    padding: var(--spacing-1, 0.25rem) var(--spacing-2, 0.5rem);
+    border-radius: var(--border-radius-1, 0.25rem);
+    color: inherit;
+    text-decoration: none;
+  }
+
+  #content.metrics-page .ranking li a:hover,
+  #content.metrics-page .ranking li a:focus-visible {
+    background: var(--background-3, #f0f0f0);
+  }
+
+  #content.metrics-page .ranking li a::before {
+    counter-increment: rank;
+    content: counter(rank);
+    color: var(--color-text-secondary, #888);
+    font-variant-numeric: tabular-nums;
+    text-align: end;
+  }
+
+  #content.metrics-page .ranking-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  #content.metrics-page .ranking-bar-track {
+    block-size: 0.6rem;
+    background: var(--background-3, #eee);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+
+  #content.metrics-page .ranking-bar {
+    position: relative;
+    display: block;
+    block-size: 100%;
+    background: var(--color-primary, #3b82f6);
+    border-radius: 999px;
+    overflow: hidden;
+    transition: inline-size 0.4s ease;
+  }
+
+  /* Red share of the bar, proportional to incidents / running instances. Sits at
+     the start and is clipped to the bar's rounded shape. */
+  #content.metrics-page .ranking-bar-incidents {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    background: var(--color-danger, #dc2626);
+    transition: inline-size 0.4s ease;
+  }
+
+  #content.metrics-page .ranking-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: var(--spacing-1, 0.25rem);
+    white-space: nowrap;
+  }
+
+  #content.metrics-page .ranking-count {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+
+  #content.metrics-page .ranking-incidents {
+    color: var(--color-danger, #dc2626);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
   }
 
   #content.metrics-page .snapshot-body {

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -9,33 +9,68 @@
   /* `main` carries no padding of its own; give the page the same breathing room
      the other pages get (Home uses `p-3`), so content isn't flush to the edges. */
   #content.metrics-page {
-    padding: var(--spacing-4, 1.5rem);
+    padding: var(--spacing-3, 1rem);
   }
 
   #content.metrics-page h1 {
-    margin-block: 0 var(--spacing-3, 1rem);
+    margin-block: 0 var(--spacing-2, 0.5rem);
+    font-size: 1.4rem;
   }
 
   #content.metrics-page .metrics-cards {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-3, 1rem);
-    margin-block-start: var(--spacing-3, 1rem);
+    gap: var(--spacing-2, 0.5rem);
+    margin-block-start: 0;
   }
 
   #content.metrics-page .metrics-cards article {
-    flex: 1 1 12rem;
-    padding: var(--spacing-3, 1rem);
+    flex: 1 1 8rem;
+    padding: var(--spacing-2, 0.5rem) var(--spacing-3, 1rem);
     border: var(--border, 1px solid);
     border-color: var(--border-color, #ccc);
     border-radius: var(--border-radius-2, 0.5rem);
     background: var(--background-2, transparent);
   }
 
-  #content.metrics-page .metric-value {
-    margin-block-start: var(--spacing-2, 0.5rem);
-    font-size: 2rem;
+  #content.metrics-page .metrics-cards h2 {
+    margin: 0;
+    font-size: 0.75rem;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--color-text-secondary, #888);
+  }
+
+  #content.metrics-page .metric-value {
+    margin-block-start: var(--spacing-1, 0.25rem);
+    font-size: 1.4rem;
+    font-weight: 600;
+  }
+
+  #content.metrics-page .metric-status {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2, 0.5rem);
+  }
+
+  #content.metrics-page .status-dot {
+    inline-size: 0.75rem;
+    block-size: 0.75rem;
+    border-radius: 50%;
+    flex: none;
+  }
+
+  #content.metrics-page .status-ok .status-dot {
+    background: var(--color-success, #16a34a);
+  }
+
+  #content.metrics-page .status-bad {
+    color: var(--color-danger, #dc2626);
+  }
+
+  #content.metrics-page .status-bad .status-dot {
+    background: var(--color-danger, #dc2626);
   }
 
   /* Staggered bento on a 5-column grid: row 1 is 3/2 (chart | processes),
@@ -44,17 +79,22 @@
   #content.metrics-page .metrics-bento {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
-    gap: var(--spacing-3, 1rem);
-    margin-block-start: var(--spacing-3, 1rem);
+    gap: var(--spacing-2, 0.5rem);
+    margin-block-start: var(--spacing-2, 0.5rem);
   }
 
   #content.metrics-page .metrics-bento > article {
     min-inline-size: 0;
-    padding: var(--spacing-3, 1rem);
+    padding: var(--spacing-2, 0.5rem) var(--spacing-3, 1rem);
     border: var(--border, 1px solid);
     border-color: var(--border-color, #ccc);
     border-radius: var(--border-radius-2, 0.5rem);
     background: var(--background-2, transparent);
+  }
+
+  #content.metrics-page .metrics-bento h2 {
+    margin: 0 0 var(--spacing-1, 0.25rem);
+    font-size: 0.95rem;
   }
 
   #content.metrics-page .bento-2 {
@@ -79,7 +119,7 @@
     display: flex;
     align-items: flex-end;
     gap: 2px;
-    block-size: 8rem;
+    block-size: 6rem;
     margin-block-start: var(--spacing-2, 0.5rem);
   }
 
@@ -234,8 +274,8 @@
   }
 
   #content.metrics-page .metrics-donut {
-    inline-size: 9rem;
-    block-size: 9rem;
+    inline-size: 6.5rem;
+    block-size: 6.5rem;
     flex: none;
   }
 

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/metrics.css
@@ -300,9 +300,10 @@
     stroke: var(--color-success, #16a34a);
   }
 
+  /* No font-size here: it is set per render from the digit count, and a
+     stylesheet rule would override the attribute. */
   #content.metrics-page .donut-center {
     fill: var(--color-text, currentColor);
-    font-size: 0.55rem;
     font-weight: 600;
     text-anchor: middle;
     dominant-baseline: central;

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -344,8 +344,8 @@ const MetricsPage = () => {
           <MetricValue signal={signals.flow_nodes} format={(d) => d.result} />
         </article>
       </section>
-      <section class="metrics-timeseries">
-        <article>
+      <section class="metrics-bento">
+        <article class="bento-3">
           <h2>{t("plugins.metrics.activity")}</h2>
           <RequestState
             signal={signals.activity_series}
@@ -354,9 +354,14 @@ const MetricsPage = () => {
             )}
           />
         </article>
-      </section>
-      <section class="metrics-charts">
-        <article class="metrics-snapshot">
+        <article class="metrics-ranking bento-2">
+          <h2>{t("plugins.metrics.top-processes")}</h2>
+          <RequestState
+            signal={signals.definition_stats}
+            on_success={() => <TopProcesses stats={signals.definition_stats.value.data} />}
+          />
+        </article>
+        <article class="metrics-snapshot bento-2">
           <h2>{t("plugins.metrics.snapshot")}</h2>
           <RequestState
             signal={[signals.running, signals.completed]}
@@ -387,14 +392,7 @@ const MetricsPage = () => {
             }}
           />
         </article>
-        <article class="metrics-ranking">
-          <h2>{t("plugins.metrics.top-processes")}</h2>
-          <RequestState
-            signal={signals.definition_stats}
-            on_success={() => <TopProcesses stats={signals.definition_stats.value.data} />}
-          />
-        </article>
-        <article class="metrics-ranking">
+        <article class="metrics-ranking bento-3">
           <h2>{t("plugins.metrics.top-tasks")}</h2>
           <RequestState
             signal={signals.top_tasks}

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -58,6 +58,13 @@ const api = {
       state,
       state.api.plugins[PLUGIN_ID].completed,
     ),
+  // Per-definition runtime counts (+ incidents) for the "top processes" ranking.
+  definition_stats: (state) =>
+    GET(
+      "/process-definition/statistics?incidents=true",
+      state,
+      state.api.plugins[PLUGIN_ID].definition_stats,
+    ),
 };
 
 // State branch — mounted at state.api.plugins.metrics.
@@ -67,6 +74,7 @@ const make_signals = () => ({
   flow_nodes: signal(null),
   running: signal(null),
   completed: signal(null),
+  definition_stats: signal(null),
 });
 
 const MetricValue = ({ signal: signl, format = (v) => v }) => (
@@ -110,6 +118,80 @@ const Donut = ({ running, completed }) => {
   );
 };
 
+// Collapse the per-definition statistics (one row per version) into one row per
+// process key: sum running instances and incidents across versions, and keep the
+// newest version's id as the link target.
+const top_processes = (stats, limit = 5) => {
+  const by_key = {};
+  for (const row of stats) {
+    const def = row.definition;
+    const entry = (by_key[def.key] ??= {
+      key: def.key,
+      name: def.name || def.key,
+      instances: 0,
+      incidents: 0,
+      version: -1,
+      definition_id: def.id,
+    });
+    entry.instances += row.instances;
+    entry.incidents += (row.incidents ?? []).reduce(
+      (sum, i) => sum + i.incidentCount,
+      0,
+    );
+    if (def.version > entry.version) {
+      entry.version = def.version;
+      entry.definition_id = def.id;
+    }
+  }
+  return Object.values(by_key)
+    .filter((e) => e.instances > 0)
+    .sort((a, b) => b.instances - a.instances)
+    .slice(0, limit);
+};
+
+const TopProcesses = ({ stats }) => {
+  const [t] = useTranslation();
+  const rows = top_processes(stats);
+  if (rows.length === 0) {
+    return <p class="fade-in">{t("plugins.metrics.no-running")}</p>;
+  }
+  const max = rows[0].instances;
+  return (
+    <ol class="ranking">
+      {rows.map((r) => (
+        <li key={r.key}>
+          <a href={`/processes/${r.definition_id}`}>
+            <span class="ranking-name" title={r.name}>
+              {r.name}
+            </span>
+            <span class="ranking-bar-track">
+              <span
+                class="ranking-bar"
+                style={{ inlineSize: `${(r.instances / max) * 100}%` }}
+              >
+                {r.incidents > 0 && (
+                  <span
+                    class="ranking-bar-incidents"
+                    style={{
+                      inlineSize: `${Math.min(r.incidents / r.instances, 1) * 100}%`,
+                    }}
+                  />
+                )}
+              </span>
+            </span>
+            <span class="ranking-meta">
+              <span class="ranking-count">{r.instances}</span>
+              {r.incidents > 0 && (
+                <span class="ranking-incidents">({r.incidents})</span>
+              )}
+            </span>
+          </a>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
 const MetricsPage = () => {
   const { state, api: metrics, signals } = use_plugin_api(PLUGIN_ID);
   const [t] = useTranslation();
@@ -120,6 +202,7 @@ const MetricsPage = () => {
     metrics.flow_nodes(state);
     metrics.running(state);
     metrics.completed(state);
+    metrics.definition_stats(state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -175,6 +258,13 @@ const MetricsPage = () => {
             }}
           />
         </article>
+        <article class="metrics-ranking">
+          <h2>{t("plugins.metrics.top-processes")}</h2>
+          <RequestState
+            signal={signals.definition_stats}
+            on_success={() => <TopProcesses stats={signals.definition_stats.value.data} />}
+          />
+        </article>
       </section>
     </main>
   );
@@ -192,6 +282,8 @@ const translations = {
         snapshot: "Process instances: running vs. completed",
         running: "Running",
         completed: "Completed",
+        "top-processes": "Top processes by running instances",
+        "no-running": "No running instances.",
       },
     },
   },
@@ -206,6 +298,8 @@ const translations = {
         snapshot: "Prozessinstanzen: laufend vs. abgeschlossen",
         running: "Laufend",
         completed: "Abgeschlossen",
+        "top-processes": "Top-Prozesse nach laufenden Instanzen",
+        "no-running": "Keine laufenden Instanzen.",
       },
     },
   },

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -29,6 +29,15 @@ const months_ago_param = (n) => {
   return encodeURIComponent(date.toISOString().replace("Z", "+0000"));
 };
 
+// Start-of-day (UTC) N days ago, encoded like months_ago_param. Midnight so the
+// interval buckets line up with calendar days.
+const days_ago_midnight_param = (n) => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - n);
+  date.setUTCHours(0, 0, 0, 0);
+  return encodeURIComponent(date.toISOString().replace("Z", "+0000"));
+};
+
 // API namespace — mounted at engine_rest.plugins.metrics. Each function follows
 // the host convention (state, ...args) => VERB(url, state, signal), so auth,
 // error shapes and RESPONSE_STATE all come for free from helper.jsx.
@@ -58,6 +67,13 @@ const api = {
       state,
       state.api.plugins[PLUGIN_ID].completed,
     ),
+  // Daily activity time series (last 30 days) for the activity chart.
+  activity_series: (state) =>
+    GET(
+      `/metrics?name=activity-instance-start&startDate=${days_ago_midnight_param(29)}&interval=86400`,
+      state,
+      state.api.plugins[PLUGIN_ID].activity_series,
+    ),
   // Per-definition runtime counts (+ incidents) for the "top processes" ranking.
   definition_stats: (state) =>
     GET(
@@ -74,6 +90,7 @@ const make_signals = () => ({
   flow_nodes: signal(null),
   running: signal(null),
   completed: signal(null),
+  activity_series: signal(null),
   definition_stats: signal(null),
 });
 
@@ -115,6 +132,59 @@ const Donut = ({ running, completed }) => {
         {total}
       </text>
     </svg>
+  );
+};
+
+// Turn the sparse metric buckets (only days with activity are returned) into a
+// gap-free daily series of the last `days`, missing days filled with 0.
+const build_activity_series = (buckets, days = 30) => {
+  const by_day = {};
+  for (const b of buckets) by_day[b.timestamp.slice(0, 10)] = b.value;
+  const series = [];
+  const day = new Date();
+  day.setUTCHours(0, 0, 0, 0);
+  day.setUTCDate(day.getUTCDate() - (days - 1));
+  for (let i = 0; i < days; i++) {
+    const key = day.toISOString().slice(0, 10);
+    series.push({ key, value: by_day[key] ?? 0 });
+    day.setUTCDate(day.getUTCDate() + 1);
+  }
+  return series;
+};
+
+// "2026-08-26" -> "26.08."
+const short_day = (key) => `${key.slice(8, 10)}.${key.slice(5, 7)}.`;
+
+const ActivityChart = ({ buckets }) => {
+  const [t] = useTranslation();
+  const series = build_activity_series(buckets);
+  const max = Math.max(1, ...series.map((p) => p.value));
+  const total = series.reduce((sum, p) => sum + p.value, 0);
+  if (total === 0) {
+    return <p class="fade-in">{t("plugins.metrics.no-activity")}</p>;
+  }
+  return (
+    <>
+      <div
+        class="activity-chart"
+        role="img"
+        aria-label={t("plugins.metrics.activity")}
+      >
+        {series.map((p) => (
+          <div class="activity-col" key={p.key}>
+            <span class="activity-tip">{`${short_day(p.key)} ${p.value}`}</span>
+            <div
+              class="activity-bar"
+              style={{ blockSize: `${(p.value / max) * 100}%` }}
+            />
+          </div>
+        ))}
+      </div>
+      <div class="activity-axis">
+        <span>{short_day(series[0].key)}</span>
+        <span>{short_day(series[series.length - 1].key)}</span>
+      </div>
+    </>
   );
 };
 
@@ -202,6 +272,7 @@ const MetricsPage = () => {
     metrics.flow_nodes(state);
     metrics.running(state);
     metrics.completed(state);
+    metrics.activity_series(state);
     metrics.definition_stats(state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -224,6 +295,17 @@ const MetricsPage = () => {
         <article>
           <h2>{t("plugins.metrics.flow-nodes")}</h2>
           <MetricValue signal={signals.flow_nodes} format={(d) => d.result} />
+        </article>
+      </section>
+      <section class="metrics-timeseries">
+        <article>
+          <h2>{t("plugins.metrics.activity")}</h2>
+          <RequestState
+            signal={signals.activity_series}
+            on_success={() => (
+              <ActivityChart buckets={signals.activity_series.value.data} />
+            )}
+          />
         </article>
       </section>
       <section class="metrics-charts">
@@ -282,6 +364,8 @@ const translations = {
         snapshot: "Process instances: running vs. completed",
         running: "Running",
         completed: "Completed",
+        activity: "Activity (last 30 days)",
+        "no-activity": "No activity in the last 30 days.",
         "top-processes": "Top processes by running instances",
         "no-running": "No running instances.",
       },
@@ -298,6 +382,8 @@ const translations = {
         snapshot: "Prozessinstanzen: laufend vs. abgeschlossen",
         running: "Laufend",
         completed: "Abgeschlossen",
+        activity: "Aktivitätsverlauf (letzte 30 Tage)",
+        "no-activity": "Keine Aktivität in den letzten 30 Tagen.",
         "top-processes": "Top-Prozesse nach laufenden Instanzen",
         "no-running": "Keine laufenden Instanzen.",
       },

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -47,6 +47,17 @@ const api = {
       state,
       state.api.plugins[PLUGIN_ID].flow_nodes,
     ),
+  // Snapshot for the "running vs. completed" donut. Running comes from the
+  // runtime (currently active), completed from history (`finished` = no longer
+  // running, i.e. completed or terminated).
+  running: (state) =>
+    GET("/process-instance/count", state, state.api.plugins[PLUGIN_ID].running),
+  completed: (state) =>
+    GET(
+      "/history/process-instance/count?finished=true",
+      state,
+      state.api.plugins[PLUGIN_ID].completed,
+    ),
 };
 
 // State branch — mounted at state.api.plugins.metrics.
@@ -54,6 +65,8 @@ const make_signals = () => ({
   version: signal(null),
   process_starts: signal(null),
   flow_nodes: signal(null),
+  running: signal(null),
+  completed: signal(null),
 });
 
 const MetricValue = ({ signal: signl, format = (v) => v }) => (
@@ -63,6 +76,40 @@ const MetricValue = ({ signal: signl, format = (v) => v }) => (
   />
 );
 
+// Two-segment SVG donut. The circle's circumference is normalised to 100
+// (r = 100 / 2π) so dash lengths are read straight as percentages. Segments are
+// laid clockwise from 12 o'clock: `completed` first (offset 25), then `running`
+// starting where it ends (offset 25 − completed%).
+const Donut = ({ running, completed }) => {
+  const total = running + completed;
+  const completed_pct = total ? (completed / total) * 100 : 0;
+  const running_pct = total ? (running / total) * 100 : 0;
+  return (
+    <svg class="metrics-donut" viewBox="0 0 42 42" aria-hidden="true">
+      <circle class="donut-track" cx="21" cy="21" r="15.91549" />
+      <circle
+        class="donut-seg donut-completed"
+        cx="21"
+        cy="21"
+        r="15.91549"
+        stroke-dasharray={`${completed_pct} ${100 - completed_pct}`}
+        stroke-dashoffset="25"
+      />
+      <circle
+        class="donut-seg donut-running"
+        cx="21"
+        cy="21"
+        r="15.91549"
+        stroke-dasharray={`${running_pct} ${100 - running_pct}`}
+        stroke-dashoffset={`${25 - completed_pct}`}
+      />
+      <text class="donut-center" x="21" y="21">
+        {total}
+      </text>
+    </svg>
+  );
+};
+
 const MetricsPage = () => {
   const { state, api: metrics, signals } = use_plugin_api(PLUGIN_ID);
   const [t] = useTranslation();
@@ -71,6 +118,8 @@ const MetricsPage = () => {
     metrics.version(state);
     metrics.process_starts(state);
     metrics.flow_nodes(state);
+    metrics.running(state);
+    metrics.completed(state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -94,6 +143,39 @@ const MetricsPage = () => {
           <MetricValue signal={signals.flow_nodes} format={(d) => d.result} />
         </article>
       </section>
+      <section class="metrics-charts">
+        <article class="metrics-snapshot">
+          <h2>{t("plugins.metrics.snapshot")}</h2>
+          <RequestState
+            signal={[signals.running, signals.completed]}
+            on_success={() => {
+              const running = signals.running.value.data.count;
+              const completed = signals.completed.value.data.count;
+              return (
+                <div class="snapshot-body">
+                  <Donut running={running} completed={completed} />
+                  <ul class="snapshot-legend">
+                    <li>
+                      <a href="/processes">
+                        <span class="dot dot-running" />
+                        {t("plugins.metrics.running")}
+                        <b>{running}</b>
+                      </a>
+                    </li>
+                    <li>
+                      <a href="/processes?history=true">
+                        <span class="dot dot-completed" />
+                        {t("plugins.metrics.completed")}
+                        <b>{completed}</b>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              );
+            }}
+          />
+        </article>
+      </section>
     </main>
   );
 };
@@ -107,6 +189,9 @@ const translations = {
         version: "Engine version",
         "process-starts": "Process starts (12 mo)",
         "flow-nodes": "Flow nodes executed (12 mo)",
+        snapshot: "Process instances: running vs. completed",
+        running: "Running",
+        completed: "Completed",
       },
     },
   },
@@ -118,6 +203,9 @@ const translations = {
         version: "Engine-Version",
         "process-starts": "Prozessstarts (12 Mon.)",
         "flow-nodes": "Ausgeführte Flow-Knoten (12 Mon.)",
+        snapshot: "Prozessinstanzen: laufend vs. abgeschlossen",
+        running: "Laufend",
+        completed: "Abgeschlossen",
       },
     },
   },

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -67,10 +67,11 @@ const api = {
       state,
       state.api.plugins[PLUGIN_ID].completed,
     ),
-  // Daily activity time series (last 30 days) for the activity chart.
+  // Daily process-start time series (last 30 days) for the chart. Uses
+  // root-process-instance-start so only top-level starts count, not call activities.
   activity_series: (state) =>
     GET(
-      `/metrics?name=activity-instance-start&startDate=${days_ago_midnight_param(29)}&interval=86400`,
+      `/metrics?name=root-process-instance-start&startDate=${days_ago_midnight_param(29)}&interval=86400`,
       state,
       state.api.plugins[PLUGIN_ID].activity_series,
     ),
@@ -364,8 +365,8 @@ const translations = {
         snapshot: "Process instances: running vs. completed",
         running: "Running",
         completed: "Completed",
-        activity: "Activity (last 30 days)",
-        "no-activity": "No activity in the last 30 days.",
+        activity: "Process starts per day (last 30 days)",
+        "no-activity": "No process starts in the last 30 days.",
         "top-processes": "Top processes by running instances",
         "no-running": "No running instances.",
       },
@@ -382,8 +383,8 @@ const translations = {
         snapshot: "Prozessinstanzen: laufend vs. abgeschlossen",
         running: "Laufend",
         completed: "Abgeschlossen",
-        activity: "Aktivitätsverlauf (letzte 30 Tage)",
-        "no-activity": "Keine Aktivität in den letzten 30 Tagen.",
+        activity: "Prozessstarts pro Tag (letzte 30 Tage)",
+        "no-activity": "Keine Prozessstarts in den letzten 30 Tagen.",
         "top-processes": "Top-Prozesse nach laufenden Instanzen",
         "no-running": "Keine laufenden Instanzen.",
       },

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -82,6 +82,13 @@ const api = {
       state,
       state.api.plugins[PLUGIN_ID].definition_stats,
     ),
+  // Completed (historic) user-task counts by task name for the "top tasks" ranking.
+  top_tasks: (state) =>
+    GET(
+      "/history/task/report?reportType=count&groupBy=taskName",
+      state,
+      state.api.plugins[PLUGIN_ID].top_tasks,
+    ),
 };
 
 // State branch — mounted at state.api.plugins.metrics.
@@ -93,6 +100,7 @@ const make_signals = () => ({
   completed: signal(null),
   activity_series: signal(null),
   definition_stats: signal(null),
+  top_tasks: signal(null),
 });
 
 const MetricValue = ({ signal: signl, format = (v) => v }) => (
@@ -251,10 +259,47 @@ const TopProcesses = ({ stats }) => {
               </span>
             </span>
             <span class="ranking-meta">
-              <span class="ranking-count">{r.instances}</span>
               {r.incidents > 0 && (
                 <span class="ranking-incidents">({r.incidents})</span>
               )}
+              <span class="ranking-count">{r.instances}</span>
+            </span>
+          </a>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+// Top completed user tasks by volume. Rows come pre-grouped per task name (per
+// definition); we just sort and take the leaders. Reuses the `.ranking` styles.
+const TopTasks = ({ rows }) => {
+  const [t] = useTranslation();
+  const top = [...rows].sort((a, b) => b.count - a.count).slice(0, 5);
+  if (top.length === 0) {
+    return <p class="fade-in">{t("plugins.metrics.no-tasks")}</p>;
+  }
+  const max = top[0].count;
+  return (
+    <ol class="ranking">
+      {top.map((r) => (
+        <li key={`${r.taskName}@${r.processDefinitionId}`}>
+          <a href={`/processes/${r.processDefinitionId}`}>
+            <span
+              class="ranking-name"
+              title={`${r.taskName} · ${r.processDefinitionName}`}
+            >
+              {r.taskName}
+              <span class="ranking-sub"> · {r.processDefinitionName}</span>
+            </span>
+            <span class="ranking-bar-track">
+              <span
+                class="ranking-bar"
+                style={{ inlineSize: `${(r.count / max) * 100}%` }}
+              />
+            </span>
+            <span class="ranking-meta">
+              <span class="ranking-count">{r.count}</span>
             </span>
           </a>
         </li>
@@ -275,6 +320,7 @@ const MetricsPage = () => {
     metrics.completed(state);
     metrics.activity_series(state);
     metrics.definition_stats(state);
+    metrics.top_tasks(state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -348,6 +394,13 @@ const MetricsPage = () => {
             on_success={() => <TopProcesses stats={signals.definition_stats.value.data} />}
           />
         </article>
+        <article class="metrics-ranking">
+          <h2>{t("plugins.metrics.top-tasks")}</h2>
+          <RequestState
+            signal={signals.top_tasks}
+            on_success={() => <TopTasks rows={signals.top_tasks.value.data} />}
+          />
+        </article>
       </section>
     </main>
   );
@@ -369,6 +422,8 @@ const translations = {
         "no-activity": "No process starts in the last 30 days.",
         "top-processes": "Top processes by running instances",
         "no-running": "No running instances.",
+        "top-tasks": "Top user tasks by volume",
+        "no-tasks": "No completed user tasks.",
       },
     },
   },
@@ -387,6 +442,8 @@ const translations = {
         "no-activity": "Keine Prozessstarts in den letzten 30 Tagen.",
         "top-processes": "Top-Prozesse nach laufenden Instanzen",
         "no-running": "Keine laufenden Instanzen.",
+        "top-tasks": "Top-User-Tasks nach Aufkommen",
+        "no-tasks": "Keine abgeschlossenen User-Tasks.",
       },
     },
   },

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -82,6 +82,13 @@ const api = {
       state,
       state.api.plugins[PLUGIN_ID].definition_stats,
     ),
+  // Count of jobs whose last execution threw — a health signal for the tile.
+  failed_jobs: (state) =>
+    GET(
+      "/job/count?withException=true",
+      state,
+      state.api.plugins[PLUGIN_ID].failed_jobs,
+    ),
   // Completed (historic) user-task counts by task name for the "top tasks" ranking.
   top_tasks: (state) =>
     GET(
@@ -100,6 +107,7 @@ const make_signals = () => ({
   completed: signal(null),
   activity_series: signal(null),
   definition_stats: signal(null),
+  failed_jobs: signal(null),
   top_tasks: signal(null),
 });
 
@@ -320,6 +328,7 @@ const MetricsPage = () => {
     metrics.completed(state);
     metrics.activity_series(state);
     metrics.definition_stats(state);
+    metrics.failed_jobs(state);
     metrics.top_tasks(state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -342,6 +351,23 @@ const MetricsPage = () => {
         <article>
           <h2>{t("plugins.metrics.flow-nodes")}</h2>
           <MetricValue signal={signals.flow_nodes} format={(d) => d.result} />
+        </article>
+        <article>
+          <h2>{t("plugins.metrics.failed-jobs")}</h2>
+          <RequestState
+            signal={signals.failed_jobs}
+            on_success={() => {
+              const count = signals.failed_jobs.value.data.count;
+              return (
+                <p
+                  class={`metric-value metric-status ${count > 0 ? "status-bad" : "status-ok"}`}
+                >
+                  <span class="status-dot" />
+                  {count}
+                </p>
+              );
+            }}
+          />
         </article>
       </section>
       <section class="metrics-bento">
@@ -413,6 +439,7 @@ const translations = {
         version: "Engine version",
         "process-starts": "Process starts (12 mo)",
         "flow-nodes": "Flow nodes executed (12 mo)",
+        "failed-jobs": "Failed jobs",
         snapshot: "Process instances: running vs. completed",
         running: "Running",
         completed: "Completed",
@@ -433,6 +460,7 @@ const translations = {
         version: "Engine-Version",
         "process-starts": "Prozessstarts (12 Mon.)",
         "flow-nodes": "Ausgeführte Flow-Knoten (12 Mon.)",
+        "failed-jobs": "Fehlgeschlagene Jobs",
         snapshot: "Prozessinstanzen: laufend vs. abgeschlossen",
         running: "Laufend",
         completed: "Abgeschlossen",

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.jsx
@@ -122,6 +122,14 @@ const MetricValue = ({ signal: signl, format = (v) => v }) => (
 // (r = 100 / 2π) so dash lengths are read straight as percentages. Segments are
 // laid clockwise from 12 o'clock: `completed` first (offset 25), then `running`
 // starting where it ends (offset 25 − completed%).
+// The hole is ~28 user units across (r 15.92 less half of the 4-unit ring).
+// Keep the label inside 22 of them so it never crowds the ring: at ~0.6 units
+// of advance per digit and em, that caps the size for short totals and shrinks
+// six-digit ones instead of letting them run into the stroke.
+const LABEL_WIDTH = 22;
+export const donut_font_size = (label) =>
+  Math.min(7, LABEL_WIDTH / (0.6 * String(label).length));
+
 const Donut = ({ running, completed }) => {
   const total = running + completed;
   const completed_pct = total ? (completed / total) * 100 : 0;
@@ -145,7 +153,12 @@ const Donut = ({ running, completed }) => {
         stroke-dasharray={`${running_pct} ${100 - running_pct}`}
         stroke-dashoffset={`${25 - completed_pct}`}
       />
-      <text class="donut-center" x="21" y="21">
+      <text
+        class="donut-center"
+        x="21"
+        y="21"
+        font-size={donut_font_size(total)}
+      >
         {total}
       </text>
     </svg>

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
@@ -59,6 +59,9 @@ describe("Engine Metrics plugin — page", () => {
     vi.spyOn(engine_rest.plugins.metrics, "top_tasks").mockImplementation(
       () => {},
     );
+    vi.spyOn(engine_rest.plugins.metrics, "failed_jobs").mockImplementation(
+      () => {},
+    );
     signal_response(state.api.plugins.metrics.version, { version: "7.99.0" });
 
     render_with_state(<MetricsPage />, { state });
@@ -81,6 +84,7 @@ describe("Engine Metrics plugin — page", () => {
       "definition_stats",
       "activity_series",
       "top_tasks",
+      "failed_jobs",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -106,6 +110,7 @@ describe("Engine Metrics plugin — page", () => {
       "definition_stats",
       "activity_series",
       "top_tasks",
+      "failed_jobs",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -150,6 +155,7 @@ describe("Engine Metrics plugin — page", () => {
       "definition_stats",
       "activity_series",
       "top_tasks",
+      "failed_jobs",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -184,6 +190,7 @@ describe("Engine Metrics plugin — page", () => {
       "definition_stats",
       "activity_series",
       "top_tasks",
+      "failed_jobs",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -216,5 +223,36 @@ describe("Engine Metrics plugin — page", () => {
     expect(names.indexOf("Final decision · Loan Approval")).toBeLessThan(
       names.indexOf("Approve Invoice · Invoice Receipt"),
     );
+  });
+
+  it("shows the failed-jobs tile green at 0 and red above 0", () => {
+    const mount = (count) => {
+      _reset_registry();
+      for (const key of Object.keys(plugin_apis)) delete plugin_apis[key];
+      register(page_descriptor);
+      const state = create_mock_state();
+      for (const fn of [
+        "version",
+        "process_starts",
+        "flow_nodes",
+        "running",
+        "completed",
+        "definition_stats",
+        "activity_series",
+        "top_tasks",
+        "failed_jobs",
+      ]) {
+        vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
+      }
+      signal_response(state.api.plugins.metrics.failed_jobs, { count });
+      return render_with_state(<MetricsPage />, { state });
+    };
+
+    const { container: ok } = mount(0);
+    expect(ok.querySelector(".metric-status.status-ok")).toBeTruthy();
+    expect(ok.querySelector(".metric-status.status-bad")).toBeFalsy();
+
+    const { container: bad } = mount(3);
+    expect(bad.querySelector(".metric-status.status-bad")).toBeTruthy();
   });
 });

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
@@ -42,6 +42,12 @@ describe("Engine Metrics plugin — page", () => {
     vi.spyOn(engine_rest.plugins.metrics, "flow_nodes").mockImplementation(
       () => {},
     );
+    vi.spyOn(engine_rest.plugins.metrics, "running").mockImplementation(
+      () => {},
+    );
+    vi.spyOn(engine_rest.plugins.metrics, "completed").mockImplementation(
+      () => {},
+    );
     signal_response(state.api.plugins.metrics.version, { version: "7.99.0" });
 
     render_with_state(<MetricsPage />, { state });
@@ -51,5 +57,27 @@ describe("Engine Metrics plugin — page", () => {
     expect(engine_rest.plugins.metrics.version).toHaveBeenCalled();
     expect(engine_rest.plugins.metrics.version.mock.lastCall[0]).toBe(state);
     expect(screen.getByText("7.99.0")).toBeTruthy();
+  });
+
+  it("renders the running-vs-completed donut with the total in its centre", () => {
+    const state = create_mock_state();
+    for (const fn of [
+      "version",
+      "process_starts",
+      "flow_nodes",
+      "running",
+      "completed",
+    ]) {
+      vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
+    }
+    signal_response(state.api.plugins.metrics.running, { count: 3 });
+    signal_response(state.api.plugins.metrics.completed, { count: 7 });
+
+    render_with_state(<MetricsPage />, { state });
+
+    // Legend shows both counts; donut centre shows the total (3 + 7 = 10).
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+    expect(screen.getByText("10")).toBeTruthy();
   });
 });

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
@@ -48,6 +48,10 @@ describe("Engine Metrics plugin — page", () => {
     vi.spyOn(engine_rest.plugins.metrics, "completed").mockImplementation(
       () => {},
     );
+    vi.spyOn(
+      engine_rest.plugins.metrics,
+      "definition_stats",
+    ).mockImplementation(() => {});
     signal_response(state.api.plugins.metrics.version, { version: "7.99.0" });
 
     render_with_state(<MetricsPage />, { state });
@@ -67,6 +71,7 @@ describe("Engine Metrics plugin — page", () => {
       "flow_nodes",
       "running",
       "completed",
+      "definition_stats",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -79,5 +84,47 @@ describe("Engine Metrics plugin — page", () => {
     expect(screen.getByText("3")).toBeTruthy();
     expect(screen.getByText("7")).toBeTruthy();
     expect(screen.getByText("10")).toBeTruthy();
+  });
+
+  it("ranks top processes, summing running instances across versions", () => {
+    const state = create_mock_state();
+    for (const fn of [
+      "version",
+      "process_starts",
+      "flow_nodes",
+      "running",
+      "completed",
+      "definition_stats",
+    ]) {
+      vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
+    }
+    // orderFulfillment spans two versions (4 + 6 = 10) and outranks invoice (2).
+    signal_response(state.api.plugins.metrics.definition_stats, [
+      {
+        instances: 4,
+        incidents: [],
+        definition: { id: "of:1", key: "orderFulfillment", name: "Order Fulfillment", version: 1 },
+      },
+      {
+        instances: 6,
+        incidents: [{ incidentType: "failedJob", incidentCount: 2 }],
+        definition: { id: "of:2", key: "orderFulfillment", name: "Order Fulfillment", version: 2 },
+      },
+      {
+        instances: 2,
+        incidents: [],
+        definition: { id: "inv:1", key: "invoice", name: "Invoice", version: 1 },
+      },
+    ]);
+
+    render_with_state(<MetricsPage />, { state });
+
+    // Aggregated running count for orderFulfillment is 10, incidents 2.
+    expect(screen.getByText("Order Fulfillment")).toBeTruthy();
+    expect(screen.getByText("10")).toBeTruthy();
+    expect(screen.getByText("(2)")).toBeTruthy();
+    // Links to the newest version's definition (of:2).
+    const link = screen.getByText("Order Fulfillment").closest("a");
+    expect(link.getAttribute("href")).toBe("/processes/of:2");
   });
 });

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
@@ -52,6 +52,10 @@ describe("Engine Metrics plugin — page", () => {
       engine_rest.plugins.metrics,
       "definition_stats",
     ).mockImplementation(() => {});
+    vi.spyOn(
+      engine_rest.plugins.metrics,
+      "activity_series",
+    ).mockImplementation(() => {});
     signal_response(state.api.plugins.metrics.version, { version: "7.99.0" });
 
     render_with_state(<MetricsPage />, { state });
@@ -72,6 +76,7 @@ describe("Engine Metrics plugin — page", () => {
       "running",
       "completed",
       "definition_stats",
+      "activity_series",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -95,6 +100,7 @@ describe("Engine Metrics plugin — page", () => {
       "running",
       "completed",
       "definition_stats",
+      "activity_series",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -126,5 +132,38 @@ describe("Engine Metrics plugin — page", () => {
     // Links to the newest version's definition (of:2).
     const link = screen.getByText("Order Fulfillment").closest("a");
     expect(link.getAttribute("href")).toBe("/processes/of:2");
+  });
+
+  it("renders a gap-free 30-day activity chart from sparse buckets", () => {
+    const state = create_mock_state();
+    for (const fn of [
+      "version",
+      "process_starts",
+      "flow_nodes",
+      "running",
+      "completed",
+      "definition_stats",
+      "activity_series",
+    ]) {
+      vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
+    }
+    // A single bucket for today; the other 29 days must be filled with 0.
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const iso_day = today.toISOString().slice(0, 10);
+    signal_response(state.api.plugins.metrics.activity_series, [
+      { timestamp: `${iso_day}T00:00:00.000+0000`, value: 100 },
+    ]);
+
+    render_with_state(<MetricsPage />, { state });
+
+    const cols = document.querySelectorAll(".activity-col");
+    expect(cols.length).toBe(30);
+    // Today's column carries the value; at least one column is the 0-filled gap.
+    const tips = [...document.querySelectorAll(".activity-tip")].map(
+      (t) => t.textContent,
+    );
+    expect(tips.some((x) => x.endsWith(" 100"))).toBe(true);
+    expect(tips.some((x) => x.endsWith(" 0"))).toBe(true);
   });
 });

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
@@ -56,6 +56,9 @@ describe("Engine Metrics plugin — page", () => {
       engine_rest.plugins.metrics,
       "activity_series",
     ).mockImplementation(() => {});
+    vi.spyOn(engine_rest.plugins.metrics, "top_tasks").mockImplementation(
+      () => {},
+    );
     signal_response(state.api.plugins.metrics.version, { version: "7.99.0" });
 
     render_with_state(<MetricsPage />, { state });
@@ -77,6 +80,7 @@ describe("Engine Metrics plugin — page", () => {
       "completed",
       "definition_stats",
       "activity_series",
+      "top_tasks",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -101,6 +105,7 @@ describe("Engine Metrics plugin — page", () => {
       "completed",
       "definition_stats",
       "activity_series",
+      "top_tasks",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -144,6 +149,7 @@ describe("Engine Metrics plugin — page", () => {
       "completed",
       "definition_stats",
       "activity_series",
+      "top_tasks",
     ]) {
       vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
     }
@@ -165,5 +171,50 @@ describe("Engine Metrics plugin — page", () => {
     );
     expect(tips.some((x) => x.endsWith(" 100"))).toBe(true);
     expect(tips.some((x) => x.endsWith(" 0"))).toBe(true);
+  });
+
+  it("ranks top user tasks by completed count, highest first", () => {
+    const state = create_mock_state();
+    for (const fn of [
+      "version",
+      "process_starts",
+      "flow_nodes",
+      "running",
+      "completed",
+      "definition_stats",
+      "activity_series",
+      "top_tasks",
+    ]) {
+      vi.spyOn(engine_rest.plugins.metrics, fn).mockImplementation(() => {});
+    }
+    signal_response(state.api.plugins.metrics.top_tasks, [
+      {
+        count: 4,
+        taskName: "Approve Invoice",
+        processDefinitionName: "Invoice Receipt",
+        processDefinitionId: "invoice:2",
+      },
+      {
+        count: 122,
+        taskName: "Final decision",
+        processDefinitionName: "Loan Approval",
+        processDefinitionId: "loanApproval:1",
+      },
+    ]);
+
+    render_with_state(<MetricsPage />, { state });
+
+    expect(screen.getByText("Final decision")).toBeTruthy();
+    expect(screen.getByText("122")).toBeTruthy();
+    // Row links to its process definition.
+    const link = screen.getByText("Final decision").closest("a");
+    expect(link.getAttribute("href")).toBe("/processes/loanApproval:1");
+    // Highest count renders before the lower one.
+    const names = [...document.querySelectorAll(".metrics-ranking")]
+      .flatMap((r) => [...r.querySelectorAll(".ranking-name")])
+      .map((n) => n.textContent);
+    expect(names.indexOf("Final decision · Loan Approval")).toBeLessThan(
+      names.indexOf("Approve Invoice · Invoice Receipt"),
+    );
   });
 });

--- a/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
+++ b/webapps-neo/frontend/src/plugins/bundled/metrics/plugin.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { screen } from "@testing-library/preact";
-import descriptors from "./plugin.jsx";
+import descriptors, { donut_font_size } from "./plugin.jsx";
 import { register, _reset_registry } from "../../registry.js";
 import { PLUGIN_POINTS } from "../../points.js";
 import engine_rest from "../../../api/engine_rest.jsx";
@@ -254,5 +254,20 @@ describe("Engine Metrics plugin — page", () => {
 
     const { container: bad } = mount(3);
     expect(bad.querySelector(".metric-status.status-bad")).toBeTruthy();
+  });
+});
+
+describe("donut_font_size", () => {
+  it("keeps the label clear of the ring as the total grows", () => {
+    // 0.6 units of advance per digit and em must stay inside the 22-unit budget.
+    for (const total of [7, 42, 913, 7113, 25000, 148000]) {
+      const size = donut_font_size(total);
+      expect(size * 0.6 * String(total).length).toBeLessThanOrEqual(22);
+      expect(size).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not blow up short totals to fill the space", () => {
+    expect(donut_font_size(7)).toBe(donut_font_size(7113));
   });
 });


### PR DESCRIPTION
Fills in the Engine Metrics page as proposed in #3594.

The bundled `metrics` plugin rendered three values — engine version, process starts (12 mo), flow nodes executed (12 mo). This adds five widgets on top of them, all reading REST endpoints the engine already exposes.

| Widget | Endpoint |
|---|---|
| Running vs. completed instances (donut) | `/process-instance/count` + `/history/process-instance/count?finished=true` |
| Process starts per day, last 30 days (chart) | `/metrics?name=root-process-instance-start&interval=86400` |
| Top processes by running instances, with incidents | `/process-definition/statistics?incidents=true` |
| Top user tasks by volume | `/history/task/report?reportType=count&groupBy=taskName` |
| Failed-jobs health tile | `/job/count?withException=true` |

Plus a layout pass so the tiles read as one dashboard rather than a list.

### Scope

```
src/plugins/bundled/metrics/plugin.jsx        +365
src/plugins/bundled/metrics/metrics.css       +335  -6
src/plugins/bundled/metrics/plugin.test.jsx   +220
```

The diff stays inside the bundled plugin. **No core file is touched** — no routing, no header, no `config.js`, no API layer — so nothing outside the metrics page can be affected. Translations stay in the plugin's own `translations` block (`en-US`, `de-DE`), as before. No new dependency.

Eight commits, one per widget plus the layout pass and a fix, so this can be reviewed or cherry-picked piecewise.

### Details worth flagging

- The daily chart queries `root-process-instance-start`, not `activity-instance-start`, so call activities do not inflate the numbers. Sparse buckets (the engine returns only days with activity) are filled to a gap-free 30-day series.
- Every widget handles its own empty state — no running instances, no completed tasks, no starts in the window — so a fresh engine renders sensibly instead of showing empty boxes.
- The donut's centre label is sized from its digit count, so a five- or six-digit total stays clear of the ring.

### Testing

`plugin.test.jsx` covers the widgets, the series builder and the donut label sizing. Full frontend suite passes (595 tests), ESLint is clean on the plugin, `vite build` succeeds.

Verified manually against an engine under synthetic load from `webapps-neo/frontend/dev-fixtures` (~7k running instances across 19 process definitions, incidents present), in light and dark mode.

### Open question

These are proposed as the default page content. The widgets are independent, so making them individually toggleable is straightforward if you would rather not expand the default view — happy to follow whichever you prefer.

related to #3594


