### PR TITLE
feat(webapps-neo): Config-driven CI branding (logo, colours, favicon)

### DIFF
--- a/webapps-neo/frontend/.env.development
+++ b/webapps-neo/frontend/.env.development
@@ -7,3 +7,9 @@ VITE_AUTH_MODE=basic # oauth | basic
 VITE_OAUTH_AUTHORITY=http://localhost:8888/realms/operaton
 VITE_OAUTH_CLIENT_ID=operaton-web-apps
 VITE_OAUTH_REDIRECT_URI=http://127.0.0.1:5173/
+
+# CI branding (logo, app name, favicon, colour tokens; see src/branding.js).
+# Quote the value. The hex colours contain "#", which dotenv otherwise reads as
+# the start of a comment and silently truncates the JSON — the block then fails
+# to parse and everything falls back to the Operaton defaults, with no error.
+#VITE_BRANDING='{"appName":"Acme BPM","logoUrl":"/branding/logo.svg","logoAlt":"Acme BPM","faviconUrl":"/branding/favicon.svg","colors":{"primary":"#0d4f8b","link":"#0d4f8b"},"colorsDark":{"primary":"#7cb3e8","link":"#7cb3e8"},"hue":212}'

--- a/webapps-neo/frontend/src/branding.js
+++ b/webapps-neo/frontend/src/branding.js
@@ -1,0 +1,97 @@
+/**
+ * branding.js
+ *
+ * CI branding from the runtime configuration (see config.js `branding`).
+ * White-label per installation: a `branding` block in config.json (or the
+ * VITE_BRANDING env fallback) overrides the logo, app name, favicon and the
+ * brand colour tokens. Anything omitted or invalid falls back to the Operaton
+ * defaults, so a partial or malformed block can never break the UI.
+ *
+ * Values are validated before they reach the DOM/CSS, so a config file cannot
+ * inject arbitrary markup or stylesheet rules.
+ */
+import { get_config } from "./config.js";
+
+const DEFAULT_APP_NAME = "Operaton";
+const DEFAULT_LOGO = "/operaton-logo.svg";
+
+// Overridable brand colours, mapped to the CSS custom property they set.
+const COLOR_TOKENS = {
+  primary: "--color-primary",
+  link: "--color-link",
+  danger: "--color-danger",
+  warning: "--color-warning",
+  success: "--color-success",
+};
+
+const is_hex = (v) =>
+  typeof v === "string" && /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(v);
+// Relative path or http(s) URL only — blocks javascript:/data: and stray markup.
+const is_url = (v) =>
+  typeof v === "string" && /^(https?:\/\/|\/)[^\s"'<>]+$/i.test(v);
+const is_finite_number = (v) => typeof v === "number" && Number.isFinite(v);
+const non_empty = (v) => typeof v === "string" && v.trim().length > 0;
+
+const branding = () => get_config().branding ?? {};
+
+export const app_name = () =>
+  non_empty(branding().appName) ? branding().appName : DEFAULT_APP_NAME;
+
+export const logo_url = () =>
+  is_url(branding().logoUrl) ? branding().logoUrl : DEFAULT_LOGO;
+
+export const logo_alt = () =>
+  non_empty(branding().logoAlt) ? branding().logoAlt : app_name();
+
+// `--token: value;` declarations for the valid hex colours in `colors`.
+const color_decls = (colors) =>
+  Object.entries(COLOR_TOKENS)
+    .filter(([key]) => is_hex(colors?.[key]))
+    .map(([key, token]) => `${token}: ${colors[key]};`);
+
+// Build the :root override stylesheet from a branding block. Only valid values
+// are emitted; missing ones keep the stylesheet defaults. Exported for testing.
+export const build_css = (b) => {
+  const light = color_decls(b.colors);
+  if (is_finite_number(b.hue)) light.push(`--hue: ${b.hue};`);
+  const dark = color_decls(b.colorsDark);
+
+  const blocks = [];
+  if (light.length) blocks.push(`:root { ${light.join(" ")} }`);
+  if (dark.length)
+    blocks.push(
+      `@media (prefers-color-scheme: dark) { :root { ${dark.join(" ")} } }`,
+    );
+  return blocks.join("\n");
+};
+
+const inject_css = (css) => {
+  if (!css) return;
+  const style = document.createElement("style");
+  style.id = "operaton-branding";
+  style.textContent = css;
+  document.head.appendChild(style);
+};
+
+const set_favicon = (url) => {
+  if (!is_url(url)) return;
+  let link = document.querySelector('link[rel~="icon"]');
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "icon";
+    document.head.appendChild(link);
+  }
+  link.href = url;
+};
+
+/**
+ * Apply the configured branding to the document: inject the colour-token
+ * overrides (light + dark), swap the favicon and set the document title. Call
+ * once at boot after `load_config()`. A missing/empty branding block is a no-op.
+ */
+export const apply_branding = () => {
+  const b = branding();
+  inject_css(build_css(b));
+  set_favicon(b.faviconUrl);
+  if (non_empty(b.appName)) document.title = b.appName;
+};

--- a/webapps-neo/frontend/src/branding.test.js
+++ b/webapps-neo/frontend/src/branding.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { set_config } from "./config.js";
+import {
+  build_css,
+  app_name,
+  logo_url,
+  logo_alt,
+  apply_branding,
+} from "./branding.js";
+
+afterEach(() => {
+  set_config(null);
+  document.getElementById("operaton-branding")?.remove();
+});
+
+describe("branding accessors", () => {
+  it("falls back to Operaton defaults without a branding block", () => {
+    set_config({});
+    expect(app_name()).toBe("Operaton");
+    expect(logo_url()).toBe("/operaton-logo.svg");
+    expect(logo_alt()).toBe("Operaton");
+  });
+
+  it("uses configured values", () => {
+    set_config({
+      branding: { appName: "Acme", logoUrl: "/b/l.svg", logoAlt: "Acme Logo" },
+    });
+    expect(app_name()).toBe("Acme");
+    expect(logo_url()).toBe("/b/l.svg");
+    expect(logo_alt()).toBe("Acme Logo");
+  });
+
+  it("rejects an unsafe logo url and keeps the default", () => {
+    set_config({ branding: { logoUrl: "javascript:alert(1)" } });
+    expect(logo_url()).toBe("/operaton-logo.svg");
+  });
+
+  it("logoAlt falls back to appName", () => {
+    set_config({ branding: { appName: "Acme" } });
+    expect(logo_alt()).toBe("Acme");
+  });
+});
+
+describe("build_css", () => {
+  it("emits valid colour tokens and hue in :root", () => {
+    const css = build_css({
+      colors: { primary: "#f15200", link: "#c14200" },
+      hue: 40,
+    });
+    expect(css).toContain("--color-primary: #f15200;");
+    expect(css).toContain("--color-link: #c14200;");
+    expect(css).toContain("--hue: 40;");
+  });
+
+  it("skips invalid hex values but keeps valid siblings", () => {
+    const css = build_css({ colors: { primary: "red", danger: "#bb2511" } });
+    expect(css).not.toContain("red");
+    expect(css).toContain("--color-danger: #bb2511;");
+  });
+
+  it("emits a dark-mode block for colorsDark", () => {
+    const css = build_css({ colorsDark: { primary: "#ff8a4c" } });
+    expect(css).toContain("prefers-color-scheme: dark");
+    expect(css).toContain("--color-primary: #ff8a4c;");
+  });
+
+  it("returns an empty string when nothing valid is present", () => {
+    expect(build_css({})).toBe("");
+    expect(build_css({ colors: { primary: "nope" }, hue: "big" })).toBe("");
+  });
+});
+
+describe("apply_branding", () => {
+  it("injects the style, swaps the favicon and sets the title", () => {
+    set_config({
+      branding: {
+        appName: "Acme",
+        faviconUrl: "/b/fav.ico",
+        colors: { primary: "#f15200" },
+      },
+    });
+    apply_branding();
+
+    expect(document.getElementById("operaton-branding")?.textContent).toContain(
+      "--color-primary: #f15200;",
+    );
+    expect(
+      document.querySelector('link[rel~="icon"]')?.getAttribute("href"),
+    ).toBe("/b/fav.ico");
+    expect(document.title).toBe("Acme");
+  });
+
+  it("is a no-op style-wise for an empty branding block", () => {
+    set_config({});
+    apply_branding();
+    expect(document.getElementById("operaton-branding")).toBeNull();
+  });
+});

--- a/webapps-neo/frontend/src/components/Header.jsx
+++ b/webapps-neo/frontend/src/components/Header.jsx
@@ -10,6 +10,7 @@ import engine_rest from "../api/engine_rest.jsx";
 import { plugins_for } from "../plugins/registry.js";
 import { PLUGIN_POINTS } from "../plugins/points.js";
 import { get_config } from "../config.js";
+import { app_name, logo_url, logo_alt } from "../branding.js";
 
 const swap_server = (e, state) => {
   const server = get_config().backends.find((s) => s.url === e.target.value);
@@ -132,15 +133,15 @@ export function Header() {
         </menu>
 
         <a href="/" id="mobile-logo">
-          OPERATON
+          {app_name()}
         </a>
         <a
           href="/"
           id="logo"
-          aria-label="Operaton"
+          aria-label={app_name()}
           aria-current={url === "/" ? "page" : undefined}
         >
-          <img src="/operaton-logo.svg" alt="Operaton" />
+          <img src={logo_url()} alt={logo_alt()} />
         </a>
         <button
           type="button"

--- a/webapps-neo/frontend/src/config.js
+++ b/webapps-neo/frontend/src/config.js
@@ -46,6 +46,22 @@ const parse_backends = (raw) => {
   }
 }
 
+// Branding arrives as a JSON string from the env (VITE_BRANDING) or as an object
+// from config.json. Values are validated later, at apply time (see branding.js),
+// so a malformed block is simply ignored rather than breaking boot.
+const as_branding = (value) =>
+  value && typeof value === "object" && !Array.isArray(value) ? value : undefined
+
+const parse_branding = (raw) => {
+  const value = clean(raw)
+  if (!value) return undefined
+  try {
+    return as_branding(JSON.parse(value))
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Configuration from the build-time environment. Used by the dev server, and as
  * the fallback when no config.json is served.
@@ -77,6 +93,7 @@ const from_env = () => {
     remote_plugins_enabled: clean(import.meta.env.VITE_REMOTE_PLUGINS_ENABLED) === "true",
     remote_plugins_allow_origins: split_origins(clean(import.meta.env.VITE_REMOTE_PLUGINS_ALLOW_ORIGINS)),
     hide_release_warning: clean(import.meta.env.VITE_HIDE_RELEASE_WARNING) === "true",
+    branding: parse_branding(import.meta.env.VITE_BRANDING),
     user: undefined,
   }
 }
@@ -123,6 +140,7 @@ const from_document = (json) => {
       : split_origins(clean(json.remotePluginsAllowOrigins)),
     hide_release_warning:
       json.hideReleaseWarning === true || clean(json.hideReleaseWarning) === "true",
+    branding: as_branding(json.branding),
     user: json.user?.id ? { id: json.user.id } : undefined,
   }
 }

--- a/webapps-neo/frontend/src/css/style.css
+++ b/webapps-neo/frontend/src/css/style.css
@@ -138,6 +138,7 @@
     #mobile-logo {
       display: block !important;
       font-weight: bold;
+      text-transform: uppercase;
       color: var(--text);
       text-decoration: none;
     }

--- a/webapps-neo/frontend/src/index.jsx
+++ b/webapps-neo/frontend/src/index.jsx
@@ -28,6 +28,7 @@ import engine_rest from "./api/engine_rest.jsx";
 import { useSignal } from "@preact/signals";
 import { is_oauth } from "./api/oauth.js";
 import { get_config, load_config } from "./config.js";
+import { apply_branding, logo_url, logo_alt } from "./branding.js";
 import { useTranslation } from "react-i18next";
 import { load_plugins } from "./plugins/loader.js";
 import { install_plugin_host } from "./plugins/host.js";
@@ -168,7 +169,7 @@ const Routing = () => {
 
     return (
       <section class="login-page">
-        <img class="login-logo" src="/operaton-logo.svg" alt="Operaton" />
+        <img class="login-logo" src={logo_url()} alt={logo_alt()} />
 
         <div class="login-content">
           <h1>{t("login.title")}</h1>
@@ -287,5 +288,9 @@ install_plugin_host();
 // The runtime configuration must be in place before anything reads it, and the
 // plugin loader needs it to know where the manifest lives.
 load_config()
+  .then((cfg) => {
+    apply_branding();
+    return cfg;
+  })
   .then(load_plugins)
   .finally(() => render(<App />, document.getElementById("app")));


### PR DESCRIPTION
Implements the configurable CI branding proposed in #3593.

An optional `branding` block in the runtime configuration white-labels the app per installation — no rebuild, no new dependency, no new endpoint. It rides along the `config.json` that is already fetched at boot, with `VITE_BRANDING` as the dev fallback.

```json
{
  "branding": {
    "appName": "Example Corp Workflows",
    "logoUrl": "/branding/logo.svg",
    "logoAlt": "Example Corp",
    "faviconUrl": "/branding/favicon.svg",
    "colors":     { "primary": "#0d4f8b", "link": "#0d4f8b", "danger": "#b3261e", "warning": "#9a6700", "success": "#1a7f37" },
    "colorsDark": { "primary": "#7cb3e8", "link": "#7cb3e8" },
    "hue": 212
  }
}
```

Every field is optional. A missing, empty or malformed value falls back to the current Operaton default, so a broken branding block renders exactly like today rather than breaking the UI.

### Scope

```
src/branding.js               +97   validation, CSS override, favicon and title
src/branding.test.js          +98
src/config.js                 +18   branding in from_env and from_document
src/index.jsx                  +7   apply at boot, login logo
src/components/Header.jsx      +7   header and mobile logo
src/css/style.css              +1
```

### How it works

- **Colours** — the stylesheet is already built on CSS custom properties (`--hue`, `--color-primary`, `--color-link`, …). Branding injects one `:root` override stylesheet at boot, plus a `@media (prefers-color-scheme: dark)` block from `colorsDark`, so light and dark stay separately tunable.
- **Logo** — `Header.jsx` and the login screen read `logoUrl` / `logoAlt`; the `aria-label` follows `appName` rather than staying hardcoded.
- **Favicon and title** — swapped at boot from `faviconUrl` / `appName`.
- The one-line `style.css` change moves the mobile logo's capitalisation from the markup (`OPERATON`) into `text-transform`, so a configured name keeps the same look without being shouted in the DOM.

### Validation

Values are checked before they reach the DOM or CSS: colours must be hex, URLs must be a relative path or `http(s)` — which rules out `javascript:` and `data:` — numbers must be finite, strings non-empty. Only valid declarations are emitted, so a config file cannot inject markup or arbitrary stylesheet rules.

### Why config rather than a plugin

The web apps have a plugin system, and this was considered as a plugin first. Branding has to be in place before first paint, and it has to work on an installation with no `pluginsUrl` configured; a plugin loads after boot, which would mean a flash of the default logo and colours on every page load. It also changes global CSS tokens, the favicon and the title rather than adding a view, and it is validated data instead of executable JavaScript. The reasoning is spelled out in #3593.

### Testing

`branding.test.js` covers the validation rules, the generated CSS for light and dark, and the fallbacks for missing and malformed blocks. Full frontend suite passes (598 tests), `vite build` succeeds, ESLint reports nothing new (the one remaining warning in `index.jsx` predates this branch).

Verified manually against real customer corporate identities, in light and dark mode.

related to #3593
