### PR TITLE
refactor: Replace Arrays#asList by List#of

### DIFF
--- a/clients/java/client/src/it/java/org/operaton/bpm/client/client/ClientIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/client/ClientIT.java
@@ -18,8 +18,6 @@ package org.operaton.bpm.client.client;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -164,7 +162,7 @@ class ClientIT {
 
       final ObjectValue[] objectValue = { null };
       RecordingExternalTaskHandler recordingHandler = new RecordingExternalTaskHandler((t, s) -> {
-        List<String> list = new ArrayList<>(Arrays.asList("lorem", "ipsum", "dolor", "sit"));
+        List<String> list = List.of("lorem", "ipsum", "dolor", "sit");
         objectValue[0] = Variables.objectValue(list).create();
         s.complete(t, Collections.singletonMap("variable", objectValue[0]));
       });

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -325,7 +325,7 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
 
     HttpGet httpGet = new HttpGet(uri);
     VariableInstanceDto[] variables = executeRequest(httpGet, VariableInstanceDto[].class);
-    return Arrays.asList(variables);
+    return List.of(variables);
   }
 
   public TaskDto getTaskByProcessInstanceId(String processInstanceId) {
@@ -353,7 +353,7 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
   public List<ExternalTaskImpl> getExternalTasksByProcessInstanceId(String processInstanceId) {
     String uri = String.format(URI_GET_EXTERNAL_TASKS, getEngineUrl()) + "?processInstanceId=" + processInstanceId;
     HttpGet httpGet = new HttpGet(uri);
-    return Arrays.asList(executeRequest(httpGet, ExternalTaskImpl[].class));
+    return List.of(executeRequest(httpGet, ExternalTaskImpl[].class));
   }
 
   public HistoricProcessInstanceDto getHistoricProcessInstanceById(String processInstanceId) {

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/EngineClient.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/EngineClient.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.client.impl;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -120,7 +119,7 @@ public class EngineClient {
 
     String resourceUrl = getBaseUrl() + FETCH_AND_LOCK_RESOURCE_PATH;
     ExternalTask[] externalTasks = engineInteraction.postRequest(resourceUrl, payload, ExternalTaskImpl[].class);
-    return Arrays.asList(externalTasks);
+    return List.of(externalTasks);
   }
 
   public void lock(String taskId, long lockDuration) {

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionBuilderImpl.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.client.topic.impl;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ public class TopicSubscriptionBuilderImpl implements TopicSubscriptionBuilder {
   @Override
   public TopicSubscriptionBuilder variables(String... variableNames) {
     ensureNotNull(variableNames, "variableNames");
-    this.variableNames = Arrays.asList(variableNames);
+    this.variableNames = List.of(variableNames);
     return this;
   }
 
@@ -98,7 +97,7 @@ public class TopicSubscriptionBuilderImpl implements TopicSubscriptionBuilder {
   @Override
   public TopicSubscriptionBuilder processDefinitionIdIn(String... processDefinitionIds) {
     ensureNotNull(processDefinitionIds, "processDefinitionIds");
-    this.processDefinitionIds = Arrays.asList(processDefinitionIds);
+    this.processDefinitionIds = List.of(processDefinitionIds);
     return this;
   }
 
@@ -111,7 +110,7 @@ public class TopicSubscriptionBuilderImpl implements TopicSubscriptionBuilder {
   @Override
   public TopicSubscriptionBuilder processDefinitionKeyIn(String... processDefinitionKeys) {
     ensureNotNull(processDefinitionKeys, "processDefinitionKeys");
-    this.processDefinitionKeys = Arrays.asList(processDefinitionKeys);
+    this.processDefinitionKeys = List.of(processDefinitionKeys);
     return this;
   }
 
@@ -154,7 +153,7 @@ public class TopicSubscriptionBuilderImpl implements TopicSubscriptionBuilder {
   @Override
   public TopicSubscriptionBuilder tenantIdIn(String... tenantIds) {
     ensureNotNull(tenantIds, "tenantIds");
-    this.tenantIds = Arrays.asList(tenantIds);
+    this.tenantIds = List.of(tenantIds);
     return this;
   }
 

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunAuthenticationProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunAuthenticationProperties.java
@@ -16,14 +16,13 @@
  */
 package org.operaton.bpm.run.property;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class OperatonBpmRunAuthenticationProperties {
   public static final String PREFIX = OperatonBpmRunProperties.PREFIX + ".auth";
   public static final String DEFAULT_AUTH = "basic";
   public static final String OAUTH2_AUTH = "oauth2";
-  private static final List<String> AUTH_METHODS = Arrays.asList(DEFAULT_AUTH, OAUTH2_AUTH);
+  private static final List<String> AUTH_METHODS = List.of(DEFAULT_AUTH, OAUTH2_AUTH);
 
   boolean enabled;
   String authentication = DEFAULT_AUTH;

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/ComponentAvailabilityIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/ComponentAvailabilityIT.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.run.qa;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
@@ -40,7 +40,7 @@ class ComponentAvailabilityIT {
   public boolean exampleAvailable;
 
   public static Collection<Object[]> commands() {
-    return Arrays.asList(new Object[][] {
+    return List.of(new Object[][] {
         { new String[0], true, true, true },
         { new String[]{"--rest"}, true, false, false },
         { new String[]{"--rest", "--webapps"}, true, true, false },

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -27,7 +27,6 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -72,7 +71,7 @@ public class SpringBootManagedContainer {
     this.commands.add(getScriptPath());
     this.commands.add("start");
     if (commands != null && commands.length > 0) {
-      this.commands.addAll(Arrays.asList(commands));
+      this.commands.addAll(List.of(commands));
     }
     InputStream defaultYml = SpringBootManagedContainer.class.getClassLoader().getResourceAsStream(BASE_TEST_APPLICATION_YML);
     createConfigurationYml(APPLICATION_YML_PATH, defaultYml);

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +52,7 @@ class LoginIT extends AbstractWebappUiIT {
   String[] commands;
 
   static Collection<Object[]> commands() {
-    return Arrays.asList(new Object[][] {
+    return List.of(new Object[][] {
       { new String[0] },
       { new String[]{"--rest", "--webapps"} },
       { new String[]{"--webapps"} }

--- a/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/transform/ListTransformer.java
+++ b/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/transform/ListTransformer.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.dmn.feel.impl.juel.transform;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.dmn.feel.impl.juel.FeelEngineLogger;
@@ -45,7 +44,7 @@ public class ListTransformer implements FeelToJuelTransformer {
   }
 
   private List<String> splitExpression(String feelExpression) {
-    return Arrays.asList(feelExpression.split(COMMA_SEPARATOR_REGEX, -1));
+    return List.of(feelExpression.split(COMMA_SEPARATOR_REGEX, -1));
   }
 
   protected List<String> transformExpressions(FeelToJuelTransform transform, String feelExpression, String inputName) {

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/builder/CustomFunctionBuilderImpl.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/builder/CustomFunctionBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.dmn.feel.impl.scala.function.builder;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
@@ -37,7 +36,7 @@ public class CustomFunctionBuilderImpl implements CustomFunctionBuilder {
 
   @Override
   public CustomFunctionBuilder setParams(String... params) {
-    List<String> paramList = Arrays.asList(params);
+    List<String> paramList = List.of(params);
     customFunction.setParams(paramList);
     return this;
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/StringListConverter.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/StringListConverter.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.rest.dto.converter;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,7 +27,7 @@ public class StringListConverter extends JacksonAwareStringToTypeConverter<List<
       return Collections.emptyList();
     }
     else {
-      return Arrays.asList(value.split(","));
+      return List.of(value.split(","));
     }
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceQueryTest.java
@@ -1100,7 +1100,7 @@ public class CaseInstanceRestServiceQueryTest extends AbstractRestServiceTest {
 
   @Test
   void testWithoutTenantIdParameter() {
-    mockedQuery = setUpMockCaseInstanceQuery(Arrays.asList(MockProvider.createMockCaseInstance(null)));
+    mockedQuery = setUpMockCaseInstanceQuery(List.of(MockProvider.createMockCaseInstance(null)));
 
     Response response = given()
       .queryParam("withoutTenantId", true)
@@ -1151,7 +1151,7 @@ public class CaseInstanceRestServiceQueryTest extends AbstractRestServiceTest {
 
   @Test
   void testWithoutTenantIdPostParameter() {
-    mockedQuery = setUpMockCaseInstanceQuery(Arrays.asList(MockProvider.createMockCaseInstance(null)));
+    mockedQuery = setUpMockCaseInstanceQuery(List.of(MockProvider.createMockCaseInstance(null)));
 
     Map<String, Object> queryParameters = new HashMap<>();
     queryParameters.put("withoutTenantId", true);
@@ -1176,7 +1176,7 @@ public class CaseInstanceRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   private List<CaseInstance> createMockCaseInstancesTwoTenants() {
-    return Arrays.asList(
+    return List.of(
         MockProvider.createMockCaseInstance(MockProvider.EXAMPLE_TENANT_ID),
         MockProvider.createMockCaseInstance(MockProvider.ANOTHER_EXAMPLE_TENANT_ID));
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/EventSubscriptionRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/EventSubscriptionRestServiceQueryTest.java
@@ -190,7 +190,7 @@ public class EventSubscriptionRestServiceQueryTest extends AbstractRestServiceTe
 
   @Test
   void testWithoutTenantIdParameter() {
-    mockedEventSubscriptionQuery = setUpMockEventSubscriptionQuery(Arrays.asList(MockProvider.createMockEventSubscription(null)));
+    mockedEventSubscriptionQuery = setUpMockEventSubscriptionQuery(List.of(MockProvider.createMockEventSubscription(null)));
 
     Response response =
         given()
@@ -313,7 +313,7 @@ public class EventSubscriptionRestServiceQueryTest extends AbstractRestServiceTe
   }
 
   private List<EventSubscription> createMockEventSubscriptionTwoTenants() {
-    return Arrays.asList(
+    return List.of(
         MockProvider.createMockEventSubscription(MockProvider.EXAMPLE_TENANT_ID),
         MockProvider.createMockEventSubscription(MockProvider.ANOTHER_EXAMPLE_TENANT_ID)
       );

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.rest;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -181,7 +180,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLock() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -192,8 +191,8 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
-    parameters.put("topics", Arrays.asList(topicParameter));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    parameters.put("topics", List.of(topicParameter));
 
     executePost(parameters);
 
@@ -207,7 +206,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     inOrder.verify(fetchAndLockBuilder).subscribe();
 
     inOrder.verify(fetchTopicBuilder).topic("aTopicName", 12354L);
-    inOrder.verify(fetchTopicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(fetchTopicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(fetchTopicBuilder).execute();
 
     verifyNoMoreInteractions(fetchTopicBuilder, fetchTopicBuilder, externalTaskService);
@@ -216,7 +215,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithBusinessKey() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -228,8 +227,8 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
-    parameters.put("topics", Arrays.asList(topicParameter));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    parameters.put("topics", List.of(topicParameter));
 
     executePost(parameters);
 
@@ -244,7 +243,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
     inOrder.verify(fetchTopicBuilder).topic("aTopicName", 12354L);
     inOrder.verify(fetchTopicBuilder).businessKey(EXAMPLE_BUSINESS_KEY);
-    inOrder.verify(fetchTopicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(fetchTopicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(fetchTopicBuilder).execute();
 
     verifyNoMoreInteractions(fetchAndLockBuilder, fetchTopicBuilder, externalTaskService);
@@ -253,7 +252,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithProcessDefinition() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -264,11 +263,11 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("processDefinitionId", EXAMPLE_PROCESS_DEFINITION_ID);
-    topicParameter.put("processDefinitionIdIn", Arrays.asList(EXAMPLE_PROCESS_DEFINITION_ID));
+    topicParameter.put("processDefinitionIdIn", List.of(EXAMPLE_PROCESS_DEFINITION_ID));
     topicParameter.put("processDefinitionKey", EXAMPLE_PROCESS_DEFINITION_KEY);
-    topicParameter.put("processDefinitionKeyIn", Arrays.asList(EXAMPLE_PROCESS_DEFINITION_KEY));
+    topicParameter.put("processDefinitionKeyIn", List.of(EXAMPLE_PROCESS_DEFINITION_KEY));
     topicParameter.put("lockDuration", 12354L);
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     executePost(parameters);
 
@@ -294,7 +293,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithVariableValue() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
@@ -305,13 +304,13 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
 
     Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(EXAMPLE_VARIABLE_INSTANCE_NAME, EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     // when
     executePost(parameters);
@@ -327,7 +326,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
     inOrder.verify(fetchTopicBuilder).topic("aTopicName", 12354L);
     inOrder.verify(fetchTopicBuilder).businessKey(EXAMPLE_BUSINESS_KEY);
-    inOrder.verify(fetchTopicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(fetchTopicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(fetchTopicBuilder).processInstanceVariableEquals(variableValueParameter);
     inOrder.verify(fetchTopicBuilder).execute();
 
@@ -337,7 +336,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithCreateTimeDesc() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
@@ -349,13 +348,13 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
 
     Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(EXAMPLE_VARIABLE_INSTANCE_NAME, EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     // when
     executePost(parameters);
@@ -375,7 +374,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     inOrder.verify(fetchAndLockBuilder).subscribe();
     inOrder.verify(fetchTopicBuilder).topic("aTopicName", 12354L);
     inOrder.verify(fetchTopicBuilder).businessKey(EXAMPLE_BUSINESS_KEY);
-    inOrder.verify(fetchTopicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(fetchTopicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(fetchTopicBuilder).processInstanceVariableEquals(variableValueParameter);
     inOrder.verify(fetchTopicBuilder).execute();
 
@@ -385,7 +384,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithSortOrderInvalidCase() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
@@ -397,13 +396,13 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
 
     Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(EXAMPLE_VARIABLE_INSTANCE_NAME, EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     // when
     given()
@@ -429,7 +428,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithEmptySortOrder() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
@@ -441,13 +440,13 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
 
     Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(EXAMPLE_VARIABLE_INSTANCE_NAME, EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     // when
     given()
@@ -473,7 +472,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithBlankSortOrder() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     String sortOrder = " ";
     Map<String, Object> parameters = new HashMap<>();
@@ -486,13 +485,13 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
 
     Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(EXAMPLE_VARIABLE_INSTANCE_NAME, EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     // when
     given()
@@ -518,7 +517,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithCreateTimeWithoutOrder() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
@@ -530,13 +529,13 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
 
     Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(EXAMPLE_VARIABLE_INSTANCE_NAME, EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     // when
     executePost(parameters);
@@ -556,7 +555,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
     inOrder.verify(fetchTopicBuilder).topic("aTopicName", 12354L);
     inOrder.verify(fetchTopicBuilder).businessKey(EXAMPLE_BUSINESS_KEY);
-    inOrder.verify(fetchTopicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(fetchTopicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(fetchTopicBuilder).processInstanceVariableEquals(variableValueParameter);
     inOrder.verify(fetchTopicBuilder).execute();
 
@@ -566,7 +565,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithCreateTimeWithInvalidOrder() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
@@ -622,7 +621,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchWithoutVariables() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -632,7 +631,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
@@ -663,7 +662,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockWithTenant() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -675,9 +674,9 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("withoutTenantId", true);
     topicParameter.put("tenantId", "tenant1");
-    topicParameter.put("tenantIdIn", Arrays.asList("tenant2"));
+    topicParameter.put("tenantIdIn", List.of("tenant2"));
     topicParameter.put("lockDuration", 12354L);
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     executePost(parameters);
 
@@ -701,7 +700,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockByProcessDefinitionVersionTag() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -712,7 +711,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("processDefinitionVersionTag", "versionTag");
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     executePost(parameters);
 
@@ -735,7 +734,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testFetchAndLockIncludeExtensionProperties() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -746,7 +745,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("includeExtensionProperties", true);
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     executePost(parameters);
 
@@ -769,7 +768,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testEnableCustomObjectDeserialization() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -779,9 +778,9 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     topicParameter.put("deserializeValues", true);
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
@@ -804,7 +803,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
     inOrder.verify(fetchTopicBuilder).topic("aTopicName", 12354L);
 
-    inOrder.verify(fetchTopicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(fetchTopicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(fetchTopicBuilder).enableCustomObjectDeserialization();
     inOrder.verify(fetchTopicBuilder).execute();
 
@@ -814,7 +813,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   void testLocalVariables() {
     // given
-    when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
+    when(fetchTopicBuilder.execute()).thenReturn(List.of(lockedExternalTaskMock));
 
     // when
     Map<String, Object> parameters = new HashMap<>();
@@ -824,9 +823,9 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
-    topicParameter.put("variables", Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    topicParameter.put("variables", List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     topicParameter.put("localVariables", true);
-    parameters.put("topics", Arrays.asList(topicParameter));
+    parameters.put("topics", List.of(topicParameter));
 
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
@@ -849,7 +848,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     inOrder.verify(fetchAndLockBuilder).subscribe();
 
     inOrder.verify(topicBuilder).topic("aTopicName", 12354L);
-    inOrder.verify(topicBuilder).variables(Arrays.asList(EXAMPLE_VARIABLE_INSTANCE_NAME));
+    inOrder.verify(topicBuilder).variables(List.of(EXAMPLE_VARIABLE_INSTANCE_NAME));
     inOrder.verify(topicBuilder).localVariables();
 
     inOrder.verify(fetchTopicBuilder).execute();
@@ -1605,7 +1604,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   void testSetRetriesForExternalTasksAsync() {
-    List<String> externalTaskIds = Arrays.asList("externalTaskId1", "externalTaskId2");
+    List<String> externalTaskIds = List.of("externalTaskId1", "externalTaskId2");
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskIds", externalTaskIds);
@@ -1633,7 +1632,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   void testSetRetriesForExternalTasksSync() {
-    List<String> externalTaskIds = Arrays.asList("externalTaskId1", "externalTaskId2");
+    List<String> externalTaskIds = List.of("externalTaskId1", "externalTaskId2");
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskIds", externalTaskIds);
@@ -1661,7 +1660,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   void testSetRetriesForExternalTasksAsyncByProcessInstanceIds() {
-    List<String> processInstanceIds = Arrays.asList("123", "456");
+    List<String> processInstanceIds = List.of("123", "456");
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("processInstanceIds", processInstanceIds);
@@ -1689,7 +1688,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   void testSetRetriesForExternalTasksSyncByProcessInstanceIds() {
-    List<String> processInstanceIds = Arrays.asList("123", "456");
+    List<String> processInstanceIds = List.of("123", "456");
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("processInstanceIds", processInstanceIds);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceQueryTest.java
@@ -966,7 +966,7 @@ public class ProcessInstanceRestServiceQueryTest extends
 
   @Test
   void testWithoutTenantIdParameter() {
-    mockedQuery = setUpMockInstanceQuery(Arrays.asList(MockProvider.createMockInstance(null)));
+    mockedQuery = setUpMockInstanceQuery(List.of(MockProvider.createMockInstance(null)));
 
     Response response = given()
       .queryParam("withoutTenantId", true)
@@ -1017,7 +1017,7 @@ public class ProcessInstanceRestServiceQueryTest extends
 
   @Test
   void testWithoutTenantIdPostParameter() {
-    mockedQuery = setUpMockInstanceQuery(Arrays.asList(MockProvider.createMockInstance(null)));
+    mockedQuery = setUpMockInstanceQuery(List.of(MockProvider.createMockInstance(null)));
 
     Map<String, Object> queryParameters = new HashMap<>();
     queryParameters.put("withoutTenantId", true);
@@ -1042,7 +1042,7 @@ public class ProcessInstanceRestServiceQueryTest extends
   }
 
   private List<ProcessInstance> createMockProcessInstancesTwoTenants() {
-    return Arrays.asList(
+    return List.of(
         MockProvider.createMockInstance(MockProvider.EXAMPLE_TENANT_ID),
         MockProvider.createMockInstance(MockProvider.ANOTHER_EXAMPLE_TENANT_ID));
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
@@ -918,7 +918,7 @@ public abstract class MockProvider {
   public static final int EXAMPLE_PROBLEM_COLUMN_2 = 88;
   public static final String EXAMPLE_PROBLEM_ELEMENT_ID_2 = "element_89";
   public static final String EXAMPLE_RESOURCE_NAME = "abc";
-  public static final List<String> EXAMPLE_ELEMENT_IDS = Arrays.asList(EXAMPLE_PROBLEM_ELEMENT_ID, EXAMPLE_PROBLEM_ELEMENT_ID_2);
+  public static final List<String> EXAMPLE_ELEMENT_IDS = List.of(EXAMPLE_PROBLEM_ELEMENT_ID, EXAMPLE_PROBLEM_ELEMENT_ID_2);
 
   // Telemetry
   public static final String EXAMPLE_TELEMETRY_INSTALLATION_ID = "8343cc7a-8ad1-42d4-97d2-43452c0bdfa3";
@@ -1877,19 +1877,19 @@ public abstract class MockProvider {
   }
 
   public static List<Authorization> createMockAuthorizations() {
-    return Arrays.asList(createMockGlobalAuthorization(), createMockGrantAuthorization(), createMockRevokeAuthorization());
+    return List.of(createMockGlobalAuthorization(), createMockGrantAuthorization(), createMockRevokeAuthorization());
   }
 
   public static List<Authorization> createMockGrantAuthorizations() {
-    return Arrays.asList(createMockGrantAuthorization());
+    return List.of(createMockGrantAuthorization());
   }
 
   public static List<Authorization> createMockRevokeAuthorizations() {
-    return Arrays.asList(createMockRevokeAuthorization());
+    return List.of(createMockRevokeAuthorization());
   }
 
   public static List<Authorization> createMockGlobalAuthorizations() {
-    return Arrays.asList(createMockGlobalAuthorization());
+    return List.of(createMockGlobalAuthorization());
   }
 
   public static Date createMockDuedate() {
@@ -2278,7 +2278,7 @@ public abstract class MockProvider {
   }
 
   public static Set<String> createMockSetFromList(String list){
-    return new HashSet<>(Arrays.asList(list.split(",")));
+    return Set.of(list.split(","));
   }
 
   public static IdentityLink createMockUserAssigneeIdentityLink() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseInstanceRestServiceQueryTest.java
@@ -1279,7 +1279,7 @@ public class HistoricCaseInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   void testWithoutTenantIdParameter() {
-    mockedQuery = setUpMockHistoricCaseInstanceQuery(Arrays.asList(MockProvider.createMockHistoricCaseInstance(null)));
+    mockedQuery = setUpMockHistoricCaseInstanceQuery(List.of(MockProvider.createMockHistoricCaseInstance(null)));
 
     Response response = given()
       .queryParam("withoutTenantId", true)
@@ -1301,7 +1301,7 @@ public class HistoricCaseInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   void testWithoutTenantIdPostParameter() {
-    mockedQuery = setUpMockHistoricCaseInstanceQuery(Arrays.asList(MockProvider.createMockHistoricCaseInstance(null)));
+    mockedQuery = setUpMockHistoricCaseInstanceQuery(List.of(MockProvider.createMockHistoricCaseInstance(null)));
 
     Map<String, Object> queryParameters = new HashMap<>();
     queryParameters.put("withoutTenantId", true);
@@ -1326,7 +1326,7 @@ public class HistoricCaseInstanceRestServiceQueryTest extends AbstractRestServic
   }
 
   private List<HistoricCaseInstance> createMockHistoricCaseInstancesTwoTenants() {
-    return Arrays.asList(
+    return List.of(
         MockProvider.createMockHistoricCaseInstance(MockProvider.EXAMPLE_TENANT_ID),
         MockProvider.createMockHistoricCaseInstance(MockProvider.ANOTHER_EXAMPLE_TENANT_ID));
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/migration/MigrationExecutionDtoBuilder.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/migration/MigrationExecutionDtoBuilder.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.rest.util.migration;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +37,7 @@ public class MigrationExecutionDtoBuilder {
   }
 
   public MigrationExecutionDtoBuilder processInstances(String... processInstanceIds) {
-    migrationExecution.put(PROP_PROCESS_INSTANCE_IDS, Arrays.asList(processInstanceIds));
+    migrationExecution.put(PROP_PROCESS_INSTANCE_IDS, List.of(processInstanceIds));
     return this;
   }
 

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/SpringBeansResolverFactory.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/SpringBeansResolverFactory.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.engine.spring;
 
-import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -52,7 +52,7 @@ public class SpringBeansResolverFactory implements ResolverFactory, Resolver {
     this.applicationContext = applicationContext;
 
     String[] beannames = applicationContext.getBeanDefinitionNames();
-    this.keySet = new HashSet<>(Arrays.asList(beannames));
+    this.keySet = new HashSet<>(List.of(beannames));
   }
 
   @Override

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/aop/ProcessStartingPointcutAdvisor.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/aop/ProcessStartingPointcutAdvisor.java
@@ -16,8 +16,6 @@
 package org.operaton.bpm.engine.spring.components.aop;
 
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.aopalliance.aop.Advice;
@@ -48,7 +46,7 @@ public class ProcessStartingPointcutAdvisor implements PointcutAdvisor {
     /**
      * annotations that shall be scanned
      */
-    private final Set<Class<? extends Annotation>> annotations = new HashSet<>(Arrays.asList(StartProcess.class));
+    private final Set<Class<? extends Annotation>> annotations = Set.of(StartProcess.class);
 
     /**
      * the {@link org.aopalliance.intercept.MethodInterceptor} that handles launching the business process.

--- a/engine-spring/src/test/java/org/operaton/bpm/engine/spring/test/taskassignment/FakeLdapService.java
+++ b/engine-spring/src/test/java/org/operaton/bpm/engine/spring/test/taskassignment/FakeLdapService.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.spring.test.taskassignment;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -35,7 +34,7 @@ public class FakeLdapService {
   }
 
   public List<String> findAllSales() {
-    return Arrays.asList("kermit", "gonzo", "fozzie");
+    return List.of("kermit", "gonzo", "fozzie");
   }
 
   public List<String> findManagers(DelegateExecution execution, String emp) {
@@ -47,7 +46,7 @@ public class FakeLdapService {
       throw new RuntimeException("emp parameter is null or empty");
     }
 
-    return Arrays.asList("management", "directors");
+    return List.of("management", "directors");
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/RuntimeContainerDelegateImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/RuntimeContainerDelegateImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.container.impl;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -122,7 +121,7 @@ public @NullMarked class RuntimeContainerDelegateImpl implements RuntimeContaine
 
 
   protected List<DeploymentOperationStep> getDeploymentSteps() {
-    return Arrays.asList(
+    return List.of(
       new ParseProcessesXmlStep(),
       new ProcessesXmlStartProcessEnginesStep(),
       new DeployProcessArchivesStep(),
@@ -131,7 +130,7 @@ public @NullMarked class RuntimeContainerDelegateImpl implements RuntimeContaine
   }
 
   protected List<DeploymentOperationStep> getUndeploymentSteps() {
-    return Arrays.asList(
+    return List.of(
       new PreUndeployInvocationStep(),
       new UndeployProcessArchivesStep(),
       new ProcessesXmlStopProcessEnginesStep(),

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ActivityExecutionTreeMapping.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ActivityExecutionTreeMapping.java
@@ -73,7 +73,7 @@ public class ActivityExecutionTreeMapping {
   }
 
   protected ExecutionEntity intersect(Set<ExecutionEntity> executions, String[] executionIds) {
-    Set<String> executionIdSet = new HashSet<>(Arrays.asList(executionIds));
+    Set<String> executionIdSet = new HashSet<>(List.of(executionIds));
 
     return executions.stream()
       .filter(execution -> executionIdSet.contains(execution.getId()))

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl;
 
 import java.io.Serial;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -105,9 +104,9 @@ public class AuthorizationQueryImpl extends AbstractQuery<AuthorizationQuery, Au
     queryByPermission = true;
 
     if (resourcesIntersection.isEmpty()) {
-      resourcesIntersection.addAll(Arrays.asList(p.getTypes()));
+      resourcesIntersection.addAll(List.of(p.getTypes()));
     } else {
-      resourcesIntersection.retainAll(new HashSet<>(Arrays.asList(p.getTypes())));
+      resourcesIntersection.retainAll(new HashSet<>(List.of(p.getTypes())));
     }
 
     this.permission |= p.getValue();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl;
 
 import java.io.Serial;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -879,7 +878,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   @Override
   public HistoricProcessInstanceQuery executedActivityIdIn(String... ids) {
     ensureNotNull(BadUserRequestException.class, "activity ids", (Object[]) ids);
-    ensureNotContainsNull(BadUserRequestException.class, "activity ids", Arrays.asList(ids));
+    ensureNotContainsNull(BadUserRequestException.class, "activity ids", List.of(ids));
     this.executedActivityIds = ids;
     return this;
   }
@@ -887,7 +886,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   @Override
   public HistoricProcessInstanceQuery activeActivityIdIn(String... ids) {
     ensureNotNull(BadUserRequestException.class, "activity ids", (Object[]) ids);
-    ensureNotContainsNull(BadUserRequestException.class, "activity ids", Arrays.asList(ids));
+    ensureNotContainsNull(BadUserRequestException.class, "activity ids", List.of(ids));
     this.activeActivityIds = ids;
     return this;
   }
@@ -895,7 +894,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   @Override
   public HistoricProcessInstanceQuery activityIdIn(String... ids) {
     ensureNotNull(BadUserRequestException.class, "activity ids", (Object[]) ids);
-    ensureNotContainsNull(BadUserRequestException.class, "activity ids", Arrays.asList(ids));
+    ensureNotContainsNull(BadUserRequestException.class, "activity ids", List.of(ids));
     this.activityIds = ids;
     return this;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceReportImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceReportImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -138,7 +137,7 @@ public class HistoricProcessInstanceReportImpl implements HistoricProcessInstanc
     List<String> processDefinitionKeys = new ArrayList<>();
 
     if (processDefinitionKeyIn != null) {
-      processDefinitionKeys.addAll(Arrays.asList(processDefinitionKeyIn));
+      processDefinitionKeys.addAll(List.of(processDefinitionKeyIn));
     }
 
     if (processDefinitionIdIn != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl;
 
 import java.io.Serial;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -98,7 +97,7 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   @Override
   public HistoricVariableInstanceQuery variableNameIn(String... names) {
     ensureNotNull("Variable names", (Object[]) names);
-    variableNameIn = Arrays.asList(names);
+    variableNameIn = List.of(names);
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/MessageCorrelationBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/MessageCorrelationBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -300,7 +299,7 @@ public class MessageCorrelationBuilderImpl implements MessageCorrelationBuilder 
       ensureProcessDefinitionAndTenantIdNotSet();
       // only one result can be expected
       MessageCorrelationResult result = execute(new CorrelateMessageCmd(this, false, false, startMessagesOnly));
-      return Arrays.asList(result);
+      return List.of(result);
     } else {
       ensureProcessDefinitionIdNotSet();
       ensureProcessInstanceAndTenantIdNotSet();
@@ -315,7 +314,7 @@ public class MessageCorrelationBuilderImpl implements MessageCorrelationBuilder 
       ensureProcessDefinitionAndTenantIdNotSet();
       // only one result can be expected
       MessageCorrelationResultWithVariables result = execute(new CorrelateMessageCmd(this, true, deserializeValues, startMessagesOnly));
-      return Arrays.asList(result);
+      return List.of(result);
     } else {
       ensureProcessDefinitionIdNotSet();
       ensureProcessInstanceAndTenantIdNotSet();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ModificationBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ModificationBuilderImpl.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
@@ -100,7 +101,7 @@ public class ModificationBuilderImpl implements ModificationBuilder {
   }
 
   @Override
-  public ModificationBuilder processInstanceIds(String... processInstanceIds) {
+  public ModificationBuilder processInstanceIds(@Nullable String... processInstanceIds) {
     if (processInstanceIds == null) {
       this.processInstanceIds = Collections.emptyList();
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/RestartProcessInstanceBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/RestartProcessInstanceBuilderImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
@@ -101,7 +102,7 @@ public class RestartProcessInstanceBuilderImpl implements RestartProcessInstance
   }
 
   @Override
-  public RestartProcessInstanceBuilder processInstanceIds(String... processInstanceIds) {
+  public RestartProcessInstanceBuilder processInstanceIds(@Nullable String... processInstanceIds) {
     this.processInstanceIds.addAll(Arrays.asList(processInstanceIds));
     return this;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/SingleQueryVariableValueCondition.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/SingleQueryVariableValueCondition.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,7 +68,7 @@ public class SingleQueryVariableValueCondition extends AbstractQueryVariableValu
     serializer.writeValue(typedValue, this);
     this.type = serializer.getName();
     if (ValueType.STRING.getName().equals(type) && DbSqlSessionFactory.ORACLE.equals(dbType)
-            && ("".equals(textValue)  && Arrays.asList(EQUALS, NOT_EQUALS).contains(wrappedQueryValue.getOperator()))) {
+            && ("".equals(textValue)  && List.of(EQUALS, NOT_EQUALS).contains(wrappedQueryValue.getOperator()))) {
       this.findNulledEmptyStrings = true;
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl;
 
 import java.io.Serial;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -292,7 +291,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     ensureNotNull("Assignees", assignees);
 
     Set<String> assigneeInIds = new HashSet<>(assignees.length);
-    assigneeInIds.addAll(Arrays.asList(assignees));
+    assigneeInIds.addAll(List.of(assignees));
 
     this.assigneeIn = assigneeInIds;
     expressions.remove("taskAssigneeIn");
@@ -305,7 +304,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     ensureNotNull("Assignees", assignees);
 
     Set<String> assigneeNotInIds = new HashSet<>(assignees.length);
-    assigneeNotInIds.addAll(Arrays.asList(assignees));
+    assigneeNotInIds.addAll(List.of(assignees));
 
     this.assigneeNotIn = assigneeNotInIds;
     expressions.remove("taskAssigneeNotIn");

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ant/DeployBarTask.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ant/DeployBarTask.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.impl.ant;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipInputStream;
 
@@ -72,7 +71,7 @@ public class DeployBarTask extends Task {
       File baseDir = directoryScanner.getBasedir();
       String[] includedFiles = directoryScanner.getIncludedFiles();
       String[] excludedFiles = directoryScanner.getExcludedFiles();
-      List<String> excludedFilesList = Arrays.asList(excludedFiles);
+      List<String> excludedFilesList = List.of(excludedFiles);
 
       for (String includedFile : includedFiles) {
         if (!excludedFilesList.contains(includedFile)) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.impl.Condition;
@@ -94,7 +93,7 @@ public class BpmnActivityBehavior {
     if (transitionsToTake.size() == 1) {
       execution.leaveActivityViaTransition(transitionsToTake.get(0));
     } else if (!transitionsToTake.isEmpty()) {
-      execution.leaveActivityViaTransitions(transitionsToTake, Arrays.asList(execution));
+      execution.leaveActivityViaTransitions(transitionsToTake, List.of(execution));
     } else {
       handleNoTransitions(execution, defaultSequenceFlow, outgoingTransitions);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -241,7 +241,7 @@ public class BpmnParse extends Parse {
   public static final String CONDITION_EXPRESSION = "conditionExpression";
   public static final String CONDITION = "condition";
 
-  private static final List<String> VARIABLE_EVENTS = Arrays.asList(
+  private static final List<String> VARIABLE_EVENTS = List.of(
       VariableListener.CREATE,
       VariableListener.DELETE,
       VariableListener.UPDATE
@@ -998,7 +998,7 @@ public class BpmnParse extends Parse {
         parseExecutionListenersOnScope(startEventElement, startEventActivity);
       }
     } else {
-      if (Arrays.asList(PROCESS_TAG, SUB_PROCESS_TAG).contains(parentElement.getTagName())) {
+      if (List.of(PROCESS_TAG, SUB_PROCESS_TAG).contains(parentElement.getTagName())) {
         addError(parentElement.getTagName() + " must define a startEvent element", parentElement);
       }
     }
@@ -1019,7 +1019,7 @@ public class BpmnParse extends Parse {
   protected void selectInitial(List<ActivityImpl> startEventActivities, ProcessDefinitionEntity processDefinition, Element parentElement) {
     ActivityImpl initial = null;
     // validate that there is s single none start event / timer start event:
-    List<String> exclusiveStartEventTypes = Arrays.asList("startEvent", "startTimerEvent");
+    List<String> exclusiveStartEventTypes = List.of("startEvent", "startTimerEvent");
 
     for (ActivityImpl activityImpl : startEventActivities) {
       if (exclusiveStartEventTypes.contains(activityImpl.getProperty(BpmnProperties.TYPE.name()))) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/DurationHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/DurationHelper.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.calendar;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -74,7 +73,7 @@ public class DurationHelper {
   private List<String> initExpressions(String inputExpressions) {
     List<String> expressions = new ArrayList<>();
     if(inputExpressions != null) {
-      expressions = Arrays.asList(inputExpressions.split("/"));
+      expressions = List.of(inputExpressions.split("/"));
     }
     return expressions;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CompositeProcessEnginePlugin.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CompositeProcessEnginePlugin.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.cfg;
 
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -129,7 +128,7 @@ public class CompositeProcessEnginePlugin extends AbstractProcessEnginePlugin {
     final List<ProcessEnginePlugin> plugins = new ArrayList<>();
     plugins.add(plugin);
     if (additionalPlugins != null && additionalPlugins.length > 0) {
-      plugins.addAll(Arrays.asList(additionalPlugins));
+      plugins.addAll(List.of(additionalPlugins));
     }
     return plugins;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractProcessInstanceModificationCommand.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractProcessInstanceModificationCommand.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.jspecify.annotations.NonNull;
@@ -166,7 +166,7 @@ public abstract class AbstractProcessInstanceModificationCommand implements Comm
     ScopeImpl scope = getScopeForActivityInstance(processDefinition, activityInstance);
 
     Set<ExecutionEntity> executions = mapping.getExecutions(scope);
-    Set<String> activityInstanceExecutions = new HashSet<>(Arrays.asList(activityInstance.getExecutionIds()));
+    Set<String> activityInstanceExecutions = new HashSet<>(List.of(activityInstance.getExecutionIds()));
 
     for (String activityInstanceExecutionId : activityInstance.getExecutionIds()) {
       CommandContext commandContext = requireNonNull(Context.getCommandContext());

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.jspecify.annotations.NullMarked;
@@ -178,7 +178,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd extends AbstractSetSt
         getLogEntryOperation(),
         processDefinitionId,
         processDefinitionKey,
-        Arrays.asList(suspensionStateChanged, includeProcessInstances)
+        List.of(suspensionStateChanged, includeProcessInstances)
       );
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteDeploymentCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteDeploymentCmd.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,7 +70,7 @@ public class DeleteDeploymentCmd implements Command<Void> {
     }
 
     UserOperationLogManager logManager = commandContext.getOperationLogManager();
-    List<PropertyChange> propertyChanges = Arrays.asList(new PropertyChange("cascade", null, cascade));
+    List<PropertyChange> propertyChanges = List.of(new PropertyChange("cascade", null, cascade));
     DeploymentEntity deployment = commandContext.getDeploymentManager().findDeploymentById(deploymentId);
     String tenantId = deployment != null ? deployment.getTenantId() : null;
     logManager.logDeploymentOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE, deploymentId, tenantId, propertyChanges);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstanceCmd.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.history.HistoricCaseInstance;
@@ -66,7 +66,7 @@ public @NullMarked class DeleteHistoricCaseInstanceCmd implements Command<Object
 
     commandContext
       .getHistoricCaseInstanceManager()
-      .deleteHistoricCaseInstancesByIds(Arrays.asList(caseInstanceId));
+      .deleteHistoricCaseInstancesByIds(List.of(caseInstanceId));
 
     return null;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricVariableInstancesByProcessInstanceIdCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricVariableInstancesByProcessInstanceIdCmd.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.BadUserRequestException;
@@ -58,8 +58,8 @@ public @NullMarked class DeleteHistoricVariableInstancesByProcessInstanceIdCmd i
       checker.checkDeleteHistoricVariableInstancesByProcessInstance(instance);
     }
 
-    commandContext.getHistoricDetailManager().deleteHistoricDetailsByProcessInstanceIds(Arrays.asList(processInstanceId));
-    commandContext.getHistoricVariableInstanceManager().deleteHistoricVariableInstanceByProcessInstanceIds(Arrays.asList(processInstanceId));
+    commandContext.getHistoricDetailManager().deleteHistoricDetailsByProcessInstanceIds(List.of(processInstanceId));
+    commandContext.getHistoricVariableInstanceManager().deleteHistoricVariableInstanceByProcessInstanceIds(List.of(processInstanceId));
 
     // create user operation log
     ResourceDefinitionEntity<?> definition = null;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/UpdateExternalTaskRetriesBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/UpdateExternalTaskRetriesBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.cmd;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -67,7 +66,7 @@ public @NullMarked class UpdateExternalTaskRetriesBuilderImpl implements UpdateE
       this.externalTaskIds = Collections.emptyList();
     }
     else {
-      this.externalTaskIds = Arrays.asList(externalTaskIds);
+      this.externalTaskIds = List.of(externalTaskIds);
     }
     return this;
   }
@@ -84,7 +83,7 @@ public @NullMarked class UpdateExternalTaskRetriesBuilderImpl implements UpdateE
       this.processInstanceIds = Collections.emptyList();
     }
     else {
-      this.processInstanceIds = Arrays.asList(processInstanceIds);
+      this.processInstanceIds = List.of(processInstanceIds);
     }
     return this;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/behavior/PlanItemDefinitionActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/behavior/PlanItemDefinitionActivityBehavior.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.cmmn.behavior;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -211,7 +210,7 @@ public abstract class PlanItemDefinitionActivityBehavior implements CmmnActivity
       CmmnActivityExecution parent = execution.getParent();
 
       // instantiate a new instance of given activity
-      List<CmmnExecution> children = parent.createChildExecutions(Arrays.asList(activity));
+      List<CmmnExecution> children = parent.createChildExecutions(List.of(activity));
       // start the lifecycle of the new instance
       parent.triggerChildExecutionsLifecycle(children);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
@@ -721,7 +721,7 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
   @Override
   @SuppressWarnings({ "unchecked", "rawtypes" })
   protected List<VariableInstanceLifecycleListener<CoreVariableInstance>> getVariableInstanceLifecycleListeners() {
-    return Arrays.asList((VariableInstanceLifecycleListener) VARIABLE_INSTANCE_ENTITY_PERSISTENCE_LISTENER,
+    return List.of((VariableInstanceLifecycleListener) VARIABLE_INSTANCE_ENTITY_PERSISTENCE_LISTENER,
         (VariableInstanceLifecycleListener) VARIABLE_INSTANCE_SEQUENCE_COUNTER_LISTENER,
         (VariableInstanceLifecycleListener) VARIABLE_INSTANCE_HISTORY_LISTENER,
         (VariableInstanceLifecycleListener) CMMN_VARIABLE_INVOCATION_LISTENER,
@@ -771,7 +771,7 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
 
     for (VariableInstanceEntity variableInstance : variableStore.getVariables()) {
       invokeVariableLifecycleListenersDelete(variableInstance, this,
-          Arrays.asList((VariableInstanceLifecycleListener) VARIABLE_INSTANCE_ENTITY_PERSISTENCE_LISTENER));
+          List.of((VariableInstanceLifecycleListener) VARIABLE_INSTANCE_ENTITY_PERSISTENCE_LISTENER));
       variableStore.removeVariable(variableInstance.getName());
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionManager.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.cmmn.entity.runtime;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.BadUserRequestException;
@@ -82,7 +81,7 @@ public class CaseExecutionManager extends AbstractManager {
       Context
         .getCommandContext()
         .getHistoricCaseInstanceManager()
-        .deleteHistoricCaseInstancesByIds(Arrays.asList(caseInstanceId));
+        .deleteHistoricCaseInstancesByIds(List.of(caseInstanceId));
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/ItemHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/ItemHandler.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.cmmn.handler;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -92,11 +91,11 @@ public abstract @NullMarked class ItemHandler extends CmmnElementHandler<CmmnEle
 
   protected static final String PARENT_COMPLETE = "parentComplete";
 
-  public static final List<String> TASK_OR_STAGE_CREATE_EVENTS = Arrays.asList(
+  public static final List<String> TASK_OR_STAGE_CREATE_EVENTS = List.of(
       CaseExecutionListener.CREATE
     );
 
-  public static final List<String> TASK_OR_STAGE_UPDATE_EVENTS = Arrays.asList(
+  public static final List<String> TASK_OR_STAGE_UPDATE_EVENTS = List.of(
       CaseExecutionListener.ENABLE,
       CaseExecutionListener.DISABLE,
       CaseExecutionListener.RE_ENABLE,
@@ -108,7 +107,7 @@ public abstract @NullMarked class ItemHandler extends CmmnElementHandler<CmmnEle
       CaseExecutionListener.PARENT_RESUME
     );
 
-  public static final List<String> TASK_OR_STAGE_END_EVENTS = Arrays.asList(
+  public static final List<String> TASK_OR_STAGE_END_EVENTS = List.of(
       CaseExecutionListener.TERMINATE,
       CaseExecutionListener.EXIT,
       CaseExecutionListener.COMPLETE,
@@ -117,16 +116,16 @@ public abstract @NullMarked class ItemHandler extends CmmnElementHandler<CmmnEle
 
   public static final List<String> TASK_OR_STAGE_EVENTS = new ArrayList<>();
 
-  public static final List<String> EVENT_LISTENER_OR_MILESTONE_CREATE_EVENTS = Arrays.asList(
+  public static final List<String> EVENT_LISTENER_OR_MILESTONE_CREATE_EVENTS = List.of(
       CaseExecutionListener.CREATE
     );
 
-  public static final List<String> EVENT_LISTENER_OR_MILESTONE_UPDATE_EVENTS = Arrays.asList(
+  public static final List<String> EVENT_LISTENER_OR_MILESTONE_UPDATE_EVENTS = List.of(
       CaseExecutionListener.SUSPEND,
       CaseExecutionListener.RESUME
     );
 
-  public static final List<String> EVENT_LISTENER_OR_MILESTONE_END_EVENTS = Arrays.asList(
+  public static final List<String> EVENT_LISTENER_OR_MILESTONE_END_EVENTS = List.of(
       CaseExecutionListener.TERMINATE,
       CaseExecutionListener.PARENT_TERMINATE,
       CaseExecutionListener.OCCUR,
@@ -135,24 +134,24 @@ public abstract @NullMarked class ItemHandler extends CmmnElementHandler<CmmnEle
 
   public static final List<String> EVENT_LISTENER_OR_MILESTONE_EVENTS = new ArrayList<>();
 
-  public static final List<String> CASE_PLAN_MODEL_CREATE_EVENTS = Arrays.asList(
+  public static final List<String> CASE_PLAN_MODEL_CREATE_EVENTS = List.of(
       CaseExecutionListener.CREATE
     );
 
-  public static final List<String> CASE_PLAN_MODEL_UPDATE_EVENTS = Arrays.asList(
+  public static final List<String> CASE_PLAN_MODEL_UPDATE_EVENTS = List.of(
       CaseExecutionListener.TERMINATE,
       CaseExecutionListener.SUSPEND,
       CaseExecutionListener.COMPLETE,
       CaseExecutionListener.RE_ACTIVATE
     );
 
-  public static final List<String> CASE_PLAN_MODEL_CLOSE_EVENTS = Arrays.asList(
+  public static final List<String> CASE_PLAN_MODEL_CLOSE_EVENTS = List.of(
       CaseExecutionListener.CLOSE
     );
 
   public static final List<String> CASE_PLAN_MODEL_EVENTS = new ArrayList<>();
 
-  public static final List<String> DEFAULT_VARIABLE_EVENTS = Arrays.asList(
+  public static final List<String> DEFAULT_VARIABLE_EVENTS = List.of(
       VariableListener.CREATE,
       VariableListener.DELETE,
       VariableListener.UPDATE
@@ -340,10 +339,10 @@ public abstract @NullMarked class ItemHandler extends CmmnElementHandler<CmmnEle
       CaseControlRule caseRule = initializeCaseControlRule(condition, context);
       activity.setProperty(PROPERTY_REPETITION_RULE, caseRule);
 
-      List<String> events = Arrays.asList(TERMINATE, COMPLETE);
+      List<String> events = List.of(TERMINATE, COMPLETE);
       String repeatOnStandardEvent = repetitionRule.getOperatonRepeatOnStandardEvent();
       if (repeatOnStandardEvent != null && !repeatOnStandardEvent.isEmpty()) {
-        events = Arrays.asList(repeatOnStandardEvent);
+        events = List.of(repeatOnStandardEvent);
       }
       activity.getProperties().set(CmmnProperties.REPEAT_ON_STANDARD_EVENTS, events);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/scope/VariableStore.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/scope/VariableStore.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.core.variable.scope;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,7 +50,7 @@ public class VariableStore<T extends CoreVariableInstance> {
   public VariableStore(VariablesProvider<T> provider, VariableStoreObserver<T>... observers) {
     this.variablesProvider = provider;
     this.observers = new ArrayList<>();
-    this.observers.addAll(Arrays.asList(observers));
+    this.observers.addAll(List.of(observers));
   }
 
   /**

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -216,7 +216,7 @@ public class DbSqlSessionFactory implements SessionFactory {
 
     // mysql specific
     // use the same specific for mariadb since it based on mysql and work with the exactly same statements
-    for(String mysqlLikeDatabase : Arrays.asList(MYSQL, MARIADB)) {
+    for(String mysqlLikeDatabase : List.of(MYSQL, MARIADB)) {
 
       databaseSpecificLimitBeforeStatements.put(mysqlLikeDatabase, "");
       optimizeDatabaseSpecificLimitBeforeWithoutOffsetStatements.put(mysqlLikeDatabase, "");

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/DeleteHistoricDecisionInstanceByInstanceIdCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/DeleteHistoricDecisionInstanceByInstanceIdCmd.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.dmn.cmd;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.history.HistoricDecisionInstance;
@@ -63,7 +62,7 @@ public class DeleteHistoricDecisionInstanceByInstanceIdCmd implements Command<Ob
 
     commandContext
         .getHistoricDecisionInstanceManager()
-        .deleteHistoricDecisionInstanceByIds(Arrays.asList(historicDecisionInstanceId));
+        .deleteHistoricDecisionInstanceByIds(List.of(historicDecisionInstanceId));
 
     return null;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/externaltask/ExternalTaskQueryTopicBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/externaltask/ExternalTaskQueryTopicBuilderImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.externaltask;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,10 +120,10 @@ public class ExternalTaskQueryTopicBuilderImpl implements ExternalTaskQueryTopic
 
   @Override
   public ExternalTaskQueryTopicBuilder variables(String... variables) {
-    // don't use plain Arrays.asList since this returns an instance of a different list class
+    // don't use plain List.of since this returns an instance of a different list class
     // that is private and may mess mybatis queries up
     if (variables != null) {
-      currentInstruction.setVariablesToFetch(new ArrayList<>(Arrays.asList(variables)));
+      currentInstruction.setVariablesToFetch(new ArrayList<>(List.of(variables)));
     }
     return this;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/handler/DefaultFormHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/handler/DefaultFormHandler.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.form.handler;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ public class DefaultFormHandler implements FormHandler {
   public static final String FORM_REF_BINDING_DEPLOYMENT = "deployment";
   public static final String FORM_REF_BINDING_LATEST = "latest";
   public static final String FORM_REF_BINDING_VERSION = "version";
-  public static final List<String> ALLOWED_FORM_REF_BINDINGS = Arrays.asList(FORM_REF_BINDING_DEPLOYMENT, FORM_REF_BINDING_LATEST, FORM_REF_BINDING_VERSION);
+  public static final List<String> ALLOWED_FORM_REF_BINDINGS = List.of(FORM_REF_BINDING_DEPLOYMENT, FORM_REF_BINDING_LATEST, FORM_REF_BINDING_VERSION);
 
   protected String deploymentId;
   protected String businessKeyFieldId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricBatchesBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricBatchesBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.history;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -56,7 +55,7 @@ public class SetRemovalTimeToHistoricBatchesBuilderImpl implements SetRemovalTim
 
   @Override
   public SetRemovalTimeToHistoricBatchesBuilder byIds(String... ids) {
-    this.ids = ids != null ? Arrays.asList(ids) : null;
+    this.ids = ids != null ? List.of(ids) : null;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricDecisionInstancesBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricDecisionInstancesBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.history;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -56,7 +55,7 @@ public class SetRemovalTimeToHistoricDecisionInstancesBuilderImpl implements Set
 
   @Override
   public SetRemovalTimeToHistoricDecisionInstancesBuilder byIds(String... ids) {
-    this.ids = ids !=  null ? Arrays.asList(ids) : null;
+    this.ids = ids !=  null ? List.of(ids) : null;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricProcessInstancesBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricProcessInstancesBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.history;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -58,7 +57,7 @@ public class SetRemovalTimeToHistoricProcessInstancesBuilderImpl implements SetR
 
   @Override
   public SetRemovalTimeToHistoricProcessInstancesBuilder byIds(String... ids) {
-    this.ids = ids !=  null ? Arrays.asList(ids) : null;
+    this.ids = ids !=  null ? List.of(ids) : null;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandler.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.incident;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -58,7 +57,7 @@ public class CompositeIncidentHandler implements IncidentHandler {
    */
   public CompositeIncidentHandler(IncidentHandler mainIncidentHandler, final IncidentHandler... incidentHandlers) {
     EnsureUtil.ensureNotNull("Incident handlers", (Object[]) incidentHandlers);
-    initializeIncidentsHandlers(mainIncidentHandler, Arrays.asList(incidentHandlers));
+    initializeIncidentsHandlers(mainIncidentHandler, List.of(incidentHandlers));
   }
 
   /**

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/MigrationPlanExecutionBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/MigrationPlanExecutionBuilderImpl.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.impl.interceptor.CommandExecutor;
 import org.operaton.bpm.engine.impl.migration.batch.MigrateProcessInstanceBatchCmd;
@@ -52,7 +53,7 @@ public class MigrationPlanExecutionBuilderImpl implements MigrationPlanExecution
   }
 
   @Override
-  public MigrationPlanExecutionBuilder processInstanceIds(String... processInstanceIds) {
+  public MigrationPlanExecutionBuilder processInstanceIds(@Nullable String @Nullable... processInstanceIds) {
     if (processInstanceIds == null) {
       this.processInstanceIds = Collections.emptyList();
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/parser/EventSubscriptionInstanceHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/parser/EventSubscriptionInstanceHandler.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.migration.instance.parser;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -38,7 +37,7 @@ import org.operaton.bpm.engine.migration.MigrationInstruction;
  */
 public class EventSubscriptionInstanceHandler implements MigratingDependentInstanceParseHandler<MigratingActivityInstance, List<EventSubscriptionEntity>> {
 
-  private static final Set<String> SUPPORTED_EVENT_TYPES = new HashSet<>(Arrays.asList(EventType.MESSAGE.name(), EventType.SIGNAL.name(), EventType.CONDITONAL.name()));
+  private static final Set<String> SUPPORTED_EVENT_TYPES = Set.of(EventType.MESSAGE.name(), EventType.SIGNAL.name(), EventType.CONDITONAL.name());
 
   @Override
   public void handle(MigratingInstanceParseContext parseContext, MigratingActivityInstance owningInstance, List<EventSubscriptionEntity> elements) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.persistence.entity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -324,7 +323,7 @@ public class AuthorizationManager extends AbstractManager {
 
   protected CompositePermissionCheck createCompositePermissionCheck(PermissionCheck permissionCheck) {
     CompositePermissionCheck compositePermissionCheck = new CompositePermissionCheck();
-    compositePermissionCheck.setAtomicChecks(Arrays.asList(permissionCheck));
+    compositePermissionCheck.setAtomicChecks(List.of(permissionCheck));
     return compositePermissionCheck;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/DeploymentManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/DeploymentManager.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.authorization.Resources;
@@ -112,7 +111,7 @@ public class DeploymentManager extends AbstractManager {
       // in a transaction! We have to set the instances flag to false.
       final CommandContext commandContext = Context.getCommandContext();
       commandContext.runWithoutAuthorization(new DeleteProcessDefinitionsByIdsCmd(
-              Arrays.asList(processDefinitionId),
+              List.of(processDefinitionId),
               cascade,
               false,
               skipCustomListeners,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionManager.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +91,7 @@ public class ExecutionManager extends AbstractManager {
     execution.deleteCascade(deleteReason, skipCustomListeners, skipIoMappings, externallyTerminated, skipSubprocesses);
 
     if (cascade) {
-      getHistoricProcessInstanceManager().deleteHistoricProcessInstanceByIds(Arrays.asList(processInstanceId));
+      getHistoricProcessInstanceManager().deleteHistoricProcessInstanceByIds(List.of(processInstanceId));
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -94,7 +94,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   private static final VariableInstanceFactory VARIABLE_INSTANCE_FACTORY = new VariableInstanceEntityFactory();
 
   protected static final List<VariableInstanceLifecycleListener<CoreVariableInstance>> DEFAULT_VARIABLE_LIFECYCLE_LISTENERS =
-      Arrays.asList(
+      List.of(
           (VariableInstanceLifecycleListener) VARIABLE_INSTANCE_ENTITY_PERSISTENCE_LISTENER,
           (VariableInstanceLifecycleListener) VARIABLE_INSTANCE_SEQUENCE_COUNTER_LISTENER,
           (VariableInstanceLifecycleListener) VARIABLE_INSTANCE_HISTORY_LISTENER

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.persistence.entity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -259,7 +258,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
       UserOperationLogContextEntryBuilder entryBuilder =
           UserOperationLogContextEntryBuilder.entry(operation, EntityTypes.IDENTITY_LINK)
             .category(UserOperationLogEntry.CATEGORY_TASK_WORKER)
-            .inContextOf(task, Arrays.asList(propertyChange));
+            .inContextOf(task, List.of(propertyChange));
 
       context.addEntry(entryBuilder.create());
       fireUserOperationLog(context);
@@ -488,7 +487,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
       UserOperationLogContextEntryBuilder entryBuilder =
           UserOperationLogContextEntryBuilder.entry(operation, EntityTypes.ATTACHMENT)
             .category(UserOperationLogEntry.CATEGORY_TASK_WORKER)
-            .inContextOf(task, Arrays.asList(propertyChange));
+            .inContextOf(task, List.of(propertyChange));
       context.addEntry(entryBuilder.create());
 
       fireUserOperationLog(context);
@@ -502,7 +501,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
       UserOperationLogContextEntryBuilder entryBuilder =
           UserOperationLogContextEntryBuilder.entry(operation, EntityTypes.ATTACHMENT)
             .category(UserOperationLogEntry.CATEGORY_TASK_WORKER)
-            .inContextOf(processInstance, Arrays.asList(propertyChange));
+            .inContextOf(processInstance, List.of(propertyChange));
       context.addEntry(entryBuilder.create());
 
       fireUserOperationLog(context);
@@ -553,7 +552,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
       }
       else if (taskId != null) {
         TaskEntity task = getTaskManager().findTaskById(taskId);
-        entryBuilder.inContextOf(task, Arrays.asList(propertyChange))
+        entryBuilder.inContextOf(task, List.of(propertyChange))
           .category(UserOperationLogEntry.CATEGORY_TASK_WORKER);
       }
 
@@ -571,7 +570,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
           UserOperationLogContextEntryBuilder.entry(operation, EntityTypes.VARIABLE)
             .category(UserOperationLogEntry.CATEGORY_OPERATOR)
             .propertyChanges(propertyChange)
-            .inContextOf(historicProcessInstance, definition, Arrays.asList(propertyChange));
+            .inContextOf(historicProcessInstance, definition, List.of(propertyChange));
 
       context.addEntry(entryBuilder.create());
       fireUserOperationLog(context);
@@ -587,7 +586,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
           UserOperationLogContextEntryBuilder.entry(operation, EntityTypes.VARIABLE)
             .category(UserOperationLogEntry.CATEGORY_OPERATOR)
             .propertyChanges(propertyChange)
-            .inContextOf(historicVariableInstance, definition, Arrays.asList(propertyChange));
+            .inContextOf(historicVariableInstance, definition, List.of(propertyChange));
 
       context.addEntry(entryBuilder.create());
       fireUserOperationLog(context);
@@ -809,7 +808,7 @@ public class UserOperationLogManager extends AbstractHistoricManager {
     if (namesForPermissions.length == 0) {
       return Permissions.NONE.getName();
     }
-    return StringUtil.trimToMaximumLengthAllowed(StringUtil.join(Arrays.asList(namesForPermissions).iterator()));
+    return StringUtil.trimToMaximumLengthAllowed(StringUtil.join(List.of(namesForPermissions).iterator()));
   }
 
   protected String getResourceName(int resourceType) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
@@ -1007,7 +1007,7 @@ public abstract class PvmExecutionImpl extends CoreExecution implements
 
   @Override
   public void leaveActivityViaTransition(PvmTransition outgoingTransition) {
-    leaveActivityViaTransitions(Arrays.asList(outgoingTransition), Collections.emptyList());
+    leaveActivityViaTransitions(List.of(outgoingTransition), Collections.emptyList());
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/DefaultDeserializationTypeValidator.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/DefaultDeserializationTypeValidator.java
@@ -16,10 +16,9 @@
  */
 package org.operaton.bpm.engine.impl.runtime;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.operaton.bpm.engine.runtime.WhitelistingDeserializationTypeValidator;
@@ -32,11 +31,11 @@ import org.operaton.bpm.engine.runtime.WhitelistingDeserializationTypeValidator;
  */
 public class DefaultDeserializationTypeValidator implements WhitelistingDeserializationTypeValidator {
 
-  protected static final Collection<String> ALLOWED_PACKAGES = Arrays.asList("java.lang");
-  protected static final Collection<String> ALLOWED_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+  protected static final Collection<String> ALLOWED_PACKAGES = List.of("java.lang");
+  protected static final Collection<String> ALLOWED_CLASSES = Set.of(
       "java.util.ArrayList", "java.util.Arrays$ArrayList", "java.util.HashMap", "java.util.HashSet",
       "java.util.LinkedHashMap", "java.util.LinkedHashSet", "java.util.LinkedList",
-      "java.util.Properties", "java.util.TreeMap", "java.util.TreeSet")));
+      "java.util.Properties", "java.util.TreeMap", "java.util.TreeSet");
 
   protected Set<String> allowedClasses = new HashSet<>(ALLOWED_CLASSES);
   protected Set<String> allowedPackages = new HashSet<>(ALLOWED_PACKAGES);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/JuelScriptEngineFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/JuelScriptEngineFactory.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.scripting.engine;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,15 +32,9 @@ import org.jspecify.annotations.Nullable;
  */
 public class JuelScriptEngineFactory implements ScriptEngineFactory {
 
-  private static final List<String> names;
-  private static final List<String> extensions;
-  private static final List<String> mimeTypes;
-
-  static {
-    names = Collections.unmodifiableList(Arrays.asList("juel"));
-    extensions = names;
-    mimeTypes = Collections.unmodifiableList(new ArrayList<String>(0));
-  }
+  private static final List<String> names = List.of("juel");
+  private static final List<String> extensions = names;
+  private static final List<String> mimeTypes = List.of();
 
   @Override
   public String getEngineName() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
@@ -16,10 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.scripting.engine;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +61,7 @@ public class ScriptBindings implements Bindings {
    * </p>
    */
   protected static final Set<String> UNSTORED_KEYS =
-    new HashSet<>(Arrays.asList(
+    Set.of(
       "out",
       "out:print",
       "lang:import",
@@ -78,7 +76,7 @@ public class ScriptBindings implements Bindings {
       "execution",
       "__doc__", // do not export python doc string
       "__builtins__" // python built-in functions
-      ));
+      );
 
   protected List<Resolver> scriptResolvers;
   protected VariableScope variableScope;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/task/TaskDecorator.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/task/TaskDecorator.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.impl.task;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -205,7 +204,7 @@ public class TaskDecorator {
   protected List<String> extractCandidates(String str) {
     String[] parts = str.split(",\\s*+", -1);
     if (parts.length == 1) {
-      return Arrays.asList(parts);
+      return List.of(parts);
     }
     List<String> result = new ArrayList<>(parts.length);
     for (int i = 0; i < parts.length - 1; i++) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/JsonUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/JsonUtil.java
@@ -69,7 +69,7 @@ public final class JsonUtil {
 
   public static void addArrayField(@Nullable JsonObject jsonObject, @Nullable String name, String @Nullable[] array) {
     if (jsonObject != null && name != null && array != null) {
-      addListField(jsonObject, name, Arrays.asList(array));
+      addListField(jsonObject, name, List.of(array));
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -103,7 +103,7 @@ public final class ParseUtil {
           return null;
         }
       }
-      return new FailedJobRetryConfiguration(retries, Arrays.asList(intervals));
+      return new FailedJobRetryConfiguration(retries, List.of(intervals));
     } else {
       return null;
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
@@ -373,7 +373,7 @@ public final class ReflectUtil {
   public static Object instantiate(String className, Object[] args) {
     Class<?> clazz = loadClass(className);
     Constructor<?> constructor = findMatchingConstructor(clazz, args);
-    ensureNotNull("couldn't find constructor for '%s' with args %s".formatted(className, Arrays.asList(args)), "constructor", constructor);
+    ensureNotNull("couldn't find constructor for '%s' with args %s".formatted(className, List.of(args)), "constructor", constructor);
     try {
       return constructor.newInstance(args);
     } catch (Exception e) {

--- a/engine/src/main/java/org/operaton/bpm/engine/migration/MigrationPlanExecutionBuilder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/migration/MigrationPlanExecutionBuilder.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.migration;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.authorization.BatchPermissions;
@@ -39,7 +40,7 @@ public interface MigrationPlanExecutionBuilder {
   /**
    * @param processInstanceIds the process instance ids to migrate.
    */
-  MigrationPlanExecutionBuilder processInstanceIds(String... processInstanceIds);
+  MigrationPlanExecutionBuilder processInstanceIds(@Nullable String @Nullable... processInstanceIds);
 
   /**
    * @param processInstanceQuery a query which selects the process instances to migrate.

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -67,7 +66,7 @@ public abstract class TestHelper {
 
   public static final String EMPTY_LINE = "                                                                                           ";
 
-  public static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList(
+  public static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = List.of(
     "ACT_GE_PROPERTY",
     "ACT_GE_SCHEMA_LOG"
   );
@@ -75,9 +74,9 @@ public abstract class TestHelper {
   public static final List<String> RESOURCE_SUFFIXES = new ArrayList<>();
 
   static {
-    RESOURCE_SUFFIXES.addAll(Arrays.asList(BPMN_RESOURCE_SUFFIXES));
-    RESOURCE_SUFFIXES.addAll(Arrays.asList(CMMN_RESOURCE_SUFFIXES));
-    RESOURCE_SUFFIXES.addAll(Arrays.asList(DMN_RESOURCE_SUFFIXES));
+    RESOURCE_SUFFIXES.addAll(List.of(BPMN_RESOURCE_SUFFIXES));
+    RESOURCE_SUFFIXES.addAll(List.of(CMMN_RESOURCE_SUFFIXES));
+    RESOURCE_SUFFIXES.addAll(List.of(DMN_RESOURCE_SUFFIXES));
   }
 
   /**

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/MigratingProcessInstanceValidationReportAssert.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/MigratingProcessInstanceValidationReportAssert.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.test.util;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -67,7 +66,7 @@ public class MigratingProcessInstanceValidationReportAssert {
 
     Assertions.assertThat(actualReport).as("No validation report found for source scope: " + sourceScopeId).isNotNull();
 
-    assertFailures(sourceScopeId, Arrays.asList(expectedFailures), actualReport.getFailures());
+    assertFailures(sourceScopeId, List.of(expectedFailures), actualReport.getFailures());
 
     return this;
   }
@@ -85,7 +84,7 @@ public class MigratingProcessInstanceValidationReportAssert {
 
     Assertions.assertThat(actualReport).as("No validation report found for source scope: " + sourceScopeId).isNotNull();
 
-    assertFailures(sourceScopeId, Arrays.asList(expectedFailures), actualReport.getFailures());
+    assertFailures(sourceScopeId, List.of(expectedFailures), actualReport.getFailures());
 
     return this;
   }

--- a/engine/src/main/junit4/org/operaton/bpm/engine/test/util/ActivityInstanceAssert.java
+++ b/engine/src/main/junit4/org/operaton/bpm/engine/test/util/ActivityInstanceAssert.java
@@ -86,7 +86,7 @@ public final class ActivityInstanceAssert {
           return false;
         } else {
 
-          List<ActivityInstance> unmatchedInstances = new ArrayList<>(Arrays.asList(expectedInstance.getChildActivityInstances()));
+          List<ActivityInstance> unmatchedInstances = new ArrayList<>(List.of(expectedInstance.getChildActivityInstances()));
           for (ActivityInstance actualChild : actualInstance.getChildActivityInstances()) {
             boolean matchFound = false;
             for (ActivityInstance expectedChild : new ArrayList<ActivityInstance>(unmatchedInstances)) {
@@ -106,7 +106,7 @@ public final class ActivityInstanceAssert {
           }
 
           List<TransitionInstance> unmatchedTransitionInstances =
-              new ArrayList<>(Arrays.asList(expectedInstance.getChildTransitionInstances()));
+              new ArrayList<>(List.of(expectedInstance.getChildTransitionInstances()));
           for (TransitionInstance child : actualInstance.getChildTransitionInstances()) {
             Iterator<TransitionInstance> expectedTransitionInstanceIt = unmatchedTransitionInstances.iterator();
 
@@ -157,7 +157,7 @@ public final class ActivityInstanceAssert {
       newInstance.setId(activityInstanceId);
 
       ActivityInstanceImpl parentInstance = activityInstanceStack.peek();
-      List<ActivityInstance> childInstances = new ArrayList<>(Arrays.asList(parentInstance.getChildActivityInstances()));
+      List<ActivityInstance> childInstances = new ArrayList<>(List.of(parentInstance.getChildActivityInstances()));
       childInstances.add(newInstance);
       parentInstance.setChildActivityInstances(childInstances.toArray(new ActivityInstance[childInstances.size()]));
 
@@ -195,7 +195,7 @@ public final class ActivityInstanceAssert {
       ActivityInstanceImpl parentInstance = activityInstanceStack.peek();
 
       List<TransitionInstance> childInstances = new ArrayList<>(
-          Arrays.asList(parentInstance.getChildTransitionInstances()));
+          List.of(parentInstance.getChildTransitionInstances()));
       childInstances.add(newInstance);
       parentInstance.setChildTransitionInstances(childInstances.toArray(new TransitionInstance[childInstances.size()]));
 

--- a/engine/src/main/junit4/org/operaton/bpm/engine/test/util/ProcessEngineTestRule.java
+++ b/engine/src/main/junit4/org/operaton/bpm/engine/test/util/ProcessEngineTestRule.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.test.util;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.TimerTask;
@@ -51,6 +50,7 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessEngineTestRule extends TestWatcher {
@@ -112,11 +112,11 @@ public class ProcessEngineTestRule extends TestWatcher {
   }
 
   public DeploymentWithDefinitions deploy(BpmnModelInstance... bpmnModelInstances) {
-    return deploy(createDeploymentBuilder(), Arrays.asList(bpmnModelInstances), Collections.<String> emptyList());
+    return deploy(createDeploymentBuilder(), List.of(bpmnModelInstances), emptyList());
   }
 
   public DeploymentWithDefinitions deploy(String... resources) {
-    return deploy(createDeploymentBuilder(), Collections.<BpmnModelInstance> emptyList(), Arrays.asList(resources));
+    return deploy(createDeploymentBuilder(), emptyList(), List.of(resources));
   }
 
   public <T extends DeploymentWithDefinitions> T deploy(DeploymentBuilder deploymentBuilder) {
@@ -132,11 +132,11 @@ public class ProcessEngineTestRule extends TestWatcher {
   }
 
   public Deployment deployForTenant(String tenantId, BpmnModelInstance... bpmnModelInstances) {
-    return deploy(createDeploymentBuilder().tenantId(tenantId), Arrays.asList(bpmnModelInstances), Collections.<String> emptyList());
+    return deploy(createDeploymentBuilder().tenantId(tenantId), List.of(bpmnModelInstances), emptyList());
   }
 
   public Deployment deployForTenant(String tenantId, String... resources) {
-    return deploy(createDeploymentBuilder().tenantId(tenantId), Collections.<BpmnModelInstance> emptyList(), Arrays.asList(resources));
+    return deploy(createDeploymentBuilder().tenantId(tenantId), emptyList(), List.of(resources));
   }
 
   public Deployment deployForTenant(String tenant, BpmnModelInstance bpmnModelInstance, String resource) {

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/batch/BatchElementConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/batch/BatchElementConfigurationTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.batch;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,7 @@ class BatchElementConfigurationTest {
   void shouldProduceListOfIdsSortedByKey() {
     // given
     BatchElementConfiguration configuration = new BatchElementConfiguration();
-    configuration.addDeploymentMappings(Arrays.asList(
+    configuration.addDeploymentMappings(List.of(
         new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("ABC", "bar"), new ImmutablePair<>("AAB", "baz")));
     // when
     List<String> ids = configuration.getIds();
@@ -44,7 +43,7 @@ class BatchElementConfigurationTest {
   void shouldProduceListOfMappingsSortedByKey() {
     // given
     BatchElementConfiguration configuration = new BatchElementConfiguration();
-    configuration.addDeploymentMappings(Arrays.asList(
+    configuration.addDeploymentMappings(List.of(
         new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("ABC", "bar"), new ImmutablePair<>("AAB", "baz")));
     // when
     DeploymentMappings mappings = configuration.getMappings();
@@ -56,7 +55,7 @@ class BatchElementConfigurationTest {
   void shouldIncludeNullMappings() {
     // given
     BatchElementConfiguration configuration = new BatchElementConfiguration();
-    configuration.addDeploymentMappings(Arrays.asList(
+    configuration.addDeploymentMappings(List.of(
         new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("AAB", "baz"), new ImmutablePair<>(null, "null")));
     // when
     List<String> ids = configuration.getIds();
@@ -70,12 +69,12 @@ class BatchElementConfigurationTest {
   void shouldRecalculateMappingsWhenNewElementsAdded() {
     // given
     BatchElementConfiguration configuration = new BatchElementConfiguration();
-    configuration.addDeploymentMappings(Arrays.asList(
+    configuration.addDeploymentMappings(List.of(
         new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("AAB", "baz")));
     configuration.getIds();
     configuration.getMappings();
     // when
-    configuration.addDeploymentMappings(Arrays.asList(
+    configuration.addDeploymentMappings(List.of(
         new ImmutablePair<>("AAB", "bar")));
     List<String> ids = configuration.getIds();
     DeploymentMappings mappings = configuration.getMappings();
@@ -90,8 +89,8 @@ class BatchElementConfigurationTest {
     // given
     BatchElementConfiguration configuration = new BatchElementConfiguration();
     configuration.addDeploymentMappings(
-        Arrays.asList(new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("AAB", "baz")),
-        Arrays.asList("null"));
+        List.of(new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("AAB", "baz")),
+        List.of("null"));
     // when
     List<String> ids = configuration.getIds();
     DeploymentMappings mappings = configuration.getMappings();
@@ -105,8 +104,8 @@ class BatchElementConfigurationTest {
     // given
     BatchElementConfiguration configuration = new BatchElementConfiguration();
     configuration.addDeploymentMappings(
-        Arrays.asList(new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("AAB", "baz"), new ImmutablePair<>(null, "null")),
-        Arrays.asList("bar"));
+        List.of(new ImmutablePair<>("ABC", "foo"), new ImmutablePair<>("AAB", "baz"), new ImmutablePair<>(null, "null")),
+        List.of("bar"));
     // when
     List<String> ids = configuration.getIds();
     DeploymentMappings mappings = configuration.getMappings();

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/task/TaskDecoratorExtractCandidatesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/task/TaskDecoratorExtractCandidatesTest.java
@@ -15,7 +15,6 @@
  */
 package org.operaton.bpm.engine.impl.task;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,7 +42,7 @@ class TaskDecoratorExtractCandidatesTest {
       "'  ,  '|,"
   })
   void shouldMirrorPreviousSplitBehavior(String input, String expectedCsv) {
-    List<String> expected = Arrays.asList(expectedCsv.split(","));
+    List<String> expected = List.of(expectedCsv.split(","));
 
     List<String> actual = taskDecorator.extractCandidates(input);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/delegate/AssertingJavaDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/delegate/AssertingJavaDelegate.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.api.delegate;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -47,7 +46,7 @@ public class AssertingJavaDelegate implements JavaDelegate {
   }
 
   public static void addAsserts(DelegateExecutionAsserter... as) {
-    asserts.addAll(Arrays.asList(as));
+    asserts.addAll(List.of(as));
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/delegate/AssertingTaskListener.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/delegate/AssertingTaskListener.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.api.delegate;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.delegate.DelegateTask;
@@ -43,7 +42,7 @@ public class AssertingTaskListener implements TaskListener {
   }
 
   public static void addAsserts(DelegateTaskAsserter... asserters) {
-    asserts.addAll(Arrays.asList(asserters));
+    asserts.addAll(List.of(asserters));
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/listener/AssertingCaseExecutionListener.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/listener/AssertingCaseExecutionListener.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.api.multitenancy.listener;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.delegate.CaseExecutionListener;
@@ -43,7 +42,7 @@ public class AssertingCaseExecutionListener implements CaseExecutionListener {
   }
 
   public static void addAsserts(DelegateCaseExecutionAsserter... asserters) {
-    asserts.addAll(Arrays.asList(asserters));
+    asserts.addAll(List.of(asserters));
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -1153,7 +1153,7 @@ class RepositoryServiceTest {
     assertThat(repositoryService.createProcessDefinitionQuery().orderByProcessDefinitionName().asc().count()).isEqualTo(4);
     assertThat(repositoryService.createProcessDefinitionQuery().latestVersion().orderByProcessDefinitionName().asc().count()).isEqualTo(2);
 
-    deleteDeployments(Arrays.asList(deployment1Id, deployment2Id));
+    deleteDeployments(List.of(deployment1Id, deployment2Id));
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
@@ -99,7 +99,7 @@ public class ModificationExecutionAsyncTest {
 
   @Parameters(name = "Job DueDate is set: {0}")
   public static Collection<Object[]> scenarios() {
-    return Arrays.asList(new Object[][] {
+    return List.of(new Object[][] {
       { false, null },
       { true, START_DATE }
     });
@@ -1155,7 +1155,7 @@ public class ModificationExecutionAsyncTest {
     Batch batch = runtimeService
       .createModification(processDefinition.getId())
       .startBeforeActivity("user2")
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(List.of(processInstance.getId()))
       .executeAsync();
 
     helper.completeSeedJobs(batch);
@@ -1188,7 +1188,7 @@ public class ModificationExecutionAsyncTest {
     Batch batch = runtimeService
       .createModification(processDefinition.getId())
       .cancelAllForActivity("user2")
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(List.of(processInstance.getId()))
       .skipCustomListeners()
       .executeAsync();
 
@@ -1215,7 +1215,7 @@ public class ModificationExecutionAsyncTest {
     Batch batch = runtimeService
       .createModification(processDefinition.getId())
       .startAfterActivity("user2")
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(List.of(processInstance.getId()))
       .executeAsync();
 
     helper.completeSeedJobs(batch);
@@ -1248,7 +1248,7 @@ public class ModificationExecutionAsyncTest {
     Batch batch = runtimeService
       .createModification(processDefinition.getId())
       .startBeforeActivity("user2")
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(List.of(processInstance.getId()))
       .skipIoMappings()
       .executeAsync();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.runtime;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -214,7 +213,7 @@ public class RuntimeServiceTest {
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
     // if we skip the custom listeners,
-    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(),processInstance2.getId()), null, false, false);
+    runtimeService.deleteProcessInstances(List.of(processInstance.getId(),processInstance2.getId()), null, false, false);
 
     assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
@@ -485,7 +484,7 @@ public class RuntimeServiceTest {
   @Test
   void testDeleteProcessInstancesWithFake() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-    var processInstanceIds = Arrays.asList(instance.getId(), "aFake");
+    var processInstanceIds = List.of(instance.getId(), "aFake");
 
     assertThatThrownBy(() -> runtimeService.deleteProcessInstances(processInstanceIds, "test", false, false, false, false))
       .isInstanceOf(NotFoundException.class)
@@ -499,7 +498,7 @@ public class RuntimeServiceTest {
   void testDeleteProcessInstancesIfExistsWithFake() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    runtimeService.deleteProcessInstancesIfExists(Arrays.asList(instance.getId(), "aFake"), "test", false, false, false);
+    runtimeService.deleteProcessInstancesIfExists(List.of(instance.getId(), "aFake"), "test", false, false, false);
     //dont't expect exception, existing instances are deleted
     assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("oneTaskProcess").count()).isZero();
   }
@@ -3142,7 +3141,7 @@ public class RuntimeServiceTest {
     subprocessList.addAll(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance2.getId()).list());
 
     // when
-    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(), processInstance2.getId()), null, false, false, true, false);
+    runtimeService.deleteProcessInstances(List.of(processInstance.getId(), processInstance2.getId()), null, false, false, true, false);
 
     // then
     testRule.assertProcessEnded(processInstance.getId());
@@ -3168,7 +3167,7 @@ public class RuntimeServiceTest {
     subprocessList.addAll(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance2.getId()).list());
 
     // when
-    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(), processInstance2.getId()), null, false, false, false, false);
+    runtimeService.deleteProcessInstances(List.of(processInstance.getId(), processInstance2.getId()), null, false, false, false, false);
 
     // then
     testRule.assertProcessEnded(processInstance.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationProcessInstanceTest.java
@@ -99,7 +99,8 @@ class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
-    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList("foo", null, "bar"));
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(
+            Arrays.asList("foo", null, "bar"));
 
     // when/then
     assertThatThrownBy(migrationPlanExecutionBuilder::execute)
@@ -339,7 +340,7 @@ class MigrationProcessInstanceTest {
     assertThat(targetProcessInstanceQuery.count()).isZero();
 
     runtimeService.newMigration(migrationPlan)
-      .processInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId()))
+      .processInstanceIds(List.of(processInstance1.getId(), processInstance2.getId()))
       .processInstanceQuery(sourceProcessInstanceQuery)
       .execute();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/AsyncEmailTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/AsyncEmailTaskTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.test.bpmn.async;
 
-import java.util.Arrays;
 import java.util.List;
 
 import ch.martinelli.oss.testcontainers.mailpit.Message;
@@ -50,7 +49,7 @@ class AsyncEmailTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(messages.get(0));
     assertEmailSend(rawMessage, false, "Hello Kermit!", "This a text only e-mail.", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), null);
+            List.of("kermit@operaton.org"), null);
     testRule.assertProcessEnded(procId);
   }
 
@@ -70,7 +69,7 @@ class AsyncEmailTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(messages.get(0));
     assertEmailSend(rawMessage, false, "Hello Kermit!", "This a text only e-mail.", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), null);
+            List.of("kermit@operaton.org"), null);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/mail/EmailSendTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/mail/EmailSendTaskTest.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.bpmn.mail;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -50,7 +49,7 @@ class EmailSendTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(messages.get(0));
     assertEmailSend(rawMessage, false, "Hello Kermit!", "This a text only e-mail.", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), null);
+            List.of("kermit@operaton.org"), null);
   }
 
   @Deployment
@@ -96,7 +95,7 @@ class EmailSendTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(messages.get(0));
     assertEmailSend(rawMessage, false, subject, "Hello " + recipientName + ", this is an e-mail",
-            sender, Arrays.asList(recipient), null);
+            sender, List.of(recipient), null);
   }
 
   @Deployment
@@ -108,7 +107,7 @@ class EmailSendTaskTest extends EmailTestCase {
     Message emailMsg = messages.get(0);
     String rawMessage = getRawMessage(emailMsg);
     assertEmailSend(rawMessage, false, "Hello world", "This is the content", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), Arrays.asList("fozzie@operaton.org"));
+            List.of("kermit@operaton.org"), List.of("fozzie@operaton.org"));
 
     // Bcc is not stored in the header (obviously)
     // so the only way to verify the bcc, is that the messae has the bcc field in Mailpit message.
@@ -124,7 +123,7 @@ class EmailSendTaskTest extends EmailTestCase {
     List<Message> messages = getReceivedEmails();
     assertThat(messages).hasSize(1);
     String rawMessage = getRawMessage(messages.get(0));
-    assertEmailSend(rawMessage, true, "Test", "Mr. <b>Kermit</b>", "operaton@localhost", Arrays.asList("kermit@operaton.org"), null);
+    assertEmailSend(rawMessage, true, "Test", "Mr. <b>Kermit</b>", "operaton@localhost", List.of("kermit@operaton.org"), null);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/mail/EmailServiceTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/mail/EmailServiceTaskTest.java
@@ -44,7 +44,7 @@ class EmailServiceTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(receivedEmails.get(0));
     assertEmailSend(rawMessage, false, "Hello Kermit!", "This a text only e-mail.", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), null);
+            List.of("kermit@operaton.org"), null);
     testRule.assertProcessEnded(procId);
   }
 
@@ -91,7 +91,7 @@ class EmailServiceTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(messages.get(0));
     assertEmailSend(rawMessage, false, subject, "Hello " + recipientName + ", this is an e-mail",
-            sender, Arrays.asList(recipient), null);
+            sender, List.of(recipient), null);
   }
 
   @Deployment
@@ -103,7 +103,7 @@ class EmailServiceTaskTest extends EmailTestCase {
     Message emailMsg = messages.get(0);
     String rawMessage = getRawMessage(emailMsg);
     assertEmailSend(rawMessage, false, "Hello world", "This is the content", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), Arrays.asList("fozzie@operaton.org"));
+            List.of("kermit@operaton.org"), List.of("fozzie@operaton.org"));
 
     // Bcc is not stored in the header (obviously)
     // so the only way to verify the bcc, is that the messae has the bcc field in Mailpit message.
@@ -121,7 +121,7 @@ class EmailServiceTaskTest extends EmailTestCase {
 
     String rawMessage = getRawMessage(messages.get(0));
     assertEmailSend(rawMessage, true, "Test", "Mr. <b>Kermit</b>", "operaton@localhost",
-            Arrays.asList("kermit@operaton.org"), null);
+            List.of("kermit@operaton.org"), null);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/multiinstance/DelegateBean.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/multiinstance/DelegateBean.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.bpmn.multiinstance;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -37,6 +36,6 @@ public class DelegateBean implements Serializable {
   public List<String> resolveCollection(DelegateExecution delegateExecution) {
 
     DelegateEvent.recordEventFor(delegateExecution);
-    return Arrays.asList("1");
+    return List.of("1");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/handler/ExecutionListenerCases.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/handler/ExecutionListenerCases.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.cmmn.handler;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.delegate.CaseExecutionListener;
 import org.operaton.bpm.engine.impl.cmmn.handler.ItemHandler;
@@ -29,7 +29,7 @@ import org.operaton.bpm.engine.test.cmmn.handler.specification.ScriptExecutionLi
 public final class ExecutionListenerCases {
 
   public static final Iterable<Object[]> TASK_OR_STAGE_CASES =
-      Arrays.asList(new Object[][] {
+      List.of(new Object[][] {
           // class delegate
           {new ClassExecutionListenerSpec(CaseExecutionListener.CREATE)},
           {new ClassExecutionListenerSpec(CaseExecutionListener.ENABLE)},
@@ -127,7 +127,7 @@ public final class ExecutionListenerCases {
 
 
   public static final Iterable<Object[]> EVENTLISTENER_OR_MILESTONE_CASES =
-      Arrays.asList(new Object[][] {
+      List.of(new Object[][] {
           // class delegate
           {new ClassExecutionListenerSpec(CaseExecutionListener.CREATE)},
           {new ClassExecutionListenerSpec(CaseExecutionListener.SUSPEND)},
@@ -196,7 +196,7 @@ public final class ExecutionListenerCases {
       });
 
   public static final Iterable<Object[]> CASE_PLAN_MODEL_CASES =
-      Arrays.asList(new Object[][] {
+      List.of(new Object[][] {
           // class delegate
           {new ClassExecutionListenerSpec(CaseExecutionListener.CREATE)},
           {new ClassExecutionListenerSpec(CaseExecutionListener.COMPLETE)},

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/CustomUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/CustomUserOperationLogTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.history.useroperationlog;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +61,7 @@ public class CustomUserOperationLogTest {
           userOperationLogContext.setUserId("kermit");
 
           final UserOperationLogContextEntry entry = new UserOperationLogContextEntry("foo", "bar");
-          entry.setPropertyChanges(Arrays.asList(new PropertyChange(null, null, null)));
+          entry.setPropertyChanges(List.of(new PropertyChange(null, null, null)));
           entry.setTaskId(TASK_ID);
           userOperationLogContext.addEntry(entry);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/LegacyUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/LegacyUserOperationLogTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.history.useroperationlog;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -153,7 +153,7 @@ public class LegacyUserOperationLogTest {
     ProcessDefinition definition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(definition.getId());
     batch = runtimeService.deleteProcessInstancesAsync(
-        Arrays.asList(processInstance.getId()), null, "test reason");
+        List.of(processInstance.getId()), null, "test reason");
 
     Job seedJob = managementService
         .createJobQuery()
@@ -180,7 +180,7 @@ public class LegacyUserOperationLogTest {
       .build();
 
     batch = runtimeService.newMigration(migrationPlan)
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(List.of(processInstance.getId()))
       .executeAsync();
     Job seedJob = managementService
         .createJobQuery()

--- a/engine/src/test/resources/org/operaton/bpm/application/impl/event/pa.event.listener.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/application/impl/event/pa.event.listener.operaton.cfg.xml
@@ -8,7 +8,7 @@
   
     <property name="processEngineName" value="ProcessApplicationEventListenerTest-engine" />
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:BPMNParseListenerTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:ProcessApplicationEventListenerTest;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/deployment/deploy.diagram.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/deployment/deploy.diagram.operaton.cfg.xml
@@ -6,9 +6,9 @@
 
   <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
   
-    <property name="processEngineName" value="BPMNParseListenerTest-engine" />
-  
-    <property name="jdbcUrl" value="jdbc:h2:mem:BPMNParseListenerTest;DB_CLOSE_DELAY=1000" />
+    <property name="processEngineName" value="BpmnDeploymentTest-engine" />
+
+    <property name="jdbcUrl" value="jdbc:h2:mem:BpmnDeploymentTest;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/task.listener.operaton.cfg.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/task.listener.operaton.cfg.xml
@@ -8,7 +8,7 @@
   
     <property name="processEngineName" value="BuiltinTaskListenerTest-engine" />
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:BPMNParseListenerTest;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:BuiltinTaskListenerTest;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/freemarker-template-engine/src/main/java/org/operaton/templateengines/FreeMarkerScriptEngineFactory.java
+++ b/freemarker-template-engine/src/main/java/org/operaton/templateengines/FreeMarkerScriptEngineFactory.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.templateengines;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,15 +33,9 @@ public class FreeMarkerScriptEngineFactory implements ScriptEngineFactory {
   public static final String NAME = "freemarker";
   public static final String VERSION = "2.3.29";
 
-  public static final List<String> names;
-  public static final List<String> extensions;
-  public static final List<String> mimeTypes;
-
-  static {
-    names = Collections.unmodifiableList(Arrays.asList(NAME, "Freemarker", "FreeMarker"));
-    extensions = Collections.unmodifiableList(Collections.singletonList("ftl"));
-    mimeTypes = Collections.emptyList();
-  }
+  public static final List<String> names = List.of(NAME, "Freemarker", "FreeMarker");
+  public static final List<String> extensions = List.of("ftl");
+  public static final List<String> mimeTypes = List.of();
 
   @Override
   public String getEngineName() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTestConstants.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTestConstants.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.model.bpmn;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -58,13 +57,13 @@ public final class BpmnTestConstants {
   public static final String TEST_DELEGATE_EXPRESSION_XML = "${" + TEST_CLASS_XML + "}";
   public static final String TEST_DELEGATE_EXPRESSION_API = "${" + TEST_CLASS_API + "}";
   public static final String TEST_GROUPS_XML = "group1, ${group2(a, b)}, group3";
-  public static final List<String> TEST_GROUPS_LIST_XML = Arrays.asList("group1", "${group2(a, b)}", "group3");
+  public static final List<String> TEST_GROUPS_LIST_XML = List.of("group1", "${group2(a, b)}", "group3");
   public static final String TEST_GROUPS_API = "#{group1( c,d)}, group5";
-  public static final List<String> TEST_GROUPS_LIST_API = Arrays.asList("#{group1( c,d)}", "group5");
+  public static final List<String> TEST_GROUPS_LIST_API = List.of("#{group1( c,d)}", "group5");
   public static final String TEST_USERS_XML = "user1, ${user2(a, b)}, user3";
-  public static final List<String> TEST_USERS_LIST_XML = Arrays.asList("user1", "${user2(a, b)}", "user3");
+  public static final List<String> TEST_USERS_LIST_XML = List.of("user1", "${user2(a, b)}", "user3");
   public static final String TEST_USERS_API = "#{user1( c,d)}, user5";
-  public static final List<String> TEST_USERS_LIST_API = Arrays.asList("#{user1( c,d)}", "user5");
+  public static final List<String> TEST_USERS_LIST_API = List.of("#{user1( c,d)}", "user5");
   public static final String TEST_DUE_DATE_XML = "2014-02-27";
   public static final String TEST_DUE_DATE_API = "2015-03-28";
   public static final String TEST_FOLLOW_UP_DATE_API = "2015-01-01";
@@ -88,7 +87,7 @@ public final class BpmnTestConstants {
   public static final String TEST_CONDITION = "${true}";
   public static final String TEST_CONDITIONAL_VARIABLE_NAME = "variable";
   public static final String TEST_CONDITIONAL_VARIABLE_EVENTS = "create, update";
-  public static final List<String> TEST_CONDITIONAL_VARIABLE_EVENTS_LIST = Arrays.asList("create", "update");
+  public static final List<String> TEST_CONDITIONAL_VARIABLE_EVENTS_LIST = List.of("create", "update");
 
   public static final String TEST_STRING_FORM_REF_BINDING = "version";
   public static final String TEST_STRING_FORM_REF_VERSION = "2";

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/StringUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/StringUtil.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.model.xml.impl.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -69,7 +68,7 @@ public final class StringUtil {
     if (text != null) {
       result = text.split(separator);
     }
-    return new ArrayList<>(Arrays.asList(result));
+    return new ArrayList<>(List.of(result));
   }
 
   public static @Nullable String joinList(@Nullable List<String> list, String separator) {

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/assertions/AttributeAssert.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/assertions/AttributeAssert.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.model.xml.test.assertions;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.AbstractAssert;
@@ -198,7 +197,7 @@ public class AttributeAssert extends AbstractAssert<AttributeAssert, Attribute<?
   public AttributeAssert hasIncomingReferences(Reference<?>... references) {
     isNotNull();
 
-    List<Reference<?>> incomingReferences = Arrays.asList(references);
+    List<Reference<?>> incomingReferences = List.of(references);
     List<Reference<?>> actualIncomingReferences = actual.getIncomingReferences();
 
     if (!actualIncomingReferences.containsAll(incomingReferences)) {
@@ -235,7 +234,7 @@ public class AttributeAssert extends AbstractAssert<AttributeAssert, Attribute<?
   public AttributeAssert hasOutgoingReferences(Reference<?>... references) {
     isNotNull();
 
-    List<Reference<?>> outgoingReferences = Arrays.asList(references);
+    List<Reference<?>> outgoingReferences = List.of(references);
     List<Reference<?>> actualOutgoingReferences = actual.getOutgoingReferences();
 
     if (!actualOutgoingReferences.containsAll(outgoingReferences)) {

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/assertions/ModelElementTypeAssert.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/assertions/ModelElementTypeAssert.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.model.xml.test.assertions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -120,7 +119,7 @@ public class ModelElementTypeAssert extends AbstractAssert<ModelElementTypeAsser
 
     List<String> actualAttributeNames = getActualAttributeNames();
 
-    if (!actualAttributeNames.containsAll(Arrays.asList(attributeNames))) {
+    if (!actualAttributeNames.containsAll(List.of(attributeNames))) {
       failWithMessage("Expected element type <%s> to have attributes <%s> but has <%s>", typeName, attributeNames, actualAttributeNames);
     }
 
@@ -154,7 +153,7 @@ public class ModelElementTypeAssert extends AbstractAssert<ModelElementTypeAsser
   public ModelElementTypeAssert hasChildElements(ModelElementType... types) {
     isNotNull();
 
-    List<ModelElementType> childElementTypes = Arrays.asList(types);
+    List<ModelElementType> childElementTypes = List.of(types);
     List<ModelElementType> actualChildElementTypes = actual.getChildElementTypes();
 
     if (!actualChildElementTypes.containsAll(childElementTypes)) {
@@ -227,7 +226,7 @@ public class ModelElementTypeAssert extends AbstractAssert<ModelElementTypeAsser
   public ModelElementTypeAssert isExtendedBy(ModelElementType... types) {
     isNotNull();
 
-    List<ModelElementType> extendingTypes = Arrays.asList(types);
+    List<ModelElementType> extendingTypes = List.of(types);
     Collection<ModelElementType> actualExtendingTypes = actual.getExtendingTypes();
 
     if (!actualExtendingTypes.containsAll(extendingTypes)) {
@@ -254,7 +253,7 @@ public class ModelElementTypeAssert extends AbstractAssert<ModelElementTypeAsser
   public ModelElementTypeAssert isNotExtendedBy(ModelElementType... types) {
     isNotNull();
 
-    List<ModelElementType> notExtendingTypes = Arrays.asList(types);
+    List<ModelElementType> notExtendingTypes = List.of(types);
     Collection<ModelElementType> actualExtendingTypes = actual.getExtendingTypes();
 
     List<ModelElementType> errorTypes = new ArrayList<>();

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/engine/AbstractScriptEngineFactory.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/engine/AbstractScriptEngineFactory.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.integrationtest.functional.scriptengine.engine;
 
 import java.io.Reader;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -67,7 +66,7 @@ public abstract class AbstractScriptEngineFactory implements ScriptEngineFactory
 
   @Override
   public List<String> getNames() {
-    return Arrays.asList(name);
+    return List.of(name);
   }
 
   @Override

--- a/qa/test-db-instance-migration/test-fixture-724/src/main/java/org/operaton/bpm/qa/upgrade/batch/CreateSetProcessInstanceVariablesBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-724/src/main/java/org/operaton/bpm/qa/upgrade/batch/CreateSetProcessInstanceVariablesBatchScenario.java
@@ -25,7 +25,6 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.qa.upgrade.DescribesScenario;
 import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
-import java.util.Arrays;
 import java.util.List;
 
 public final class CreateSetProcessInstanceVariablesBatchScenario {
@@ -48,7 +47,7 @@ public final class CreateSetProcessInstanceVariablesBatchScenario {
           .getId();
 
       String batchId = runtimeService.setVariablesAsync(
-          Arrays.asList(processInstanceIdOne, processInstanceIdTwo),
+          List.of(processInstanceIdOne, processInstanceIdTwo),
           Variables.createVariables().putValue("foo", "bar")).getId();
 
       engine.getManagementService().setProperty("createSeedCreatedScenario.batch.id", batchId);
@@ -71,7 +70,7 @@ public final class CreateSetProcessInstanceVariablesBatchScenario {
           .getId();
 
       Batch batch = runtimeService.setVariablesAsync(
-          Arrays.asList(processInstanceIdOne, processInstanceIdTwo),
+          List.of(processInstanceIdOne, processInstanceIdTwo),
           Variables.createVariables().putValue("foo", "bar"));
 
       List<Job> jobs = managementService.createJobQuery()

--- a/qa/test-db-instance-migration/test-fixture-724/src/main/java/org/operaton/bpm/qa/upgrade/batch/deploymentaware/DeploymentAwareBatchesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-724/src/main/java/org/operaton/bpm/qa/upgrade/batch/deploymentaware/DeploymentAwareBatchesScenario.java
@@ -26,7 +26,6 @@ import org.operaton.bpm.qa.upgrade.DescribesScenario;
 import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public final class DeploymentAwareBatchesScenario {
@@ -118,7 +117,7 @@ public final class DeploymentAwareBatchesScenario {
           .build();
 
       Batch batch = engine.getRuntimeService().newMigration(migrationPlan)
-          .processInstanceIds(Arrays.asList(instance.getId()))
+          .processInstanceIds(List.of(instance.getId()))
           .executeAsync();
       engine.getManagementService().setProperty(getPropertyName("migrate.batchId"), batch.getId());
     };

--- a/qa/test-db-util/src/main/java/org/operaton/bpm/qa/upgrade/util/ExpectedActivityInstance.java
+++ b/qa/test-db-util/src/main/java/org/operaton/bpm/qa/upgrade/util/ExpectedActivityInstance.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.qa.upgrade.util;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -42,10 +41,10 @@ public class ExpectedActivityInstance {
     this.activityIds = activityIds;
   }
   public void setActivityIds(String[] activityIds) {
-    this.activityIds = Arrays.asList(activityIds);
+    this.activityIds = List.of(activityIds);
   }
   public void setActivityId(String activityId) {
-    this.activityIds = Arrays.asList(activityId);
+    this.activityIds = List.of(activityId);
   }
   public List<ExpectedActivityInstance> getChildActivityInstances() {
     return childActivityInstances;

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/subscription/SubscriptionConfiguration.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/subscription/SubscriptionConfiguration.java
@@ -177,7 +177,7 @@ public class SubscriptionConfiguration {
     setLockDuration(isNull(configuredLockDuration) ? null : configuredLockDuration);
 
     String[] configuredVariableNames = config.variableNames();
-    setVariableNames(isNull(configuredVariableNames) ? null : Arrays.asList(configuredVariableNames));
+    setVariableNames(isNull(configuredVariableNames) ? null : List.of(configuredVariableNames));
 
     setLocalVariables(config.localVariables());
 
@@ -189,14 +189,14 @@ public class SubscriptionConfiguration {
 
     String[] configuredProcessDefinitionIdIn = config.processDefinitionIdIn();
     setProcessDefinitionIdIn(isNull(configuredProcessDefinitionIdIn) ? null :
-        Arrays.asList(configuredProcessDefinitionIdIn));
+        List.of(configuredProcessDefinitionIdIn));
 
     String configuredProcessDefinitionKey = config.processDefinitionKey();
     setProcessDefinitionKey(isNull(configuredProcessDefinitionKey) ? null : configuredProcessDefinitionKey);
 
     String[] configuredProcessDefinitionKeyIn = config.processDefinitionKeyIn();
     setProcessDefinitionKeyIn(isNull(configuredProcessDefinitionKeyIn) ? null :
-        Arrays.asList(configuredProcessDefinitionKeyIn));
+        List.of(configuredProcessDefinitionKeyIn));
 
     String configuredProcessDefinitionVersionTag = config.processDefinitionVersionTag();
     setProcessDefinitionVersionTag(isNull(configuredProcessDefinitionVersionTag) ? null :
@@ -209,7 +209,7 @@ public class SubscriptionConfiguration {
     setWithoutTenantId(config.withoutTenantId());
 
     String[] configuredTenantIdIn = config.tenantIdIn();
-    setTenantIdIn(isNull(configuredTenantIdIn) ? null : Arrays.asList(configuredTenantIdIn));
+    setTenantIdIn(isNull(configuredTenantIdIn) ? null : List.of(configuredTenantIdIn));
 
     setIncludeExtensionProperties(config.includeExtensionProperties());
   }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.spring.boot.starter.event;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -43,14 +42,14 @@ import static org.operaton.bpm.engine.delegate.TaskListener.*;
  */
 public class PublishDelegateParseListener implements BpmnParseListener {
 
-  private static final List<String> TASK_EVENTS = Arrays.asList(
+  private static final List<String> TASK_EVENTS = List.of(
     EVENTNAME_COMPLETE,
     EVENTNAME_ASSIGNMENT,
     EVENTNAME_CREATE,
     EVENTNAME_DELETE,
     EVENTNAME_UPDATE
   );
-  private static final List<String> EXECUTION_EVENTS = Arrays.asList(
+  private static final List<String> EXECUTION_EVENTS = List.of(
     EVENTNAME_START,
     EVENTNAME_END);
 

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/jdbc/HistoryLevelDeterminatorJdbcTemplateImpl.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/jdbc/HistoryLevelDeterminatorJdbcTemplateImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.spring.boot.starter.jdbc;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -47,7 +46,7 @@ public class HistoryLevelDeterminatorJdbcTemplateImpl implements HistoryLevelDet
 
   protected static final String SQL_TEMPLATE = "SELECT VALUE_ FROM " + TABLE_PREFIX_PLACEHOLDER + "ACT_GE_PROPERTY WHERE NAME_='historyLevel'";
 
-  protected final List<HistoryLevel> historyLevels = new ArrayList<>(Arrays.asList( HistoryLevel.HISTORY_LEVEL_ACTIVITY,
+  protected final List<HistoryLevel> historyLevels = new ArrayList<>(List.of( HistoryLevel.HISTORY_LEVEL_ACTIVITY,
       HistoryLevel.HISTORY_LEVEL_AUDIT, HistoryLevel.HISTORY_LEVEL_FULL, HistoryLevel.HISTORY_LEVEL_NONE));
 
   protected String defaultHistoryLevel = new SpringProcessEngineConfiguration().getHistory();

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/OperatonBpmProperties.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/OperatonBpmProperties.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.spring.boot.starter.property;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -45,9 +46,9 @@ public class OperatonBpmProperties {
 
   static String[] initDeploymentResourcePattern() {
     final Set<String> suffixes = new HashSet<>();
-    suffixes.addAll(Arrays.asList(DEFAULT_DMN_RESOURCE_SUFFIXES));
-    suffixes.addAll(Arrays.asList(DEFAULT_BPMN_RESOURCE_SUFFIXES));
-    suffixes.addAll(Arrays.asList(DEFAULT_CMMN_RESOURCE_SUFFIXES));
+    suffixes.addAll(List.of(DEFAULT_DMN_RESOURCE_SUFFIXES));
+    suffixes.addAll(List.of(DEFAULT_BPMN_RESOURCE_SUFFIXES));
+    suffixes.addAll(List.of(DEFAULT_CMMN_RESOURCE_SUFFIXES));
 
     final Set<String> patterns = new HashSet<>();
     for (String suffix : suffixes) {

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
@@ -219,7 +219,7 @@ public class ProcessInstanceAssert extends AbstractProcessAssert<ProcessInstance
       ListAssert<Execution> assertion = Assertions.assertThat(executions).overridingErrorMessage("Expecting %s " +
         (isWaitingFor ? "to be waiting for %s, ": "NOT to be waiting for %s, ") +
         "but actually did " + (isWaitingFor ? "not ": "") + "find it to be waiting for message [%s].",
-        actual, Arrays.asList(messageNames), messageName);
+        actual, List.of(messageNames), messageName);
       if (isWaitingFor) {
         assertion.isNotEmpty();
       } else {
@@ -359,7 +359,7 @@ public class ProcessInstanceAssert extends AbstractProcessAssert<ProcessInstance
 
     MapAssert<String, Object> assertion = variables()
       .overridingErrorMessage(message.toString(), toString(actual),
-        shouldHaveSpecificVariables ? Arrays.asList(names) : vars.keySet(), vars.keySet());
+        shouldHaveSpecificVariables ? List.of(names) : vars.keySet(), vars.keySet());
     if (shouldHaveVariables) {
       if (shouldHaveSpecificVariables) {
         assertion.containsKeys(names);

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.MapAssert;
@@ -708,7 +708,7 @@ public abstract class AbstractCaseAssert<S extends AbstractCaseAssert<S, A>, A e
     MapAssert<String, Object> assertion = variables().overridingErrorMessage(
         message.toString(),
         toString(actual),
-        shouldHaveSpecificVariables ? Arrays.asList(names)
+        shouldHaveSpecificVariables ? List.of(names)
             : vars.keySet(),
         vars.keySet());
     if (shouldHaveVariables) {

--- a/webapps-neo/assembly/src/main/java/org/operaton/bpm/webapp/neo/impl/db/QuerySessionFactory.java
+++ b/webapps-neo/assembly/src/main/java/org/operaton/bpm/webapp/neo/impl/db/QuerySessionFactory.java
@@ -20,7 +20,6 @@ package org.operaton.bpm.webapp.neo.impl.db;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -93,7 +92,7 @@ public class QuerySessionFactory extends StandaloneProcessEngineConfiguration {
   protected String buildMappings(List<String> mappingFiles) {
 
     List<String> mappings = new ArrayList<>(mappingFiles);
-    mappings.addAll(Arrays.asList(DEFAULT_MAPPING_FILES));
+    mappings.addAll(List.of(DEFAULT_MAPPING_FILES));
 
     StringBuilder builder = new StringBuilder();
     for (String mappingFile: mappings) {

--- a/webapps-neo/assembly/src/main/java/org/operaton/bpm/webapp/neo/impl/security/filter/headersec/provider/impl/StrictTransportSecurityProvider.java
+++ b/webapps-neo/assembly/src/main/java/org/operaton/bpm/webapp/neo/impl/security/filter/headersec/provider/impl/StrictTransportSecurityProvider.java
@@ -17,7 +17,7 @@
  */
 package org.operaton.bpm.webapp.neo.impl.security.filter.headersec.provider.impl;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -61,7 +61,7 @@ public class StrictTransportSecurityProvider extends HeaderSecurityProvider {
   @Override
   public Map<String, String> initParams() {
 
-    Arrays.asList(Parameters.values()).forEach(parameter -> initParams.put(parameter.getName(), null));
+    List.of(Parameters.values()).forEach(parameter -> initParams.put(parameter.getName(), null));
 
     return initParams;
   }

--- a/webapps-neo/assembly/src/main/runtime/develop/java/org/operaton/bpm/pa/DevProcessApplication.java
+++ b/webapps-neo/assembly/src/main/runtime/develop/java/org/operaton/bpm/pa/DevProcessApplication.java
@@ -18,7 +18,6 @@
 package org.operaton.bpm.pa;
 
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -473,7 +472,7 @@ public class DevProcessApplication extends ServletProcessApplication {
       Calendar calendar = Calendar.getInstance();
       calendar.add(Calendar.DAY_OF_MONTH, -14);
       ClockUtil.setCurrentTime(calendar.getTime());
-      processEngine.getIdentityService().setAuthentication("demo", Arrays.asList(Groups.OPERATON_ADMIN));
+      processEngine.getIdentityService().setAuthentication("demo", List.of(Groups.OPERATON_ADMIN));
       Task task = processEngine.getTaskService().createTaskQuery().processInstanceId(pi.getId()).singleResult();
       processEngine.getTaskService().claim(task.getId(), "demo");
       processEngine.getTaskService().complete(task.getId(), createVariables().putValue("approved", true));

--- a/webapps-neo/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
+++ b/webapps-neo/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
@@ -18,7 +18,6 @@
 package org.operaton.bpm.pa.rest;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +68,7 @@ public class TestServlet extends HttpServlet {
 
   public static final Logger log = Logger.getLogger(TestServlet.class.getName());
 
-  private static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList(
+  private static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = List.of(
       "ACT_GE_PROPERTY"
     );
 

--- a/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/auth/AuthCacheTest.java
+++ b/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/auth/AuthCacheTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.webapp.neo.impl.security.auth;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import jakarta.servlet.ServletException;
@@ -474,7 +473,7 @@ class AuthCacheTest {
     mockedAuthenticationUtil = mockStatic(AuthenticationUtil.class);
     mockedProcessEngineUtil = mockStatic(ProcessEngineUtil.class);
     List<ProcessEngine> processEngines = new ArrayList<>();
-    Arrays.asList(engines).forEach(engine -> {
+    List.of(engines).forEach(engine -> {
       ProcessEngine processEngineMock = mock(ProcessEngine.class, RETURNS_DEEP_STUBS);
       processEngines.add(processEngineMock);
 
@@ -495,7 +494,7 @@ class AuthCacheTest {
     }
 
     Authentications authentications = new Authentications();
-    List<String> enginesAsList = Arrays.asList(engines);
+    List<String> enginesAsList = List.of(engines);
     for (int i = 0; i < enginesAsList.size(); i++) {
       String engine = enginesAsList.get(i);
       UserAuthentication userAuthentication = AuthenticationUtil.createAuthentication(engine, "userId" + (i + 1));

--- a/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/auth/ContainerAuthenticationFilterTest.java
+++ b/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/auth/ContainerAuthenticationFilterTest.java
@@ -20,8 +20,8 @@ package org.operaton.bpm.webapp.neo.impl.security.auth;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -92,7 +92,7 @@ class ContainerAuthenticationFilterTest {
 
   @Parameters
   static Collection<Object[]> getRequestUrls() {
-    return Arrays.asList(new Object[][]{
+    return List.of(new Object[][]{
         {"/app/cockpit/default/", "default", false, true},
         {"/app/cockpit/engine2/", "engine2", false, true},
         {"/api/cockpit/plugin/some-plugin/default/process-instance", "default", false, true},

--- a/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/filter/RequestFilterTest.java
+++ b/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/filter/RequestFilterTest.java
@@ -17,8 +17,8 @@
  */
 package org.operaton.bpm.webapp.neo.impl.security.filter;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +42,7 @@ public class RequestFilterTest {
   protected String applicationPath;
 
   public static Collection<String> data() {
-    return Arrays.asList(EMPTY_PATH, CUSTOM_APP_PATH);
+    return List.of(EMPTY_PATH, CUSTOM_APP_PATH);
   }
 
   public void initRequestFilterTest(String applicationPath) {

--- a/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/filter/csrf/CsrfPreventionFilterTest.java
+++ b/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/impl/security/filter/csrf/CsrfPreventionFilterTest.java
@@ -17,8 +17,8 @@
  */
 package org.operaton.bpm.webapp.neo.impl.security.filter.csrf;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -60,7 +60,7 @@ public class CsrfPreventionFilterTest {
   protected boolean isModifyingFetchRequest;
 
   public static Collection<Object[]> getRequestUrls() {
-    return Arrays.asList(new Object[][]{
+    return List.of(new Object[][]{
       {"/app/cockpit/default/", "/api/admin/auth/user/default/login/cockpit", true},
       {"/app/cockpit/engine1/", "/api/admin/auth/user/engine1/login/cockpit", true},
 

--- a/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/plugin/resource/AbstractAppPluginRootResourceTest.java
+++ b/webapps-neo/assembly/src/test/java/org/operaton/bpm/webapp/neo/plugin/resource/AbstractAppPluginRootResourceTest.java
@@ -19,8 +19,9 @@ package org.operaton.bpm.webapp.neo.plugin.resource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+
 import jakarta.servlet.ServletContext;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -73,7 +74,7 @@ public class AbstractAppPluginRootResourceTest {
 
   @Parameters
   public static Collection<Object[]> getAssets() {
-    return Arrays.asList(new Object[][]{
+    return List.of(new Object[][]{
         {"app/plugin.js", MIME_TYPE_TEXT_JAVASCRIPT, true},
         {"app/plugin.css", MIME_TYPE_TEXT_CSS, true},
         {"app/asset.js", MIME_TYPE_TEXT_JAVASCRIPT, true},

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/CockpitPlugins.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/CockpitPlugins.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.cockpit.impl.plugin;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,7 +40,7 @@ public class CockpitPlugins extends AbstractCockpitPlugin {
 
   @Override
   public List<String> getMappingFiles() {
-    return Arrays.asList(MAPPING_FILES);
+    return List.of(MAPPING_FILES);
   }
 
   @Override

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/db/QuerySessionFactory.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/db/QuerySessionFactory.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.webapp.impl.db;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -96,7 +95,7 @@ public @NullMarked class QuerySessionFactory extends StandaloneProcessEngineConf
   protected String buildMappings(List<String> mappingFiles) {
 
     List<String> mappings = new ArrayList<>(mappingFiles);
-    mappings.addAll(Arrays.asList(DEFAULT_MAPPING_FILES));
+    mappings.addAll(List.of(DEFAULT_MAPPING_FILES));
 
     StringBuilder builder = new StringBuilder();
     for (String mappingFile: mappings) {

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/headersec/provider/impl/StrictTransportSecurityProvider.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/headersec/provider/impl/StrictTransportSecurityProvider.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -60,7 +60,7 @@ public class StrictTransportSecurityProvider extends HeaderSecurityProvider {
   @Override
   public Map<String, String> initParams() {
 
-    Arrays.asList(Parameters.values()).forEach(parameter -> initParams.put(parameter.getName(), null));
+    List.of(Parameters.values()).forEach(parameter -> initParams.put(parameter.getName(), null));
 
     return initParams;
   }

--- a/webapps/assembly/src/main/runtime/develop/java/org/operaton/bpm/pa/DevProcessApplication.java
+++ b/webapps/assembly/src/main/runtime/develop/java/org/operaton/bpm/pa/DevProcessApplication.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.pa;
 
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -424,7 +423,7 @@ public class DevProcessApplication extends ServletProcessApplication {
       Calendar calendar = Calendar.getInstance();
       calendar.add(Calendar.DAY_OF_MONTH, -14);
       ClockUtil.setCurrentTime(calendar.getTime());
-      processEngine.getIdentityService().setAuthentication("demo", Arrays.asList(Groups.OPERATON_ADMIN));
+      processEngine.getIdentityService().setAuthentication("demo", List.of(Groups.OPERATON_ADMIN));
       Task task = processEngine.getTaskService().createTaskQuery().processInstanceId(pi.getId()).singleResult();
       processEngine.getTaskService().claim(task.getId(), "demo");
       processEngine.getTaskService().complete(task.getId(), createVariables().putValue("approved", true));

--- a/webapps/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
+++ b/webapps/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.pa.rest;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ public class TestServlet extends HttpServlet {
 
   public static final Logger log = Logger.getLogger(TestServlet.class.getName());
 
-  private static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList(
+  private static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = List.of(
       "ACT_GE_PROPERTY"
     );
 


### PR DESCRIPTION
Reduces compiler warnings when List#of() should be preferred. Note that an implications are:
- resulting lists are immutable
- eleements must not be null