### PR TITLE
fix(webapps-neo): Migrate every matching instance when none is selected

### DIFF
--- a/webapps-neo/frontend/src/pages/Migrations.jsx
+++ b/webapps-neo/frontend/src/pages/Migrations.jsx
@@ -21,6 +21,7 @@ import {
   remove_query_row,
   update_query_row,
   build_query,
+  migration_selectors,
   add_query_params_abstract,
 } from "./migration_helpers.js";
 
@@ -225,12 +226,12 @@ const ProcessSelection = () => {
             query_obj = build_query(
               migration_state.process_instance_query.peek(),
             ),
-            has_query = Object.keys(query_obj).length > 0;
+            selectors = migration_selectors(selected_ids, query_obj);
           engine_rest.migration.execute(
             state,
             migration_plan,
-            selected_ids.length > 0 ? selected_ids : null,
-            has_query ? query_obj : null,
+            selectors.process_instance_ids,
+            selectors.process_instance_query,
             execute_form_data.peek().skip_custom_listeners,
             execute_form_data.peek().skip_io_mappings,
             execute_form_data.peek().async,

--- a/webapps-neo/frontend/src/pages/Migrations.test.js
+++ b/webapps-neo/frontend/src/pages/Migrations.test.js
@@ -8,6 +8,7 @@ import {
   update_variable,
   update_mapping,
   add_query_params_abstract,
+  migration_selectors,
 } from "./migration_helpers.js";
 
 // --- Tests ---
@@ -237,6 +238,38 @@ describe("Migrations", () => {
       const mappings = { taskA: "targetA", taskB: "targetB" };
       update_mapping("", "taskA", mappings);
       expect(mappings).toEqual({ taskA: "targetA", taskB: "targetB" });
+    });
+  });
+
+  describe("migration_selectors", () => {
+    it("sends the ticked instances as ids and no query", () => {
+      expect(migration_selectors(["a", "b"], {})).toEqual({
+        process_instance_ids: ["a", "b"],
+        process_instance_query: null,
+      });
+    });
+
+    it("sends an empty query when nothing is ticked, meaning every match", () => {
+      // Sending null for both is what made the engine reject the migration
+      // with "Process instance ids cannot empty" instead of migrating all.
+      expect(migration_selectors([], {})).toEqual({
+        process_instance_ids: null,
+        process_instance_query: {},
+      });
+    });
+
+    it("keeps a built query alongside ticked instances", () => {
+      expect(migration_selectors(["a"], { businessKey: "K1" })).toEqual({
+        process_instance_ids: ["a"],
+        process_instance_query: { businessKey: "K1" },
+      });
+    });
+
+    it("sends a built query on its own when nothing is ticked", () => {
+      expect(migration_selectors([], { businessKey: "K1" })).toEqual({
+        process_instance_ids: null,
+        process_instance_query: { businessKey: "K1" },
+      });
     });
   });
 

--- a/webapps-neo/frontend/src/pages/migration_helpers.js
+++ b/webapps-neo/frontend/src/pages/migration_helpers.js
@@ -213,3 +213,23 @@ export const add_query_params_abstract = (
     route(`${url}&${name}=${value}`);
   }
 };
+
+/**
+ * Which selectors to send with a migration.
+ *
+ * Ticked instances go as ids. A query goes along whenever one was built — the
+ * query builder is additive to the checkboxes, and the engine unions both. It
+ * also goes along when nothing is ticked at all: "leave all unchecked to
+ * migrate every matching instance" is what the page promises, and an empty
+ * query is exactly that set once `execute` stamps the source definition onto
+ * it. Sending neither selector leaves the engine with no instances, and it
+ * rejects the request instead of migrating everything.
+ */
+export const migration_selectors = (selected_ids, query) => {
+  const nothing_selected = selected_ids.length === 0;
+  return {
+    process_instance_ids: nothing_selected ? null : selected_ids,
+    process_instance_query:
+      Object.keys(query).length > 0 || nothing_selected ? query : null,
+  };
+};


### PR DESCRIPTION
Fixes #3628.

## The defect

The page promises:

> Leave all unchecked to migrate every matching instance.

Doing exactly that sent both selectors as `null`:

```js
// src/pages/Migrations.jsx (before)
selected_ids.length > 0 ? selected_ids : null,   // → null
has_query ? query_obj : null,                    // → null when no filter is set
```

The engine collected an empty set from `{"processInstanceIds": null, "processInstanceQuery": null}`
and rejected the request:

```java
// engine/…/impl/migration/MigrateProcessInstanceCmd.java:97
ensureNotEmpty(BadUserRequestException.class,
    "Process instance ids cannot empty", "process instance ids", processInstanceIds);
```

The engine is right — it was given nothing to migrate. What was wrong is that the UI
never translated "nothing selected" into "every matching instance".

## The change

An empty query is exactly the set the hint describes, because `execute` already stamps
the source definition onto whatever query it is given:

```js
// src/api/resources/migration.js
processInstanceQuery: { ...process_instance_query,
                        processDefinitionId: migration_plan.sourceProcessDefinitionId }
```

So the query is now sent when nothing is ticked, and the promise holds.

**Nothing else changes.** The query builder stays additive to the checkboxes — the engine
unions ids and query, and a query that was actually built is still sent alongside a
selection, exactly as before. Only the combination that could not work is affected:

| ticked | query built | ids sent | query sent | changed |
| --- | --- | --- | --- | --- |
| yes | no | yes | no | no |
| yes | yes | yes | yes | no |
| no | yes | no | yes | no |
| no | no | no | **yes (empty)** | **yes** |

## Where the decision lives

It moved out of the submit handler into `migration_selectors` in `migration_helpers.js`.
It sat inline in the JSX where no test could reach it, which is presumably why the case
went unnoticed. Four tests now cover the table above.

## Worth deciding separately

Migrating *every* matching instance is not reversible, and on a busy definition it can be
a lot of them. Showing the affected count and asking for confirmation would fit here, and
running it as a batch (`executeAsync`) is arguably the normal case rather than the
exception. Both felt like product decisions rather than part of this fix, so they are not
in this PR — happy to follow up if you want them.

I have not checked whether `validate` has the same gap when nothing is selected.

## Testing

Full suite green (602), ESLint clean, Prettier clean on the touched files. Verified by
hand against a local engine: five instances on v1 of a definition, nothing ticked, no
filter — before the change the migration was rejected and nothing moved, after it all five
were migrated to v2. Ticking a subset still migrates only that subset.
