### PR TITLE
fix(webapps-neo): Show a candidate group change on the task straight away

### DIFF
--- a/webapps-neo/frontend/src/pages/Tasks.jsx
+++ b/webapps-neo/frontend/src/pages/Tasks.jsx
@@ -739,6 +739,15 @@ const SetGroupsButton = () => {
     close = () => document.getElementById("add_groups").close(),
     show = () => document.getElementById("add_groups").showModal(),
     group_state = useSignal(null),
+    // Both the card above and the table below read identity_links, and nothing
+    // re-read them after a change: an added or removed group only appeared
+    // after leaving the task and coming back. The dialog deliberately stays
+    // open — managing groups is usually several steps in a row.
+    refresh_groups = () =>
+      engine_rest.task.get_identity_links(
+        state,
+        state.api.task.one.value.data.id,
+      ),
     submit = (event) => {
       event.preventDefault();
       engine_rest.task
@@ -748,15 +757,21 @@ const SetGroupsButton = () => {
             state.api.task.add_group.value.status === RESPONSE_STATE.SUCCESS
           ) {
             group_state.value = "";
+            void refresh_groups();
           }
         });
     },
     delete_group = (group_id) =>
-      engine_rest.task.delete_group(
-        state,
-        state.api.task.one.value.data.id,
-        group_id,
-      );
+      void Promise.resolve(
+        engine_rest.task.delete_group(
+          state,
+          state.api.task.one.value.data.id,
+          group_id,
+        ),
+      ).then((result) => {
+        if (result?.status !== RESPONSE_STATE.SUCCESS) return;
+        void refresh_groups();
+      });
 
   return (
     <>

--- a/webapps-neo/frontend/src/pages/Tasks.test.jsx
+++ b/webapps-neo/frontend/src/pages/Tasks.test.jsx
@@ -310,6 +310,54 @@ describe("TasksPage", () => {
       fireEvent.click(opener);
     };
 
+    const open_groups_dialog = (container) => {
+      const detail = container.querySelector("#task-details");
+      const opener = [...detail.querySelectorAll("button.task-card")].find((b) =>
+        b.textContent.includes("tasks.groups.set"),
+      );
+      fireEvent.click(opener);
+    };
+
+    it("re-reads the candidate groups after one was added", async () => {
+      engine_rest.task.add_group.mockImplementation((state) => {
+        state.api.task.add_group.value = { status: RESPONSE_STATE.SUCCESS };
+        return Promise.resolve(state.api.task.add_group.value);
+      });
+      signal_response(state.api.task.one, sample_task());
+      signal_response(state.api.task.identity_links, []);
+      const { getByText, container } = renderDetail();
+      open_groups_dialog(container);
+      engine_rest.task.get_identity_links.mockClear();
+
+      fireEvent.input(container.querySelector("#group_id"), {
+        target: { value: "reviewers" },
+      });
+      fireEvent.click(getByText("tasks.groups.add-group"));
+
+      await vi.waitFor(() =>
+        expect(engine_rest.task.get_identity_links).toHaveBeenCalled(),
+      );
+    });
+
+    it("re-reads the candidate groups after one was removed", async () => {
+      engine_rest.task.delete_group.mockResolvedValue({
+        status: RESPONSE_STATE.SUCCESS,
+      });
+      signal_response(state.api.task.one, sample_task());
+      signal_response(state.api.task.identity_links, [
+        { groupId: "reviewers", type: "candidate" },
+      ]);
+      const { getByText, container } = renderDetail();
+      open_groups_dialog(container);
+      engine_rest.task.get_identity_links.mockClear();
+
+      fireEvent.click(getByText("common.delete"));
+
+      await vi.waitFor(() =>
+        expect(engine_rest.task.get_identity_links).toHaveBeenCalled(),
+      );
+    });
+
     it("claims the task via claim_task", () => {
       signal_response(state.api.task.one, sample_task({ assignee: null }));
       const { getByText, container } = renderDetail();


### PR DESCRIPTION
Fixes #3645.

## The defect

The groups card and the table inside the dialog both read
`state.api.task.identity_links`, and that signal is filled in exactly one place:

```jsx
// src/pages/Tasks.jsx:496 — inside load_task_chain
await engine_rest.task.get_identity_links(state, task.id);
```

`load_task_chain` runs in the effect keyed on `[params.task_id]`, so only when the open
task changes. Neither handler re-read afterwards — removing a group did not even look at
its result. The change reached the engine and stayed invisible until the task was left and
reopened, which reads as a failed click and invites adding the same group twice.

## The change

Both paths re-read the identity links on success.

The dialog stays open, unlike the assignee dialog which closes after its action. Managing
groups is usually several steps in a row — add two, remove one — and closing after each
click would make the common case worse.

Removing goes through `Promise.resolve` first, so the handler does not depend on
`delete_group` returning a promise.

## Testing

Two tests, one per path, asserting the identity links are re-read. Full suite green (600),
ESLint clean.

Verified by hand against a running engine, watching both the card and the table:

| action | card | table |
| --- | --- | --- |
| add `group-b` | `group-a` → `group-a, group-b` | 1 → 2 rows |
| remove `group-b` | back to `group-a` | 2 → 1 rows |

## Note on a neighbour

The assignee dialog shows the same symptom for a different reason: three flags meant to
reflect the action just taken compare `.value?.data?.status`, while the signal carries the
status beside `data` — so they are always false, and nothing re-read the task either. That
is addressed in the work on #3629, not here.

