### PR TITLE
fix(ci): Restore pull-requests permission for contributor greetings

### DIFF
--- a/.github/workflows/check-for-new-contributor.yml
+++ b/.github/workflows/check-for-new-contributor.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: write
+      issues: read           # listForRepo only; the greeting goes on a PR
+      pull-requests: write   # commenting on a PR needs this, issues: write is not enough
     # This job intentionally uses pull_request_target only for metadata reads and comments.
     # Do not check out or execute PR code here.
     # Only run for PRs from forks (different repository) and not from operaton/operaton
@@ -153,6 +154,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write   # this job also comments on PRs (issue_comment fires for both)
     if: |
       github.event_name == 'issue_comment' && 
       github.event.action == 'created'


### PR DESCRIPTION
first-time contributor jobs. Commenting on a pull request needs the pull-requests scope -- `issues: write` only covers issues -- so every greeting on a fork PR has failed since 2026-05-31 with

    HttpError: Resource not accessible by integration

It went unnoticed because without the pull-requests scope the token also sees no pull requests in `issues.listForRepo`, so `prCount` was always 0 and the old `prCount === 1` guard never reached the comment call. 4f973c977 changed that guard to `priorPrCount === 0`, which is always true for a first-time contributor, and the missing permission surfaced as a hard failure.

Last greeting posted on a PR: #2781 (2026-04-20), none since.

greet-first-time-comment gets the same scope, since issue_comment fires for pull requests too. greet-first-time-issue is unchanged.