### PR TITLE
feat(webapps-neo): Show only the pages the user is authorized for

### DIFF
--- a/webapps-neo/frontend/public/locales/de-DE/translation.json
+++ b/webapps-neo/frontend/public/locales/de-DE/translation.json
@@ -847,6 +847,11 @@
     "goto-hint-prefix": "Mit der \"Gehe zu\"-Funktion oben rechts oder durch Drücken von",
     "goto-hint-suffix": "können Sie schnell zu einer Ressource navigieren, wenn Sie deren ID kennen."
   },
+  "no-access": {
+    "title": "Kein Zugriff auf diesen Bereich",
+    "text": "Ihr Konto ist für die Anwendung {{app}} nicht freigeschaltet.",
+    "hint": "Ein Administrator muss Ihrer Gruppe den Zugriff darauf gewähren."
+  },
   "bpmn": {
     "zoom-in": "Vergrößern",
     "zoom-out": "Verkleinern",

--- a/webapps-neo/frontend/public/locales/en-US/translation.json
+++ b/webapps-neo/frontend/public/locales/en-US/translation.json
@@ -847,6 +847,11 @@
     "goto-hint-prefix": "Using the \"Go To\" function in the top right or pressing",
     "goto-hint-suffix": "you can quickly navigate to a resource if you know its ID."
   },
+  "no-access": {
+    "title": "No access to this area",
+    "text": "Your account is not authorized for the {{app}} application.",
+    "hint": "An administrator has to grant your group access to it."
+  },
   "bpmn": {
     "zoom-in": "Zoom in",
     "zoom-out": "Zoom out",

--- a/webapps-neo/frontend/src/api/resources/auth.js
+++ b/webapps-neo/frontend/src/api/resources/auth.js
@@ -50,6 +50,7 @@ const start_session = (state, username, password) => {
       // Once the session exists the password has no further use here, so make
       // sure nothing is left holding one.
       state.auth.credentials.value = { username: null, password: null };
+      state.auth.authorized_apps.value = result.authorizedApps ?? null;
       return result.userId ?? username;
     });
 };
@@ -61,7 +62,13 @@ const session_user = (state) => {
 
   return fetch(_url_auth(), { headers, credentials: "include" })
     .then((response) => (response.ok ? response.json() : null))
-    .then((result) => result?.userId ?? null)
+    .then((result) => {
+      // A reload restores the session from the cookie, so the applications have
+      // to be restored with it — otherwise the navigation would open up again
+      // after every refresh.
+      state.auth.authorized_apps.value = result?.authorizedApps ?? null;
+      return result?.userId ?? null;
+    })
     .catch(() => null);
 };
 
@@ -135,6 +142,7 @@ const login = (
 const clear_local_session = (state) => {
   state.auth.credentials.value = { username: null, password: null };
   state.auth.user.id.value = null;
+  state.auth.authorized_apps.value = null;
   state.auth.logged_in.value = {
     status: RESPONSE_STATE.ERROR,
     data: "unauthenticated",

--- a/webapps-neo/frontend/src/components/Header.jsx
+++ b/webapps-neo/frontend/src/components/Header.jsx
@@ -11,6 +11,7 @@ import { plugins_for } from "../plugins/registry.js";
 import { PLUGIN_POINTS } from "../plugins/points.js";
 import { get_config } from "../config.js";
 import { app_name, logo_url, logo_alt } from "../branding.js";
+import { page_allowed } from "../helper/authorized_apps.js";
 
 const swap_server = (e, state) => {
   const server = get_config().backends.find((s) => s.url === e.target.value);
@@ -32,8 +33,8 @@ const builtin_nav = [
 
 // Built-ins plus every PAGE plugin's nav entry — the single source of truth for
 // both the desktop menu and the mobile dialog.
-const nav_entries = () => [
-  ...builtin_nav,
+const nav_entries = (authorized_apps) => [
+  ...builtin_nav.filter((entry) => page_allowed(authorized_apps, entry.href)),
   ...plugins_for(PLUGIN_POINTS.PAGE)
     .filter((plugin) => plugin.properties?.href && plugin.properties?.nameKey)
     .map((plugin) => ({
@@ -46,8 +47,9 @@ const nav_entries = () => [
 // Rendered in both the desktop <menu> and the mobile <dialog> so nav entries
 // (built-in and plugin) are declared exactly once.
 const MainNavEntries = ({ url, on_navigate }) => {
-  const [t] = useTranslation();
-  return nav_entries().map((entry) => (
+  const [t] = useTranslation(),
+    state = useContext(AppState);
+  return nav_entries(state.auth.authorized_apps.value).map((entry) => (
     <li key={entry.href}>
       <a
         href={entry.href}

--- a/webapps-neo/frontend/src/components/Header.test.jsx
+++ b/webapps-neo/frontend/src/components/Header.test.jsx
@@ -75,6 +75,27 @@ describe("Header", () => {
     ]);
   });
 
+  it("shows only the pages the signed-in user is authorized for", () => {
+    state.auth.authorized_apps.value = ["neo", "welcome", "tasklist"];
+    const { container } = renderHeader(state);
+    const hrefs = Array.from(
+      container.querySelectorAll("#primary-navigation li > a"),
+    ).map((a) => a.getAttribute("href"));
+    expect(hrefs).toEqual(["/tasks"]);
+  });
+
+  it("shows the cockpit pages when the user has cockpit", () => {
+    state.auth.authorized_apps.value = ["neo", "welcome", "cockpit"];
+    const { container } = renderHeader(state);
+    const hrefs = Array.from(
+      container.querySelectorAll("#primary-navigation li > a"),
+    ).map((a) => a.getAttribute("href"));
+    expect(hrefs).not.toContain("/tasks");
+    expect(hrefs).not.toContain("/admin");
+    expect(hrefs).toContain("/processes");
+    expect(hrefs).toContain("/migrations");
+  });
+
   it("marks the link for the current route as the current page", () => {
     mockUrl = "/processes/p1";
     const { container } = renderHeader(state);

--- a/webapps-neo/frontend/src/components/RequireApp.jsx
+++ b/webapps-neo/frontend/src/components/RequireApp.jsx
@@ -1,0 +1,41 @@
+import { useContext } from "preact/hooks";
+import { useTranslation } from "react-i18next";
+import { AppState } from "../state.js";
+import { app_allowed } from "../helper/authorized_apps.js";
+
+/**
+ * Says why a page is closed, instead of rendering it empty.
+ *
+ * Without an authorization the engine filters every query, so the page would
+ * load and show nothing at all — indistinguishable from "there is no data".
+ */
+const NoAccess = ({ app }) => {
+  const [t] = useTranslation();
+  return (
+    <main id="content" class="p-3">
+      <h1>{t("no-access.title")}</h1>
+      <p>{t("no-access.text", { app })}</p>
+      <p>{t("no-access.hint")}</p>
+    </main>
+  );
+};
+
+/**
+ * Wraps a page so it is only rendered when the signed-in user may use `app`.
+ *
+ * Hiding the navigation entry is not enough on its own: the address bar, a
+ * bookmark and the keyboard shortcuts all reach a page directly. This is the
+ * single place where that is decided.
+ */
+export const require_app = (Component, app) => {
+  const Guarded = (props) => {
+    const state = useContext(AppState);
+    return app_allowed(state.auth.authorized_apps.value, app) ? (
+      <Component {...props} />
+    ) : (
+      <NoAccess app={app} />
+    );
+  };
+  Guarded.displayName = `require_app(${app})`;
+  return Guarded;
+};

--- a/webapps-neo/frontend/src/components/RequireApp.test.jsx
+++ b/webapps-neo/frontend/src/components/RequireApp.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { h } from "preact";
+import { render, cleanup } from "@testing-library/preact";
+import { AppState } from "../state.js";
+import { create_mock_state } from "../test/helpers.js";
+import { require_app } from "./RequireApp.jsx";
+
+const Page = () => h("div", { "data-testid": "page" }, "the page");
+const Guarded = require_app(Page, "admin");
+
+const renderGuarded = (state) =>
+  render(h(AppState.Provider, { value: state }, h(Guarded, {})));
+
+describe("require_app", () => {
+  let state;
+  beforeEach(() => {
+    state = create_mock_state();
+  });
+  afterEach(cleanup);
+
+  it("renders the page when the application is authorized", () => {
+    state.auth.authorized_apps.value = ["welcome", "admin"];
+    const { queryByTestId } = renderGuarded(state);
+    expect(queryByTestId("page")).not.toBeNull();
+  });
+
+  it("says why instead of rendering an empty page when it is not", () => {
+    // Without the authorization the engine filters every query, so the page
+    // would render but stay empty — which reads as "there is no data".
+    state.auth.authorized_apps.value = ["welcome", "tasklist"];
+    const { queryByTestId, getByText } = renderGuarded(state);
+    expect(queryByTestId("page")).toBeNull();
+    expect(getByText("no-access.title")).toBeTruthy();
+  });
+
+  it("renders the page when the server reported no applications", () => {
+    state.auth.authorized_apps.value = null;
+    const { queryByTestId } = renderGuarded(state);
+    expect(queryByTestId("page")).not.toBeNull();
+  });
+});

--- a/webapps-neo/frontend/src/helper/authorized_apps.js
+++ b/webapps-neo/frontend/src/helper/authorized_apps.js
@@ -1,0 +1,33 @@
+/**
+ * Which application each built-in page belongs to.
+ *
+ * The engine authorizes on the three applications the previous web apps knew,
+ * so Neo's finer-grained pages map onto those. A page that is not listed is
+ * always available — `/`, `/account` and `/help` belong to no application.
+ */
+export const PAGE_APPS = {
+  "/tasks": "tasklist",
+  "/processes": "cockpit",
+  "/decisions": "cockpit",
+  "/deployments": "cockpit",
+  "/batches": "cockpit",
+  "/migrations": "cockpit",
+  "/admin": "admin",
+};
+
+/**
+ * Whether the signed-in user may use `app`, given the `authorizedApps` the
+ * server reported at sign-in.
+ *
+ * Anything but a list means the server never told us — a backend configured
+ * elsewhere has no session to ask. Nothing is hidden then: the engine still
+ * filters every query, and hiding pages on a guess is worse than showing them.
+ * With engine authorization switched off the server reports every application,
+ * so this needs no separate case.
+ */
+export const app_allowed = (authorized_apps, app) =>
+  !app || !Array.isArray(authorized_apps) || authorized_apps.includes(app);
+
+/** Whether the page at `href` is available to the signed-in user. */
+export const page_allowed = (authorized_apps, href) =>
+  app_allowed(authorized_apps, PAGE_APPS[href]);

--- a/webapps-neo/frontend/src/helper/authorized_apps.test.js
+++ b/webapps-neo/frontend/src/helper/authorized_apps.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { app_allowed, page_allowed, PAGE_APPS } from "./authorized_apps.js";
+
+describe("authorized_apps", () => {
+  describe("app_allowed", () => {
+    it("allows an application the server listed", () => {
+      expect(app_allowed(["welcome", "tasklist"], "tasklist")).toBe(true);
+    });
+
+    it("refuses one it did not list", () => {
+      expect(app_allowed(["welcome", "tasklist"], "cockpit")).toBe(false);
+      expect(app_allowed(["welcome", "tasklist"], "admin")).toBe(false);
+    });
+
+    it("allows everything when the server told us nothing", () => {
+      // A backend configured elsewhere has no session to ask. Hiding pages on
+      // a guess would be worse than showing them — the engine filters anyway.
+      expect(app_allowed(null, "admin")).toBe(true);
+      expect(app_allowed(undefined, "admin")).toBe(true);
+    });
+
+    it("allows a page that belongs to no application", () => {
+      expect(app_allowed(["welcome"], undefined)).toBe(true);
+    });
+  });
+
+  describe("page_allowed", () => {
+    it("maps every cockpit page onto the cockpit application", () => {
+      const cockpit_pages = Object.entries(PAGE_APPS)
+        .filter(([, app]) => app === "cockpit")
+        .map(([href]) => href);
+      expect(cockpit_pages).toContain("/processes");
+      for (const href of cockpit_pages) {
+        expect(page_allowed(["welcome", "tasklist"], href)).toBe(false);
+        expect(page_allowed(["welcome", "cockpit"], href)).toBe(true);
+      }
+    });
+
+    it("keeps pages that belong to no application available", () => {
+      for (const href of ["/", "/account", "/help"]) {
+        expect(page_allowed(["welcome"], href)).toBe(true);
+      }
+    });
+
+    it("lets a tasklist-only user keep just the task list", () => {
+      const apps = ["neo", "welcome", "tasklist"];
+      expect(page_allowed(apps, "/tasks")).toBe(true);
+      expect(page_allowed(apps, "/admin")).toBe(false);
+      expect(page_allowed(apps, "/deployments")).toBe(false);
+    });
+  });
+});

--- a/webapps-neo/frontend/src/index.jsx
+++ b/webapps-neo/frontend/src/index.jsx
@@ -16,6 +16,7 @@ import { AdminPage } from "./pages/Admin.jsx";
 import { DeploymentsPage } from "./pages/Deployments.jsx";
 import { BatchesPage } from "./pages/Batches.jsx";
 import { NotFound } from "./pages/_404.jsx";
+import { require_app } from "./components/RequireApp.jsx";
 import { SetupPage } from "./pages/Setup.jsx";
 import { AccountPage } from "./pages/Account.jsx";
 
@@ -36,6 +37,16 @@ import { plugins_for } from "./plugins/registry.js";
 import { PLUGIN_POINTS } from "./plugins/points.js";
 
 ("use strict");
+
+// Wrapped once at module scope: a component created during render would be a
+// new type on every pass and remount the page underneath it.
+const TasksGuarded = require_app(TasksPage, "tasklist");
+const ProcessesGuarded = require_app(ProcessesPage, "cockpit");
+const DecisionsGuarded = require_app(DecisionsPage, "cockpit");
+const DeploymentsGuarded = require_app(DeploymentsPage, "cockpit");
+const BatchesGuarded = require_app(BatchesPage, "cockpit");
+const MigrationsGuarded = require_app(MigrationsPage, "cockpit");
+const AdminGuarded = require_app(AdminPage, "admin");
 
 export const App = () => {
   return (
@@ -104,23 +115,23 @@ const Routing = () => {
           <Route path="/" component={DashboardPage} />
           <Route
             path="/decisions/:decision_id?/:panel?"
-            component={DecisionsPage}
+            component={DecisionsGuarded}
           />
           {/*<Route path="/tasks/start/:id" component={TasksPage} />*/}
-          <Route path="/tasks/:task_id?/:tab?" component={TasksPage} />
+          <Route path="/tasks/:task_id?/:tab?" component={TasksGuarded} />
           <Route
             path="/processes/:definition_id?/:panel?/:selection_id?/:sub_panel?"
-            component={ProcessesPage}
+            component={ProcessesGuarded}
           />
-          <Route path="/migrations" component={MigrationsPage} />
+          <Route path="/migrations" component={MigrationsGuarded} />
           <Route
             path="/deployments/:deployment_id?/:resource_name?"
-            component={DeploymentsPage}
+            component={DeploymentsGuarded}
           />
-          <Route path="/batches/:batch_id?" component={BatchesPage} />
+          <Route path="/batches/:batch_id?" component={BatchesGuarded} />
           <Route
             path="/admin/:page_id?/:selection_id?/:sub_selection_id?"
-            component={AdminPage}
+            component={AdminGuarded}
           />
           <Route
             path="/account/:page_id?/:selection_id?"

--- a/webapps-neo/frontend/src/state.js
+++ b/webapps-neo/frontend/src/state.js
@@ -28,6 +28,9 @@ const createAppState = () => {
     credentials: signal({ username: null, password: null }),
     token: signal(null),
     user: { id: signal() },
+    // Which applications the server said this user may use, from the sign-in
+    // response. null until we know — see helper/authorized_apps.js.
+    authorized_apps: signal(null),
     login_response: signal(null),
     logout_response: signal(null),
   };


### PR DESCRIPTION
Fixes #3630.

## The defect

The primary navigation was a fixed list, so every signed-in user was offered all seven
entries, Admin included, whatever their `APPLICATION` authorizations. The pages behind them
are not a data leak — the engine filters every query — but people were sent into areas
closed to them and landed on empty screens with nothing explaining why.

The information was already there and unused: the sign-in response carries
`authorizedApps`.

## The change

`authorizedApps` is kept in state, restored on reload — the session survives a refresh, so
the navigation must not open up again — and cleared on sign-out.

Neo has finer-grained pages than the three applications the engine authorizes on, so
`helper/authorized_apps.js` holds that mapping in one place:

| page | application |
| --- | --- |
| `/tasks` | `tasklist` |
| `/processes`, `/decisions`, `/deployments`, `/batches`, `/migrations` | `cockpit` |
| `/admin` | `admin` |

Pages belonging to no application — `/`, `/account`, `/help` — stay available.

**Hiding an entry is not enough on its own**, since the address bar, a bookmark and the
keyboard shortcuts all reach a page directly. The routes are wrapped so an unauthorized
page says which application is missing instead of rendering empty. That wrapper is also why
the shortcuts are left alone: they route as before and meet the same answer, so there is
one place where this is decided.

When the server reports nothing — a backend configured elsewhere has no session to ask —
nothing is hidden. Hiding on a guess would be worse than showing, and with engine
authorization switched off the server reports every application anyway, so that needs no
separate case.

## Testing

Ten tests: the mapping and its fallbacks, the navigation filtered per user, and the guard
rendering the page or the message.

Walked through against a running engine with three users:

| user | `authorizedApps` | navigation |
| --- | --- | --- |
| a reporter | `neo, tasklist, welcome` | `/tasks` |
| a support agent | `+ cockpit` | `/tasks`, `/processes`, `/decisions`, `/deployments`, `/batches`, `/migrations` |
| admin | `+ admin` | all of them |

Typing a closed route directly: `/admin` as the agent and `/processes` as the reporter both
answer "No access to this area — your account is not authorized for the … application",
while `/tasks` opens normally for both.

Full suite green (610), ESLint clean.
