### PR TITLE
fix(webapps-neo): Claim a task as the signed-in user, not "demo"

### DIFF
--- a/webapps-neo/frontend/src/api/resources/task.js
+++ b/webapps-neo/frontend/src/api/resources/task.js
@@ -9,6 +9,7 @@ import {
   PUT,
   DELETE,
   set_request_headers,
+  resolve_user,
 } from "../helper.jsx";
 import engine_rest from "../engine_rest.jsx";
 
@@ -67,15 +68,10 @@ const get_task_form_variables = (state, task_id) =>
 
 // The profile signal holds the login placeholder ({ id }) until a page fetches
 // the profile, after which it holds a response envelope ({ data: { id } }).
-const current_user_id = (state) => {
-  const profile = state.api.user.profile.value;
-  return profile?.data?.id ?? profile?.id;
-};
-
 const claim_task = (state, task_id) =>
   POST(
     `/task/${task_id}/claim`,
-    { userId: current_user_id(state) },
+    { userId: resolve_user(state) },
     state,
     state.api.task.claim_result,
   );
@@ -83,7 +79,7 @@ const claim_task = (state, task_id) =>
 const unclaim_task = (state, task_id) =>
   POST(
     `/task/${task_id}/unclaim`,
-    { userId: current_user_id(state) },
+    { userId: resolve_user(state) },
     state,
     state.api.task.unclaim_result,
   );

--- a/webapps-neo/frontend/src/api/resources/task.test.js
+++ b/webapps-neo/frontend/src/api/resources/task.test.js
@@ -93,21 +93,37 @@ describe("api/resources/task", () => {
     });
   });
 
-  it("claim_task POSTs the current user id", () => {
+  it("claim_task POSTs the signed-in user id", () => {
+    state.auth.user.id.value = "alice";
     task.claim_task(state, "t1");
     expect_api_call(POST, {
       url: "/task/t1/claim",
-      body: { userId: "demo" },
+      body: { userId: "alice" },
       state,
       signal: state.api.task.claim_result,
     });
   });
 
-  it("unclaim_task POSTs the current user id", () => {
+  it("claim_task ignores whichever profile the admin page last loaded", () => {
+    // The Admin page loads the profile of the user being edited into the same
+    // signal, so it must not be the source of "me".
+    state.auth.user.id.value = "alice";
+    state.api.user.profile.value = { data: { id: "bob" } };
+    task.claim_task(state, "t1");
+    expect_api_call(POST, {
+      url: "/task/t1/claim",
+      body: { userId: "alice" },
+      state,
+      signal: state.api.task.claim_result,
+    });
+  });
+
+  it("unclaim_task POSTs the signed-in user id", () => {
+    state.auth.user.id.value = "alice";
     task.unclaim_task(state, "t1");
     expect_api_call(POST, {
       url: "/task/t1/unclaim",
-      body: { userId: "demo" },
+      body: { userId: "alice" },
       state,
       signal: state.api.task.unclaim_result,
     });

--- a/webapps-neo/frontend/src/pages/Tasks.jsx
+++ b/webapps-neo/frontend/src/pages/Tasks.jsx
@@ -19,6 +19,7 @@ import {
   without_manage,
   write_list_query,
 } from "../helper/list_query.js";
+import { resolve_user } from "../api/helper.jsx";
 import { AppState } from "../state.js";
 import { StartProcessList } from "./StartProcessList.jsx";
 import { TaskForm } from "../components/TaskForm.jsx";
@@ -173,9 +174,7 @@ const load_tasks = (state, query, firstResult = 0) => {
     );
   } else {
     const filter =
-      filterValue === "my"
-        ? { assignee: state.api.user.profile.value?.id }
-        : {};
+      filterValue === "my" ? { assignee: resolve_user(state) } : {};
     void engine_rest.task.get_tasks(
       state,
       sortBy,
@@ -254,7 +253,7 @@ const TasksManage = () => {
     const body = {
       resourceType: "Task",
       name: filter.name,
-      owner: state.api.user.profile.value?.id,
+      owner: resolve_user(state),
       query: filter.query,
       properties: {},
     };
@@ -266,7 +265,7 @@ const TasksManage = () => {
     const body = {
       resourceType: "Task",
       name: filter.name,
-      owner: state.api.user.profile.value?.id,
+      owner: resolve_user(state),
       query: filter.query,
       properties: {},
     };
@@ -879,14 +878,14 @@ const ClaimButton = () => {
   const state = useContext(AppState),
     [t] = useTranslation(),
     task = state.api.task.one.value?.data,
-    user = state.api.user.profile.value?.data,
+    user_id = resolve_user(state),
     claim_result = state.api.task.claim_result.value?.data,
     assign_result = state.api.task.assign_result.value?.data,
     unclaim_result = state.api.task.unclaim_result.value?.data,
     close = () => document.getElementById("set_assignee").close(),
     show = () => document.getElementById("set_assignee").showModal(),
     user_is_assignee = task?.assignee,
-    assignee_is_different = task?.assignee && user?.id !== task?.assignee,
+    assignee_is_different = task?.assignee && user_id !== task?.assignee,
     claimed = claim_result?.status === RESPONSE_STATE.SUCCESS,
     assigned = assign_result?.status === RESPONSE_STATE.SUCCESS,
     unclaimed = unclaim_result?.status === RESPONSE_STATE.SUCCESS;
@@ -1073,7 +1072,7 @@ const Filter = () => {
       const body = {
         resourceType: "Task",
         name,
-        owner: state.api.user.profile.value?.id,
+        owner: resolve_user(state),
         query,
         properties: {
           description,

--- a/webapps-neo/frontend/src/state.js
+++ b/webapps-neo/frontend/src/state.js
@@ -49,8 +49,7 @@ const createAppState = () => {
       count: signal(null),
       list: signal(null),
       create: signal(null),
-      // todo: remove demo user when login is implemented
-      profile: signal({ id: "demo" }),
+      profile: signal(null),
       update: signal(null),
       delete: signal(null),
       group: {


### PR DESCRIPTION
Fixes #3631.

## The defect

The user profile signal was seeded with a placeholder:

```js
// src/state.js
// todo: remove demo user when login is implemented
profile: signal({ id: "demo" }),
```

`claim_task` read its id, so claiming assigned the task to `demo` — an account that need
not exist. The task then belongs to nobody: it drops out of the user's list and only "reset
assignee" brings it back.

The placeholder was not the whole story. The Admin page loads the profile of the user being
edited into that same signal, so after visiting Admin a claim would assign the task to
*that* person instead. Only a detour via Account made claim act on yourself.

## The change

Every "who am I" read now goes through `resolve_user`, the helper the rest of the code
already uses, which reads the signed-in user from `state.auth`:

```js
// src/api/helper.jsx
export const resolve_user = (state, user_name) => user_name ?? state.auth.user.id.value;
```

The comment above it describes this same bug, already fixed elsewhere — the account
settings page was PUTting to `/user/demo/credentials`. The claim path was missed in that
fix.

Three call sites had the same defect and are covered:

| what | was | now |
| --- | --- | --- |
| claim / unclaim | `demo`, or whoever Admin last loaded | the signed-in user |
| the "my tasks" filter | filtered by `demo`, so it showed nothing | the signed-in user |
| owner of a saved filter | stored as `demo` | the signed-in user |

The placeholder is gone and the profile signal starts empty, so a missing sign-in surfaces
instead of silently becoming a plausible-looking account.

## Testing

Full suite green (599), ESLint clean. The two existing claim/unclaim tests asserted the old
`demo` behaviour and now assert the signed-in user. A third test pins the Admin case: with
a different profile loaded into the signal, claim must still act on the signed-in user.

Walked through against a running engine: signing in and going straight to the task list —
without visiting Account — then claiming, now records the signed-in user.
