### PR TITLE
fix(webapps-neo): Reload the task list when a task is left

### DIFF
--- a/webapps-neo/frontend/src/pages/Tasks.jsx
+++ b/webapps-neo/frontend/src/pages/Tasks.jsx
@@ -1,6 +1,6 @@
 import { useSignal } from "@preact/signals";
 import { useLocation, useRoute } from "preact-iso";
-import { useContext, useEffect, useLayoutEffect } from "preact/hooks";
+import { useContext, useEffect, useLayoutEffect, useRef } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 
 import engine_rest, {
@@ -158,7 +158,7 @@ const derive_query = (current_query, patch) => {
   return out;
 };
 
-const load_tasks = (state, query, firstResult = 0) => {
+const load_tasks = (state, query, firstResult = 0, pageSize = TASK_PAGE_SIZE) => {
   const filterValue = query?.filter,
     sortBy = query?.sortBy ?? "name",
     sortOrder = query?.sortOrder ?? "asc",
@@ -168,7 +168,7 @@ const load_tasks = (state, query, firstResult = 0) => {
       state,
       filterValue,
       firstResult,
-      TASK_PAGE_SIZE,
+      pageSize,
       sorting,
     );
   } else {
@@ -181,15 +181,24 @@ const load_tasks = (state, query, firstResult = 0) => {
       sortBy,
       sortOrder,
       firstResult,
-      TASK_PAGE_SIZE,
+      pageSize,
       filter,
     );
   }
 };
 
+// Reload the list from the top, keeping however many entries are already shown.
+// A plain reload starts at firstResult 0, which replaces the list and would undo
+// "load more"; asking for as many as are on screen refreshes all of them at once.
+const reload_tasks = (state, query) => {
+  const shown = state.api.task.list.value?.data?.length ?? 0;
+  load_tasks(state, query, 0, Math.max(shown, TASK_PAGE_SIZE));
+};
+
 const TasksPage = () => {
   const state = useContext(AppState);
   const { params, query } = useRoute();
+  const open_task_id = useRef(undefined);
 
   useEffect(() => {
     if (state.api.filter.list.value === null) {
@@ -204,6 +213,18 @@ const TasksPage = () => {
     // sortBy, sortOrder. JSON-stringify is the simplest stable dep here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query.filter, query.sortBy, query.sortOrder]);
+
+  useEffect(() => {
+    // Completing a task routes back to /tasks, and so does navigating back by
+    // hand. Either way the list still holds what it fetched before, including
+    // the task that is now gone. Reload it on the way back — never on the way
+    // in, so opening a task costs no extra request.
+    const returned_to_list =
+      open_task_id.current !== undefined && params.task_id === undefined;
+    open_task_id.current = params.task_id;
+    if (returned_to_list) reload_tasks(state, query);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.task_id]);
 
   if (params?.task_id === "start") {
     return (

--- a/webapps-neo/frontend/src/pages/Tasks.test.jsx
+++ b/webapps-neo/frontend/src/pages/Tasks.test.jsx
@@ -187,6 +187,57 @@ describe("TasksPage", () => {
     });
   });
 
+  describe("returning to the list", () => {
+    const rerenderPage = (r, state) =>
+      r.rerender(h(AppState.Provider, { value: state }, h(TasksPage, {})));
+
+    it("reloads the list when a task is left, so a completed one disappears", () => {
+      mockParams = { task_id: "t1" };
+      const r = renderPage(state);
+      signal_response(state.api.task.list, [
+        sample_task({ id: "t1" }),
+        sample_task({ id: "t2" }),
+      ]);
+      engine_rest.task.get_tasks.mockClear();
+
+      mockParams = {};
+      rerenderPage(r, state);
+
+      expect(engine_rest.task.get_tasks).toHaveBeenCalled();
+      const [, , , firstResult] = engine_rest.task.get_tasks.mock.lastCall;
+      expect(firstResult).toBe(0);
+    });
+
+    it("keeps however many entries were loaded, so 'load more' is not undone", () => {
+      mockParams = { task_id: "t1" };
+      const r = renderPage(state);
+      signal_response(
+        state.api.task.list,
+        Array.from({ length: 25 }, (_, i) => sample_task({ id: `t${i}` })),
+      );
+      engine_rest.task.get_tasks.mockClear();
+
+      mockParams = {};
+      rerenderPage(r, state);
+
+      const [, , , firstResult, maxResults] =
+        engine_rest.task.get_tasks.mock.lastCall;
+      expect(firstResult).toBe(0);
+      expect(maxResults).toBe(25);
+    });
+
+    it("does not reload when a task is opened", () => {
+      mockParams = {};
+      const r = renderPage(state);
+      engine_rest.task.get_tasks.mockClear();
+
+      mockParams = { task_id: "t1" };
+      rerenderPage(r, state);
+
+      expect(engine_rest.task.get_tasks).not.toHaveBeenCalled();
+    });
+  });
+
   describe("special task_id routes", () => {
     it("renders the StartProcessList for /tasks/start", () => {
       mockParams = { task_id: "start" };


### PR DESCRIPTION
Fixes #3632.

## The defect

Completing a task routes back to `/tasks`, but the list only reloads when the filter or
sort order changes:

```jsx
// src/pages/Tasks.jsx
useEffect(() => {
  load_tasks(state, query);
  // Re-load when filter/sort change. `query` keys we care about: filter,
  // sortBy, sortOrder. JSON-stringify is the simplest stable dep here.
}, [query.filter, query.sortBy, query.sortOrder]);
```

Going from `/tasks/<id>/<tab>` to `/tasks` changes none of those three, so the effect never
re-ran and the list kept showing the task that had just been completed. Clicking it again
opened a task that no longer existed.

## The change

The reload runs **only on the way back**, not on the way in — a dependency on the route
parameter alone would fire when a task is opened too, and cost an extra request per click.

It also asks for as many entries as are currently on screen. A plain reload starts at
`firstResult` 0, and `get_tasks` replaces the list at 0 while appending above it:

```js
const existing = firstResult > 0 ? (prev?.data ?? []) : [];
```

So reloading from the top would silently undo "load more" for anyone who had paged past
the first twenty. Asking for the number on screen refreshes all of them in one request.

Reloading rather than dropping the row locally is deliberate: when the next task of the
same instance lands with the same user, it has to appear, not merely the old one vanish.
That is the normal case in a support rota.

## Testing

Three tests: the list reloads when a task is left, it keeps the number of entries that were
loaded, and it does **not** reload when a task is opened. Full suite green (601), ESLint
clean.

Walked through against a running engine: completing a task now removes it from the list
without a reload, and navigating back from a task without completing it refreshes the list
as well.
