### PR TITLE
refactor: Add nullability annotations and assertions to engine classes

### DIFF
--- a/.devenv/scripts/tools/nullmarked-coverage.cfg
+++ b/.devenv/scripts/tools/nullmarked-coverage.cfg
@@ -1,0 +1,13 @@
+[exclude]
+# One fnmatch-style wildcard pattern per line, matched against the module
+# path relative to --root (e.g. engine, spring-boot-starter/starter).
+modules =
+    qa/*
+
+[options]
+# Whether to also evaluate src/test/java sources.
+include_tests = false
+
+# Sort spec for the summary table: comma-separated Column:DIRECTION pairs.
+# Columns: Module, Classes, Covered, Rate. Direction defaults to ASC.
+sort_by = Rate:DESC

--- a/.devenv/scripts/tools/nullmarked-coverage.py
+++ b/.devenv/scripts/tools/nullmarked-coverage.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# Copyright 2025 the Operaton contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Evaluates @NullMarked (JSpecify) completion rate across Maven modules.
+
+A class counts as covered if:
+  - it (or its package-info.java, or the module's module-info.java) carries
+    @NullMarked, and
+  - it does not itself carry @NullUnmarked (which opts a class back out).
+
+Writes one detailed report per module to <module>/target/nullmarked-report.txt,
+listing every uncovered file, and prints an overall summary to stdout.
+"""
+
+import argparse
+import configparser
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CONFIG_NAME = 'nullmarked-coverage.cfg'
+DEFAULT_SORT_BY = 'Rate:DESC'
+
+SORT_COLUMNS = {
+    'module': lambda row: str(row[0]).lower(),
+    'classes': lambda row: row[1],
+    'covered': lambda row: row[2],
+    'rate': lambda row: row[3],
+}
+
+
+def parse_sort_spec(spec):
+    """'Module:ASC,Rate:DESC' -> [('module', False), ('rate', True)] (reverse flags)."""
+    criteria = []
+    for part in spec.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        if ':' in part:
+            column, direction = part.split(':', 1)
+        else:
+            column, direction = part, 'ASC'
+        column = column.strip().lower()
+        direction = direction.strip().upper()
+        if column not in SORT_COLUMNS:
+            raise ValueError(f"Unknown sort column '{column}'. Valid columns: "
+                              f"{', '.join(sorted(SORT_COLUMNS))}")
+        if direction not in ('ASC', 'DESC'):
+            raise ValueError(f"Unknown sort direction '{direction}'. Use ASC or DESC.")
+        criteria.append((column, direction == 'DESC'))
+    return criteria
+
+
+def sort_summary(summary, criteria):
+    # Stable sort: apply criteria from least to most significant.
+    for column, reverse in reversed(criteria):
+        summary.sort(key=SORT_COLUMNS[column], reverse=reverse)
+    return summary
+
+NULLMARKED_RE = re.compile(r'@(?:[\w.]+\.)?NullMarked\b')
+NULLUNMARKED_RE = re.compile(r'@(?:[\w.]+\.)?NullUnmarked\b')
+TOP_LEVEL_TYPE_RE = re.compile(
+    r'^\s*(?:public\s+|final\s+|abstract\s+|sealed\s+|non-sealed\s+|strictfp\s+)*'
+    r'(?:class|interface|enum|record|@interface)\s+\w'
+)
+LINE_COMMENT_RE = re.compile(r'//.*')
+BLOCK_COMMENT_RE = re.compile(r'/\*.*?\*/', re.DOTALL)
+
+EXCLUDED_DIR_NAMES = {'target', '.git', 'node_modules', 'build'}
+
+
+def strip_comments(text):
+    text = BLOCK_COMMENT_RE.sub('', text)
+    text = LINE_COMMENT_RE.sub('', text)
+    return text
+
+
+def load_config(config_path):
+    """Returns (exclude_patterns, include_tests, sort_by) from an INI-style config file."""
+    if config_path is None or not config_path.is_file():
+        return [], False, DEFAULT_SORT_BY
+
+    parser = configparser.ConfigParser()
+    parser.read(config_path, encoding='utf-8')
+
+    patterns = []
+    if parser.has_option('exclude', 'modules'):
+        raw = parser.get('exclude', 'modules')
+        patterns = [line.strip() for line in raw.splitlines() if line.strip()]
+
+    include_tests = False
+    if parser.has_option('options', 'include_tests'):
+        include_tests = parser.getboolean('options', 'include_tests')
+
+    sort_by = DEFAULT_SORT_BY
+    if parser.has_option('options', 'sort_by'):
+        sort_by = parser.get('options', 'sort_by')
+
+    return patterns, include_tests, sort_by
+
+
+def is_excluded(module_rel, patterns):
+    module_rel_str = str(module_rel)
+    return any(fnmatch.fnmatch(module_rel_str, pattern) for pattern in patterns)
+
+
+def find_modules(root, exclude_patterns=()):
+    """Maven modules: directories with a pom.xml and a src/main/java tree."""
+    modules = []
+    for pom in root.rglob('pom.xml'):
+        if any(part in EXCLUDED_DIR_NAMES for part in pom.parts):
+            continue
+        module_dir = pom.parent
+        if not (module_dir / 'src' / 'main' / 'java').is_dir():
+            continue
+        if is_excluded(module_dir.relative_to(root), exclude_patterns):
+            continue
+        modules.append(module_dir)
+    return sorted(modules)
+
+
+def module_is_null_marked(module_dir):
+    for module_info in module_dir.rglob('module-info.java'):
+        if any(part in EXCLUDED_DIR_NAMES for part in module_info.parts):
+            continue
+        text = strip_comments(module_info.read_text(encoding='utf-8', errors='replace'))
+        if NULLMARKED_RE.search(text):
+            return True
+    return False
+
+
+def is_top_level_type_marked(text):
+    """@NullMarked / @NullUnmarked found before the first top-level type keyword."""
+    lines = text.splitlines()
+    marked = False
+    unmarked = False
+    for line in lines:
+        if TOP_LEVEL_TYPE_RE.match(line):
+            break
+        if NULLMARKED_RE.search(line):
+            marked = True
+        if NULLUNMARKED_RE.search(line):
+            unmarked = True
+    return marked, unmarked
+
+
+def analyze_module(module_dir, include_tests):
+    source_roots = [module_dir / 'src' / 'main' / 'java']
+    if include_tests:
+        source_roots.append(module_dir / 'src' / 'test' / 'java')
+
+    module_marked = module_is_null_marked(module_dir)
+
+    package_marked_cache = {}
+
+    def is_package_marked(package_dir):
+        if package_dir not in package_marked_cache:
+            package_info = package_dir / 'package-info.java'
+            marked = False
+            if package_info.is_file():
+                text = strip_comments(package_info.read_text(encoding='utf-8', errors='replace'))
+                marked = bool(NULLMARKED_RE.search(text))
+            package_marked_cache[package_dir] = marked
+        return package_marked_cache[package_dir]
+
+    covered = []
+    uncovered = []
+
+    for source_root in source_roots:
+        if not source_root.is_dir():
+            continue
+        for java_file in sorted(source_root.rglob('*.java')):
+            if any(part in EXCLUDED_DIR_NAMES for part in java_file.parts):
+                continue
+            if java_file.name in ('package-info.java', 'module-info.java'):
+                continue
+
+            text = strip_comments(java_file.read_text(encoding='utf-8', errors='replace'))
+            class_marked, class_unmarked = is_top_level_type_marked(text)
+            package_marked = is_package_marked(java_file.parent)
+
+            rel = java_file.relative_to(module_dir)
+            if class_unmarked:
+                uncovered.append((rel, '@NullUnmarked on class'))
+            elif class_marked or package_marked or module_marked:
+                covered.append(rel)
+            else:
+                uncovered.append((rel, 'no @NullMarked (class/package/module)'))
+
+    return covered, uncovered
+
+
+def write_module_report(module_dir, covered, uncovered):
+    target_dir = module_dir / 'target'
+    target_dir.mkdir(parents=True, exist_ok=True)
+    report_path = target_dir / 'nullmarked-report.txt'
+
+    total = len(covered) + len(uncovered)
+    rate = (len(covered) / total * 100) if total else 100.0
+
+    lines = []
+    lines.append(f"NullMarked coverage report for module: {module_dir.name}")
+    lines.append(f"Module path: {module_dir}")
+    lines.append('')
+    lines.append(f"Total classes:    {total}")
+    lines.append(f"Covered classes:  {len(covered)}")
+    lines.append(f"Uncovered classes: {len(uncovered)}")
+    lines.append(f"Completion rate:  {rate:.1f}%")
+    lines.append('')
+
+    if uncovered:
+        lines.append("Uncovered files:")
+        for rel, reason in sorted(uncovered, key=lambda item: str(item[0])):
+            lines.append(f"  - {rel}  [{reason}]")
+    else:
+        lines.append("All classes covered.")
+
+    report_path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    return report_path, total, rate
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', default='.', help='Repository root (default: current directory)')
+    parser.add_argument('--config', default=None,
+                         help=f'Path to config file (default: {DEFAULT_CONFIG_NAME} next to this script)')
+    parser.add_argument('--exclude', action='append', default=[],
+                         help='Wildcard pattern (fnmatch) for module paths to exclude, e.g. "qa/*". '
+                              'Repeatable; merged with the config file exclusions.')
+    parser.add_argument('--include-tests', action='store_true',
+                         help='Also evaluate src/test/java sources (overrides config)')
+    parser.add_argument('--sort-by', default=None,
+                         help='Comma-separated sort spec, e.g. "Module:ASC,Rate:DESC". '
+                              'Columns: Module, Classes, Covered, Rate. Direction defaults to ASC. '
+                              f'Overrides config (default: {DEFAULT_SORT_BY}).')
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    config_path = Path(args.config).resolve() if args.config else Path(__file__).with_name(DEFAULT_CONFIG_NAME)
+    config_excludes, config_include_tests, config_sort_by = load_config(config_path)
+
+    exclude_patterns = config_excludes + args.exclude
+    include_tests = args.include_tests or config_include_tests
+
+    try:
+        sort_criteria = parse_sort_spec(args.sort_by or config_sort_by)
+    except ValueError as exc:
+        print(f"Invalid --sort-by: {exc}", file=sys.stderr)
+        return 1
+
+    modules = find_modules(root, exclude_patterns)
+
+    if not modules:
+        print(f"No Maven modules with src/main/java found under {root}", file=sys.stderr)
+        return 1
+
+    summary = []
+    for module_dir in modules:
+        covered, uncovered = analyze_module(module_dir, include_tests)
+        total = len(covered) + len(uncovered)
+        if total == 0:
+            continue
+        report_path, total, rate = write_module_report(module_dir, covered, uncovered)
+        summary.append((module_dir.relative_to(root), total, len(covered), rate, report_path))
+
+    sort_summary(summary, sort_criteria)
+
+    grand_total = sum(row[1] for row in summary)
+    grand_covered = sum(row[2] for row in summary)
+    grand_rate = (grand_covered / grand_total * 100) if grand_total else 100.0
+
+    print(f"{'Module':<55} {'Classes':>8} {'Covered':>8} {'Rate':>7}")
+    print('-' * 82)
+    for module_rel, total, covered_count, rate, report_path in summary:
+        print(f"{str(module_rel):<55} {total:>8} {covered_count:>8} {rate:>6.1f}%")
+    print('-' * 82)
+    print(f"{'TOTAL':<55} {grand_total:>8} {grand_covered:>8} {grand_rate:>6.1f}%")
+    print()
+    print(f"Detailed per-module reports written to <module>/target/nullmarked-report.txt")
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.devenv/scripts/tools/nullmarked-coverage.py
+++ b/.devenv/scripts/tools/nullmarked-coverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 the Operaton contributors.
+# Copyright 2026 the Operaton contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/commons/utils/src/main/java/org/operaton/commons/utils/StringUtil.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/StringUtil.java
@@ -105,7 +105,7 @@ public final class StringUtil {
    * @param text  the String to check, may be null
    * @return the passed in String, or the empty String if it  was <code>null</code>
    */
-  public static String defaultString(String text) {
+  public static String defaultString(@Nullable String text) {
       return text == null ? "" : text;
   }
 

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectorVariableScope.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectorVariableScope.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.core.variable.CoreVariableInstance;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.core.variable.scope.SimpleVariableInstance;
@@ -40,11 +41,11 @@ import org.operaton.connect.spi.ConnectorResponse;
 public class ConnectorVariableScope extends AbstractVariableScope {
   private static final VariableInstanceFactory<CoreVariableInstance> VARIABLE_INSTANCE_FACTORY = (VariableInstanceFactory) new SimpleVariableInstanceFactory();
 
-  protected AbstractVariableScope parent;
+  protected @Nullable AbstractVariableScope parent;
 
   protected transient VariableStore<SimpleVariableInstance> variableStore;
 
-  public ConnectorVariableScope(AbstractVariableScope parent) {
+  public ConnectorVariableScope(@Nullable AbstractVariableScope parent) {
     this.parent = parent;
     this.variableStore = new VariableStore<>();
   }
@@ -69,7 +70,7 @@ public class ConnectorVariableScope extends AbstractVariableScope {
   }
 
   @Override
-  public AbstractVariableScope getParentVariableScope() {
+  public @Nullable AbstractVariableScope getParentVariableScope() {
     return parent;
   }
 

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
@@ -16,16 +16,20 @@
  */
 package org.operaton.connect.plugin.impl;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.TaskActivityBehavior;
 import org.operaton.bpm.engine.impl.core.variable.mapping.IoMapping;
 import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.connect.ConnectorException;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.spi.CloseableConnectorResponse;
 import org.operaton.connect.spi.Connector;
 import org.operaton.connect.spi.ConnectorRequest;
 import org.operaton.connect.spi.ConnectorResponse;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Daniel Meyer
@@ -40,10 +44,10 @@ public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
 
   /** cached connector instance for this activity.
    * Will be initialized after the first execution of this activity. */
-  protected Connector<?> connectorInstance;
+  protected @Nullable Connector<?> connectorInstance;
 
   /** the local ioMapping for this connector. */
-  protected IoMapping ioMapping;
+  protected @Nullable IoMapping ioMapping;
 
   public ServiceTaskConnectorActivityBehavior(String connectorId, IoMapping ioMapping) {
     this.connectorId = connectorId;
@@ -53,6 +57,8 @@ public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
   @Override
   public void execute(final ActivityExecution execution) throws Exception {
     ensureConnectorInitialized();
+    EnsureUtil.ensureNotNull("Connector not initialized", "connectorInstance", connectorInstance);
+    requireNonNull(connectorInstance);
 
     executeWithErrorPropagation(execution, () -> {
       ConnectorRequest<?> request = connectorInstance.createRequest();

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/package-info.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/package-info.java
@@ -1,4 +1,6 @@
 /**
  * Implementation of the Connect connector framework integration via {@link org.operaton.connect.plugin.impl.ConnectProcessEnginePlugin}.
  */
-package org.operaton.connect.plugin.impl;
+@NullMarked package org.operaton.connect.plugin.impl;
+
+import org.jspecify.annotations.NullMarked;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/registry/ActivitiStateHandlerRegistry.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/registry/ActivitiStateHandlerRegistry.java
@@ -20,6 +20,8 @@ import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -41,13 +43,13 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Josh Long
  * @since 1.0
  */
-public class ActivitiStateHandlerRegistry extends ReceiveTaskActivityBehavior implements BeanFactoryAware, BeanNameAware, ActivityBehavior, InitializingBean {
+public @NullMarked class ActivitiStateHandlerRegistry extends ReceiveTaskActivityBehavior implements BeanFactoryAware, BeanNameAware, ActivityBehavior, InitializingBean {
 
     private final Logger logger = Logger.getLogger(getClass().getName());
 
     private final ConcurrentHashMap<String, ActivitiStateHandlerRegistration> registrations = new ConcurrentHashMap<>();
 
-    private ProcessEngine processEngine;
+    private @Nullable ProcessEngine processEngine;
 
     public void setProcessEngine(ProcessEngine processEngine) {
         this.processEngine = processEngine;
@@ -58,12 +60,7 @@ public class ActivitiStateHandlerRegistry extends ReceiveTaskActivityBehavior im
         // nothing to do here
     }
 
-    @Override
-    public void signal(ActivityExecution execution, String signalName, Object data) throws Exception {
-        leave(execution);
-    }
-
-    protected String registrationKey(String processName, String stateName) {
+    protected String registrationKey(@Nullable String processName, String stateName) {
         return (org.operaton.commons.utils.StringUtil.defaultString(processName) +
                 ":" + org.operaton.commons.utils.StringUtil.defaultString(stateName)).toLowerCase();
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/AbstractBpmnActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/AbstractBpmnActivityBehavior.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 import java.util.concurrent.Callable;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.bpmn.helper.BpmnExceptionHandler;
 import org.operaton.bpm.engine.impl.bpmn.helper.ErrorPropagationException;
@@ -106,7 +107,7 @@ public @NullMarked class AbstractBpmnActivityBehavior extends FlowNodeActivityBe
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     if(SIGNAL_COMPENSATION_DONE.equals(signalName)) {
       signalCompensationDone(execution);
     } else {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BoundaryConditionalEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BoundaryConditionalEventActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.parser.ConditionalEventDefinition;
 import org.operaton.bpm.engine.impl.core.variable.event.VariableEvent;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
@@ -25,7 +27,7 @@ import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public class BoundaryConditionalEventActivityBehavior extends BoundaryEventActivityBehavior implements ConditionalEventBehavior {
+public @NullMarked class BoundaryConditionalEventActivityBehavior extends BoundaryEventActivityBehavior implements ConditionalEventBehavior {
 
   protected final ConditionalEventDefinition conditionalEvent;
 
@@ -39,7 +41,7 @@ public class BoundaryConditionalEventActivityBehavior extends BoundaryEventActiv
   }
 
   @Override
-  public void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final VariableEvent variableEvent) {
+  public void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final @Nullable VariableEvent variableEvent) {
     final PvmExecutionImpl execution = eventSubscription.getExecution();
 
     if (execution != null && !execution.isEnded() && execution.isScope()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.process.ActivityStartBehavior;
 
 
@@ -31,6 +32,6 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityStartBehavior;
  * @author Daniel Meyer
  * @author Roman Smirnov
  */
-public class BoundaryEventActivityBehavior extends FlowNodeActivityBehavior {
+public @NullMarked class BoundaryEventActivityBehavior extends FlowNodeActivityBehavior {
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BpmnBehaviorLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/BpmnBehaviorLogger.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
@@ -29,7 +30,7 @@ import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 public class BpmnBehaviorLogger extends ProcessEngineLogger {
 
 
-  public void missingBoundaryCatchEvent(String executionId, String errorCode, String errorMessage) {
+  public void missingBoundaryCatchEvent(String executionId, String errorCode, @Nullable String errorMessage) {
     logInfo(
       "001",
       "Execution with id '{}' throws an error event with errorCode '{}' and errorMessage '{}', but no catching boundary event was defined. " +

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CancelBoundaryEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CancelBoundaryEventActivityBehavior.java
@@ -16,7 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
-import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.runtime.LegacyBehavior;
 
@@ -25,10 +26,10 @@ import org.operaton.bpm.engine.impl.pvm.runtime.LegacyBehavior;
  *
  * @author Daniel Meyer
  */
-public class CancelBoundaryEventActivityBehavior extends BoundaryEventActivityBehavior {
+public @NullMarked class CancelBoundaryEventActivityBehavior extends BoundaryEventActivityBehavior {
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
 
     if (LegacyBehavior.signalCancelBoundaryEvent(signalName)) {
       // join compensating executions
@@ -36,7 +37,7 @@ public class CancelBoundaryEventActivityBehavior extends BoundaryEventActivityBe
         leave(execution);
       }
       else {
-        ((ExecutionEntity)execution).forceUpdate();
+        execution.forceUpdate();
       }
     }
     else {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CancelEndEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CancelEndEventActivityBehavior.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Daniel Meyer
@@ -57,14 +58,14 @@ public @NullMarked class CancelEndEventActivityBehavior extends AbstractBpmnActi
   @Override
   public void doLeave(ActivityExecution execution) {
     // continue via the appropriate cancel boundary event
-    ScopeImpl eventScope = (ScopeImpl) cancelBoundaryEvent.getEventScope();
+    ScopeImpl eventScope = (ScopeImpl) getCancelBoundaryEvent().getEventScope();
 
     ActivityExecution boundaryEventScopeExecution = execution.findExecutionForFlowScope(eventScope);
-    boundaryEventScopeExecution.executeActivity(cancelBoundaryEvent);
+    boundaryEventScopeExecution.executeActivity(getCancelBoundaryEvent());
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
 
     // join compensating executions
     if(!execution.hasChildren()) {
@@ -78,7 +79,9 @@ public @NullMarked class CancelEndEventActivityBehavior extends AbstractBpmnActi
     this.cancelBoundaryEvent = cancelBoundaryEvent;
   }
 
-  public @Nullable PvmActivity getCancelBoundaryEvent() {
+  public PvmActivity getCancelBoundaryEvent() {
+    EnsureUtil.ensureNotNull("cancelBoundaryEvent", cancelBoundaryEvent);
+    requireNonNull(cancelBoundaryEvent);
     return cancelBoundaryEvent;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ClassDelegateActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ClassDelegateActivityBehavior.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.application.InvocationContext;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
@@ -44,7 +45,7 @@ import static org.operaton.bpm.engine.impl.util.ClassDelegateUtil.instantiateDel
  * @author Falko Menge
  * @author Roman Smirnov
  */
-public class ClassDelegateActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class ClassDelegateActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CompensationEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CompensationEventActivityBehavior.java
@@ -18,10 +18,11 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.helper.CompensationUtil;
 import org.operaton.bpm.engine.impl.bpmn.parser.CompensateEventDefinition;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
-import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 
@@ -33,7 +34,7 @@ import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
  * @author Philipp Ossler
  *
  */
-public class CompensationEventActivityBehavior extends FlowNodeActivityBehavior {
+public @NullMarked class CompensationEventActivityBehavior extends FlowNodeActivityBehavior {
 
   protected final CompensateEventDefinition compensateEventDefinition;
 
@@ -63,7 +64,7 @@ public class CompensationEventActivityBehavior extends FlowNodeActivityBehavior 
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     // join compensating executions -
     // only wait for non-event-scope executions cause a compensation event subprocess consume the compensation event and
     // do not have to compensate embedded subprocesses (which are still non-event-scope executions)
@@ -71,7 +72,7 @@ public class CompensationEventActivityBehavior extends FlowNodeActivityBehavior 
     if (((PvmExecutionImpl) execution).getNonEventScopeExecutions().isEmpty()) {
       leave(execution);
     } else {
-      ((ExecutionEntity) execution).forceUpdate();
+      execution.forceUpdate();
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ConditionalEventBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ConditionalEventBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.parser.ConditionalEventDefinition;
 import org.operaton.bpm.engine.impl.core.variable.event.VariableEvent;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
@@ -27,7 +29,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public interface ConditionalEventBehavior {
+public @NullMarked interface ConditionalEventBehavior {
 
   /**
    * Returns the current conditional event definition.
@@ -42,5 +44,5 @@ public interface ConditionalEventBehavior {
    * @param eventSubscription the event subscription which contains all necessary informations
    * @param variableEvent the variableEvent to evaluate the condition
    */
-  void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final VariableEvent variableEvent);
+  void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final @Nullable VariableEvent variableEvent);
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CustomActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/CustomActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.bpmn.delegate.ActivityBehaviorInvocation;
 import org.operaton.bpm.engine.impl.bpmn.delegate.ActivityBehaviorSignalInvocation;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -27,7 +28,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
  * @author Roman Smirnov
  *
  */
-public class CustomActivityBehavior implements ActivityBehavior, SignallableActivityBehavior {
+public @NullMarked class CustomActivityBehavior implements ActivityBehavior, SignallableActivityBehavior {
 
   protected ActivityBehavior delegateActivityBehavior;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/DmnBusinessRuleTaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/DmnBusinessRuleTaskActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.core.model.BaseCallableElement;
 import org.operaton.bpm.engine.impl.dmn.result.DecisionResultMapper;
@@ -38,7 +39,7 @@ import static org.operaton.bpm.engine.impl.util.DecisionEvaluationUtil.evaluateD
  * @author Daniel Meyer
  *
  */
-public class DmnBusinessRuleTaskActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class DmnBusinessRuleTaskActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected final BaseCallableElement callableElement;
   protected final String resultVariable;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ErrorEndEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ErrorEndEventActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.helper.BpmnExceptionHandler;
 import org.operaton.bpm.engine.impl.core.variable.mapping.value.ParameterValueProvider;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
@@ -25,12 +27,12 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Joram Barrez
  * @author Falko Menge
  */
-public class ErrorEndEventActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class ErrorEndEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected String errorCode;
-  private ParameterValueProvider errorMessageExpression;
+  private @Nullable ParameterValueProvider errorMessageExpression;
 
-  public ErrorEndEventActivityBehavior(String errorCode, ParameterValueProvider errorMessage) {
+  public ErrorEndEventActivityBehavior(String errorCode, @Nullable ParameterValueProvider errorMessage) {
     this.errorCode = errorCode;
     this.errorMessageExpression = errorMessage;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventBasedGatewayActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventBasedGatewayActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.bpmn.parser.ConditionalEventDefinition;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityBehavior;
@@ -25,7 +26,7 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
 /**
  * @author Daniel Meyer
  */
-public class EventBasedGatewayActivityBehavior extends FlowNodeActivityBehavior {
+public @NullMarked class EventBasedGatewayActivityBehavior extends FlowNodeActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventSubProcessActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventSubProcessActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.runtime.LegacyBehavior;
 
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.pvm.runtime.LegacyBehavior;
  * @author Daniel Meyer
  *
  */
-public class EventSubProcessActivityBehavior extends SubProcessActivityBehavior {
+public @NullMarked class EventSubProcessActivityBehavior extends SubProcessActivityBehavior {
 
   @Override
   public void complete(ActivityExecution scopeExecution) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventSubProcessStartConditionalEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventSubProcessStartConditionalEventActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.parser.ConditionalEventDefinition;
 import org.operaton.bpm.engine.impl.core.variable.event.VariableEvent;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
@@ -26,7 +28,7 @@ import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public class EventSubProcessStartConditionalEventActivityBehavior extends EventSubProcessStartEventActivityBehavior implements ConditionalEventBehavior {
+public @NullMarked class EventSubProcessStartConditionalEventActivityBehavior extends EventSubProcessStartEventActivityBehavior implements ConditionalEventBehavior {
 
   protected final ConditionalEventDefinition conditionalEvent;
 
@@ -40,7 +42,7 @@ public class EventSubProcessStartConditionalEventActivityBehavior extends EventS
   }
 
   @Override
-  public void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final VariableEvent variableEvent) {
+  public void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final @Nullable VariableEvent variableEvent) {
     PvmExecutionImpl execution = eventSubscription.getExecution();
 
     if (execution != null && !execution.isEnded() && execution.isScope()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventSubProcessStartEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/EventSubProcessStartEventActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.process.ActivityStartBehavior;
 
 
@@ -29,6 +30,6 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityStartBehavior;
  * @author Daniel Meyer
  * @author Roman Smirnov
  */
-public class EventSubProcessStartEventActivityBehavior extends NoneStartEventActivityBehavior {
+public @NullMarked class EventSubProcessStartEventActivityBehavior extends NoneStartEventActivityBehavior {
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.Iterator;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.Condition;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.bpmn.parser.BpmnParse;
@@ -31,7 +33,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  *
  * @author Joram Barrez
  */
-public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
+public @NullMarked class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
@@ -85,7 +87,7 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     }
   }
 
-  private boolean isOutgoingSequenceFlow(String defaultSequenceFlow, PvmTransition seqFlow, ActivityExecution execution) {
+  private boolean isOutgoingSequenceFlow(@Nullable String defaultSequenceFlow, PvmTransition seqFlow, ActivityExecution execution) {
     Condition condition = (Condition) seqFlow.getProperty(BpmnParse.PROPERTYNAME_CONDITION);
     return (condition == null && (defaultSequenceFlow == null || !defaultSequenceFlow.equals(seqFlow.getId())) )
         || (condition != null && condition.evaluate(execution));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ExternalTaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ExternalTaskActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.PriorityProvider;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.core.variable.mapping.value.ParameterValueProvider;
@@ -34,7 +36,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.MigrationObserverBehavior;
  * @author Thorben Lindhauer
  * @author Christopher Zell
  */
-public class ExternalTaskActivityBehavior extends AbstractBpmnActivityBehavior implements MigrationObserverBehavior {
+public @NullMarked class ExternalTaskActivityBehavior extends AbstractBpmnActivityBehavior implements MigrationObserverBehavior {
 
   protected ParameterValueProvider topicNameValueProvider;
   protected ParameterValueProvider priorityValueProvider;
@@ -57,7 +59,7 @@ public class ExternalTaskActivityBehavior extends AbstractBpmnActivityBehavior i
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/FlowNodeActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/FlowNodeActivityBehavior.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
@@ -65,7 +66,7 @@ public abstract @NullMarked class FlowNodeActivityBehavior implements Signallabl
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     // concrete activity behaviors that do accept signals should override this method;
 
     throw LOG.unsupportedSignalException(execution.getActivity().getId());

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/GatewayActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/GatewayActivityBehavior.java
@@ -16,25 +16,27 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
-import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import static java.util.Objects.requireNonNull;
+
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
 
 /**
- * super class for all gateway activity implementations.
+ * Super class for all gateway activity implementations.
  *
  * @author Joram Barrez
  */
-public abstract class GatewayActivityBehavior extends FlowNodeActivityBehavior {
+public abstract @NullMarked class GatewayActivityBehavior extends FlowNodeActivityBehavior {
 
   protected void lockConcurrentRoot(ActivityExecution execution) {
-    ActivityExecution concurrentRoot = null;
+    ActivityExecution concurrentRoot;
     if (execution.isConcurrent()) {
-      concurrentRoot = execution.getParent();
+      concurrentRoot = requireNonNull(execution.getParent(), "concurrent execution must have a parent");
     } else {
       concurrentRoot = execution;
     }
-    ((ExecutionEntity)concurrentRoot).forceUpdate();
+    concurrentRoot.forceUpdate();
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
@@ -18,11 +18,14 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.Condition;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.bpmn.parser.BpmnParse;
@@ -40,7 +43,7 @@ import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
  * @author Tom Van Buskirk
  * @author Joram Barrez
  */
-public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
+public @NullMarked class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
@@ -86,7 +89,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     execution.leaveActivityViaTransitions(transitionsToTake, joinedExecutions);
   }
 
-  private boolean isNotDefaultFlow(PvmTransition transition, String defaultSequenceFlow) {
+  private boolean isNotDefaultFlow(PvmTransition transition, @Nullable String defaultSequenceFlow) {
     return defaultSequenceFlow == null || !transition.getId().equals(defaultSequenceFlow);
   }
 
@@ -95,10 +98,10 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     return condition == null || condition.evaluate(execution);
   }
 
-  protected Collection<ActivityExecution> getLeafExecutions(ActivityExecution parent) {
+  protected Collection<ActivityExecution> getLeafExecutions(@Nullable ActivityExecution parent) {
     List<ActivityExecution> executionlist = new ArrayList<>();
-    List<? extends ActivityExecution> subExecutions = parent.getNonEventScopeExecutions();
-    if (subExecutions.isEmpty()) {
+    List<? extends ActivityExecution> subExecutions = parent != null ? parent.getNonEventScopeExecutions() : Collections.emptyList();
+    if (subExecutions.isEmpty() && parent != null) {
       executionlist.add(parent);
     } else {
       for (ActivityExecution concurrentExecution : subExecutions) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
 /**
@@ -24,7 +26,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Roman Smirnov
  *
  */
-public class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected boolean isAfterEventBasedGateway;
 
@@ -36,7 +38,6 @@ public class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivity
   public void execute(ActivityExecution execution) throws Exception {
     if (isAfterEventBasedGateway) {
       leave(execution);
-
     } else {
       // Do nothing: waitstate behavior
     }
@@ -47,7 +48,7 @@ public class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivity
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateCatchLinkEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateCatchLinkEventActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
 /**
@@ -23,7 +24,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Bernd Rücker
  *
  */
-public class IntermediateCatchLinkEventActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class IntermediateCatchLinkEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateConditionalEventBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateConditionalEventBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.parser.ConditionalEventDefinition;
 import org.operaton.bpm.engine.impl.core.variable.event.VariableEvent;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
@@ -27,7 +29,7 @@ import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public class IntermediateConditionalEventBehavior extends IntermediateCatchEventActivityBehavior implements ConditionalEventBehavior {
+public @NullMarked class IntermediateConditionalEventBehavior extends IntermediateCatchEventActivityBehavior implements ConditionalEventBehavior {
 
   protected final ConditionalEventDefinition conditionalEvent;
 
@@ -49,7 +51,7 @@ public class IntermediateConditionalEventBehavior extends IntermediateCatchEvent
   }
 
   @Override
-  public void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final VariableEvent variableEvent) {
+  public void leaveOnSatisfiedCondition(final EventSubscriptionEntity eventSubscription, final @Nullable VariableEvent variableEvent) {
     PvmExecutionImpl execution = eventSubscription.getExecution();
 
     if (execution != null && !execution.isEnded()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateThrowNoneEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/IntermediateThrowNoneEventActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
-public class IntermediateThrowNoneEventActivityBehavior extends FlowNodeActivityBehavior{
+import org.jspecify.annotations.NullMarked;
+
+public @NullMarked class IntermediateThrowNoneEventActivityBehavior extends FlowNodeActivityBehavior{
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -21,6 +21,8 @@ import org.apache.commons.mail2.jakarta.Email;
 import org.apache.commons.mail2.jakarta.HtmlEmail;
 import org.apache.commons.mail2.jakarta.SimpleEmail;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -34,18 +36,18 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Joram Barrez
  * @author Frederik Heremans
  */
-public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
-  protected Expression to;
-  protected Expression from;
-  protected Expression cc;
-  protected Expression bcc;
-  protected Expression subject;
-  protected Expression text;
-  protected Expression html;
-  protected Expression charset;
+  protected @Nullable Expression to;
+  protected @Nullable Expression from;
+  protected @Nullable Expression cc;
+  protected @Nullable Expression bcc;
+  protected @Nullable Expression subject;
+  protected @Nullable Expression text;
+  protected @Nullable Expression html;
+  protected @Nullable Expression charset;
 
   @Override
   public void execute(ActivityExecution execution) {
@@ -76,7 +78,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     leave(execution);
   }
 
-  protected Email createEmail(String text, String html) {
+  protected Email createEmail(@Nullable String text, @Nullable String html) {
     if (html != null) {
       return createHtmlEmail(text, html);
     } else if (text != null) {
@@ -86,7 +88,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected HtmlEmail createHtmlEmail(String text, String html) {
+  protected HtmlEmail createHtmlEmail(@Nullable String text, @Nullable String html) {
     HtmlEmail email = new HtmlEmail();
     try {
       email.setHtmlMsg(html);
@@ -109,7 +111,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected void addTo(Email email, String to) {
+  protected void addTo(Email email, @Nullable String to) {
     String[] tos = splitAndTrim(to);
     if (tos.length > 0) {
       for (String t : tos) {
@@ -124,7 +126,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected void setFrom(Email email, String from) {
+  protected void setFrom(Email email, @Nullable String from) {
     String fromAddress;
 
     if (from != null) {
@@ -140,7 +142,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected void addCc(Email email, String cc) {
+  protected void addCc(Email email, @Nullable String cc) {
     String[] ccs = splitAndTrim(cc);
     for (String c : ccs) {
       try {
@@ -151,7 +153,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected void addBcc(Email email, String bcc) {
+  protected void addBcc(Email email, @Nullable String bcc) {
     String[] bccs = splitAndTrim(bcc);
     for (String b : bccs) {
       try {
@@ -162,7 +164,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected void setSubject(Email email, String subject) {
+  protected void setSubject(Email email, @Nullable String subject) {
     email.setSubject(subject != null ? subject : "");
   }
 
@@ -185,13 +187,13 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected void setCharset(Email email, String charSetStr) {
+  protected void setCharset(Email email, @Nullable String charSetStr) {
     if (charset != null) {
       email.setCharset(charSetStr);
     }
   }
 
-  private String[] splitAndTrim(String str) {
+  private String[] splitAndTrim(@Nullable String str) {
     if (str != null) {
       String[] splittedStrings = str.split(",");
       for (int i = 0; i < splittedStrings.length; i++) {
@@ -202,7 +204,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     return new String[0];
   }
 
-  private String getStringFromField(Expression expression, DelegateExecution execution) {
+  private @Nullable String getStringFromField(@Nullable Expression expression, DelegateExecution execution) {
     if(expression != null) {
       Object value = expression.getValue(execution);
       if(value != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ManualTaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ManualTaskActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Implementation of the BPMN 2.0 'manual task': a task that is external to the
  * BPMS and to which there is no reference to IT systems whatsoever.
@@ -27,6 +29,6 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
  *
  * @author Joram Barrez
  */
-public class ManualTaskActivityBehavior extends TaskActivityBehavior {
+public @NullMarked class ManualTaskActivityBehavior extends TaskActivityBehavior {
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -29,8 +31,10 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.delegate.CompositeActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ModificationObserverBehavior;
 import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.variable.value.IntegerValue;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 
@@ -41,7 +45,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Daniel Meyer
  * @author Thorben Lindhauer
  */
-public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivityBehavior implements CompositeActivityBehavior, ModificationObserverBehavior {
+public abstract @NullMarked class MultiInstanceActivityBehavior extends AbstractBpmnActivityBehavior implements CompositeActivityBehavior, ModificationObserverBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
@@ -53,11 +57,11 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
   // Variable names for mi-instance scoped variables (as described in the spec)
   public static final String LOOP_COUNTER = "loopCounter";
 
-  protected Expression loopCardinalityExpression;
-  protected Expression completionConditionExpression;
-  protected Expression collectionExpression;
-  protected String collectionVariable;
-  protected String collectionElementVariable;
+  protected @Nullable Expression loopCardinalityExpression;
+  protected @Nullable Expression completionConditionExpression;
+  protected @Nullable Expression collectionExpression;
+  protected @Nullable String collectionVariable;
+  protected @Nullable String collectionElementVariable;
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
@@ -82,13 +86,13 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
   }
 
   protected void evaluateCollectionVariable(ActivityExecution execution, Collection<?> collection, int loopCounter) {
-    if (usesCollection() && collectionElementVariable != null && collection != null) {
+    if (usesCollection() && collectionElementVariable != null) {
       Object value = getElementAtIndex(loopCounter, collection);
       setLoopVariable(execution, collectionElementVariable, value);
     }
   }
 
-  protected Collection<?> evaluateCollection(ActivityExecution execution) {
+  protected @Nullable Collection<?> evaluateCollection(ActivityExecution execution) {
     Collection<?> collection = null;
     if (usesCollection() && collectionElementVariable != null) {
       if (collectionExpression != null) {
@@ -126,7 +130,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
     return nrOfInstances;
   }
 
-  protected Object getElementAtIndex(int i, Collection<?> collection) {
+  protected @Nullable Object getElementAtIndex(int i, Collection<?> collection) {
     Object value = null;
     int index = 0;
     Iterator<?> it = collection.iterator();
@@ -144,6 +148,8 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
 
   protected int resolveLoopCardinality(ActivityExecution execution) {
     // Using Number since expr can evaluate to eg. Long (which is also the default for Juel)
+    EnsureUtil.ensureNotNull("loopCardinalityExpression", loopCardinalityExpression);
+    requireNonNull(loopCardinalityExpression);
     Object value = loopCardinalityExpression.getValue(execution);
     if (value instanceof Number numberValue) {
       return numberValue.intValue();
@@ -157,10 +163,9 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
   protected boolean completionConditionSatisfied(ActivityExecution execution) {
     if (completionConditionExpression != null) {
       Object value = completionConditionExpression.getValue(execution);
-      if (! (value instanceof Boolean)) {
+      if (! (value instanceof Boolean booleanValue)) {
         throw LOG.expressionNotBooleanException("completionCondition", completionConditionExpression.getExpressionText());
       }
-      Boolean booleanValue = (Boolean) value;
 
       LOG.multiInstanceCompletionConditionState(booleanValue);
       return booleanValue;
@@ -178,8 +183,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
   /**
    * Get the inner activity of the multi instance execution.
    *
-   * @param execution
-   *          of multi instance activity
+   * @param miBodyActivity execution of multi instance activity
    * @return inner activity
    */
   public ActivityImpl getInnerActivity(PvmActivity miBodyActivity) {
@@ -193,18 +197,18 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
     throw new ProcessEngineException("inner activity of multi instance body activity '%s' not found".formatted(miBodyActivity.getId()));
   }
 
-  protected void setLoopVariable(ActivityExecution execution, String variableName, Object value) {
+  protected void setLoopVariable(ActivityExecution execution, String variableName, @Nullable Object value) {
     execution.setVariableLocal(variableName, value);
   }
 
-  protected Integer getLoopVariable(ActivityExecution execution, String variableName) {
+  protected @Nullable Integer getLoopVariable(ActivityExecution execution, String variableName) {
     IntegerValue value = execution.getVariableLocalTyped(variableName);
     ensureNotNull("The variable '%s' could not be found in execution with id '%s'".formatted(variableName, execution.getId()), "value", value);
     return value.getValue();
   }
 
 
-  protected Integer getLocalLoopVariable(ActivityExecution execution, String variableName) {
+  protected @Nullable Integer getLocalLoopVariable(ActivityExecution execution, String variableName) {
     return (Integer) execution.getVariableLocal(variableName);
   }
 
@@ -218,7 +222,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
 
   // Getters and Setters ///////////////////////////////////////////////////////////
 
-  public Expression getLoopCardinalityExpression() {
+  public @Nullable Expression getLoopCardinalityExpression() {
     return loopCardinalityExpression;
   }
 
@@ -226,7 +230,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
     this.loopCardinalityExpression = loopCardinalityExpression;
   }
 
-  public Expression getCompletionConditionExpression() {
+  public @Nullable Expression getCompletionConditionExpression() {
     return completionConditionExpression;
   }
 
@@ -234,7 +238,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
     this.completionConditionExpression = completionConditionExpression;
   }
 
-  public Expression getCollectionExpression() {
+  public @Nullable Expression getCollectionExpression() {
     return collectionExpression;
   }
 
@@ -242,7 +246,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
     this.collectionExpression = collectionExpression;
   }
 
-  public String getCollectionVariable() {
+  public @Nullable String getCollectionVariable() {
     return collectionVariable;
   }
 
@@ -250,7 +254,7 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
     this.collectionVariable = collectionVariable;
   }
 
-  public String getCollectionElementVariable() {
+  public @Nullable String getCollectionElementVariable() {
     return collectionElementVariable;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/NoneEndEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/NoneEndEventActivityBehavior.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
 
 /**
  * @author Joram Barrez
  */
-public class NoneEndEventActivityBehavior extends FlowNodeActivityBehavior {
+public @NullMarked class NoneEndEventActivityBehavior extends FlowNodeActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/NoneStartEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/NoneStartEventActivityBehavior.java
@@ -16,8 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
-
-
+import org.jspecify.annotations.NullMarked;
 
 /**
  * implementation of the 'none start event': a start event that has no
@@ -26,7 +25,7 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
  *
  * @author Joram Barrez
  */
-public class NoneStartEventActivityBehavior extends FlowNodeActivityBehavior {
+public @NullMarked class NoneStartEventActivityBehavior extends FlowNodeActivityBehavior {
 
   // Nothing to see here.
   // The default behaviour of the BpmnActivity is exactly what

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.pvm.PvmActivity;
 import org.operaton.bpm.engine.impl.pvm.PvmTransition;
@@ -59,7 +60,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Joram Barrez
  * @author Tom Baeyens
  */
-public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
+public @NullMarked class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ParallelMultiInstanceActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ParallelMultiInstanceActivityBehavior.java
@@ -18,8 +18,10 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.migration.instance.MigratingActivityInstance;
 import org.operaton.bpm.engine.impl.migration.instance.parser.MigratingInstanceParseContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -30,12 +32,15 @@ import org.operaton.bpm.engine.impl.pvm.delegate.MigrationObserverBehavior;
 import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.operaton.bpm.engine.impl.pvm.runtime.Callback;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Daniel Meyer
  *
  */
-public class ParallelMultiInstanceActivityBehavior extends MultiInstanceActivityBehavior implements MigrationObserverBehavior {
+public @NullMarked class ParallelMultiInstanceActivityBehavior extends MultiInstanceActivityBehavior implements MigrationObserverBehavior {
 
   @Override
   protected void createInstances(ActivityExecution execution, int nrOfInstances) {
@@ -44,6 +49,7 @@ public class ParallelMultiInstanceActivityBehavior extends MultiInstanceActivity
     // evaluate the collection to ensure the input of collectionExpression same as before
     // also reduces the loop count of collectionExpression
     Collection<?> collection = evaluateCollection(execution);
+    collection = collection != null ? collection : Collections.emptyList();
     // initialize the scope and create the desired number of child executions
     prepareScopeExecution(execution, nrOfInstances);
 
@@ -162,6 +168,8 @@ public class ParallelMultiInstanceActivityBehavior extends MultiInstanceActivity
   public void destroyInnerInstance(ActivityExecution concurrentExecution) {
 
     ActivityExecution scopeExecution = concurrentExecution.getParent();
+    EnsureUtil.ensureNotNull("Parent execution must be present", "scopeExecution", scopeExecution);
+    requireNonNull(scopeExecution);
     concurrentExecution.remove();
     scopeExecution.forceUpdate();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ReceiveTaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ReceiveTaskActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
@@ -30,7 +32,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  *
  * @author Joram Barrez
  */
-public class ReceiveTaskActivityBehavior extends TaskActivityBehavior {
+public @NullMarked class ReceiveTaskActivityBehavior extends TaskActivityBehavior {
 
   @Override
   public void performExecution(ActivityExecution execution) {
@@ -38,7 +40,7 @@ public class ReceiveTaskActivityBehavior extends TaskActivityBehavior {
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object data) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object data) throws Exception {
     leave(execution);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import org.operaton.bpm.engine.delegate.BpmnError;
@@ -36,12 +37,12 @@ import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
  * @author Daniel Meyer
  *
  */
-public class ScriptTaskActivityBehavior extends TaskActivityBehavior {
+public @NullMarked class ScriptTaskActivityBehavior extends TaskActivityBehavior {
 
   protected ExecutableScript script;
-  protected String resultVariable;
+  protected @Nullable String resultVariable;
 
-  public ScriptTaskActivityBehavior(ExecutableScript script, String resultVariable) {
+  public ScriptTaskActivityBehavior(ExecutableScript script, @Nullable String resultVariable) {
     this.script = script;
     this.resultVariable = resultVariable;
   }
@@ -68,7 +69,10 @@ public class ScriptTaskActivityBehavior extends TaskActivityBehavior {
    *          the exception to check
    * @return the BpmnError that was the cause of this exception or null if no
    *         BpmnError was found
+   * @deprecated unused internal API
    */
+  @Deprecated(forRemoval = true, since = "2.2")
+  @SuppressWarnings("java:S1133")
   protected @Nullable BpmnError checkIfCauseOfExceptionIsBpmnError(Throwable e) {
     if (e instanceof BpmnError bpmnError) {
       return bpmnError;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/SequentialMultiInstanceActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/SequentialMultiInstanceActivityBehavior.java
@@ -18,8 +18,10 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.pvm.PvmActivity;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
@@ -30,13 +32,14 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
  * @author Daniel Meyer
  * @author Thorben Lindhauer
  */
-public class SequentialMultiInstanceActivityBehavior extends MultiInstanceActivityBehavior {
+public @NullMarked class SequentialMultiInstanceActivityBehavior extends MultiInstanceActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
   @Override
   protected void createInstances(ActivityExecution execution, int nrOfInstances) {
     Collection<?> collection = evaluateCollection(execution);
+    collection = collection != null ? collection : Collections.emptyList();
     prepareScope(execution, nrOfInstances);
     setLoopVariable(execution, NUMBER_OF_ACTIVE_INSTANCES, 1);
 
@@ -56,6 +59,7 @@ public class SequentialMultiInstanceActivityBehavior extends MultiInstanceActivi
     }
     else {
       Collection<?> collection = evaluateCollection(scopeExecution);
+      collection = collection != null ? collection : Collections.emptyList();
       PvmActivity innerActivity = getInnerActivity(scopeExecution.getActivity());
       performInstance(scopeExecution, innerActivity, loopCounter, collection);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.application.InvocationContext;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.engine.delegate.Expression;
@@ -34,6 +36,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
 
+import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.ClassDelegateUtil.applyFieldDeclaration;
 
 
@@ -46,7 +49,7 @@ import static org.operaton.bpm.engine.impl.util.ClassDelegateUtil.applyFieldDecl
  * @author Slawomir Wojtasiak (Patch for ACT-1159)
  * @author Falko Menge
  */
-public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityBehavior {
+public @NullMarked class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
@@ -59,8 +62,9 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
   }
 
   @Override
-  public void signal(final ActivityExecution execution, final String signalName, final Object signalData) throws Exception {
+  public void signal(final ActivityExecution execution, final @Nullable String signalName, final @Nullable Object signalData) throws Exception {
     ProcessApplicationReference targetProcessApplication = ProcessApplicationContextUtil.getTargetProcessApplication((ExecutionEntity) execution);
+    requireNonNull(targetProcessApplication);
     if(ProcessApplicationContextUtil.requiresContextSwitch(targetProcessApplication)) {
       Context.executeWithinProcessApplication(() -> {
         signal(execution, signalName, signalData);
@@ -72,7 +76,7 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
     }
   }
 
-  public void doSignal(final ActivityExecution execution, final String signalName, final Object signalData) throws Exception {
+  public void doSignal(final ActivityExecution execution, final @Nullable String signalName, final @Nullable Object signalData) throws Exception {
     Object delegate = expression.getValue(execution);
     applyFieldDeclaration(fieldDeclarations, delegate);
     final ActivityBehavior activityBehaviorInstance = getActivityBehaviorInstance(execution, delegate);
@@ -91,7 +95,7 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
     });
   }
 
-	@Override
+  @Override
   public void performExecution(final ActivityExecution execution) throws Exception {
 	  Callable<Void> callable = () -> {
       // Note: we can't cache the result of the expression, because the

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
@@ -29,12 +31,12 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Slawomir Wojtasiak (Patch for ACT-1159)
  * @author Falko Menge
  */
-public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior {
+public @NullMarked class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior {
 
   protected Expression expression;
-  protected String resultVariable;
+  protected @Nullable String resultVariable;
 
-  public ServiceTaskExpressionActivityBehavior(Expression expression, String resultVariable) {
+  public ServiceTaskExpressionActivityBehavior(Expression expression, @Nullable String resultVariable) {
     this.expression = expression;
     this.resultVariable = resultVariable;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -27,46 +27,49 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 
 import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
-  protected Expression command;
-  protected Expression wait;
-  protected Expression arg1;
-  protected Expression arg2;
-  protected Expression arg3;
-  protected Expression arg4;
-  protected Expression arg5;
-  protected Expression outputVariable;
-  protected Expression errorCodeVariable;
-  protected Expression redirectError;
-  protected Expression cleanEnv;
-  protected Expression directory;
+  protected @Nullable Expression command;
+  protected @Nullable Expression wait;
+  protected @Nullable Expression arg1;
+  protected @Nullable Expression arg2;
+  protected @Nullable Expression arg3;
+  protected @Nullable Expression arg4;
+  protected @Nullable Expression arg5;
+  protected @Nullable Expression outputVariable;
+  protected @Nullable Expression errorCodeVariable;
+  protected @Nullable Expression redirectError;
+  protected @Nullable Expression cleanEnv;
+  protected @Nullable Expression directory;
 
-  String commandStr;
-  String arg1Str;
-  String arg2Str;
-  String arg3Str;
-  String arg4Str;
-  String arg5Str;
-  String waitStr;
-  String resultVariableStr;
-  String errorCodeVariableStr;
-  Boolean waitFlag;
-  Boolean redirectErrorFlag;
-  Boolean cleanEnvBoolan;
-  String directoryStr;
+  @Nullable String commandStr;
+  @Nullable String arg1Str;
+  @Nullable String arg2Str;
+  @Nullable String arg3Str;
+  @Nullable String arg4Str;
+  @Nullable String arg5Str;
+  @Nullable String waitStr;
+  @Nullable String resultVariableStr;
+  @Nullable String errorCodeVariableStr;
+  @Nullable Boolean waitFlag;
+  Boolean redirectErrorFlag = false;
+  @Nullable Boolean cleanEnvBoolan;
+  @Nullable String directoryStr;
 
   private void readFields(ActivityExecution execution) {
     commandStr = getStringFromField(command, execution);
@@ -95,6 +98,9 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
     readFields(execution);
 
     List<String> argList = new ArrayList<>();
+
+    EnsureUtil.ensureNotNull("Command is missing","command", commandStr);
+    Objects.requireNonNull(commandStr);
     argList.add(commandStr);
 
     if (arg1Str != null) {
@@ -169,7 +175,7 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
     }
   }
 
-  protected String getStringFromField(Expression expression, DelegateExecution execution) {
+  protected @Nullable String getStringFromField(@Nullable Expression expression, DelegateExecution execution) {
     if (expression != null) {
       Object value = expression.getValue(execution);
       if (value != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/SubProcessActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/SubProcessActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.bpmn.helper.BpmnProperties;
 import org.operaton.bpm.engine.impl.bpmn.helper.CompensationUtil;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -32,7 +33,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  *
  * @author Joram Barrez
  */
-public class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior implements CompositeActivityBehavior {
+public @NullMarked class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior implements CompositeActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/TaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/TaskActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
 
@@ -29,12 +31,12 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  *
  * @author Joram Barrez
  */
-public class TaskActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class TaskActivityBehavior extends AbstractBpmnActivityBehavior {
 
   /**
    * Activity instance id before execution.
    */
-  protected String activityInstanceId;
+  protected @Nullable String activityInstanceId;
 
   /**
    * The method which will be called before the execution is performed.
@@ -49,7 +51,6 @@ public class TaskActivityBehavior extends AbstractBpmnActivityBehavior {
    * The method which should be overridden by the sub classes to perform an execution.
    *
    * @param execution the execution which is used during performing the execution
-   * @throws Exception
    */
   protected void performExecution(ActivityExecution execution) throws Exception {
     leave(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.process.ActivityStartBehavior;
 
@@ -30,7 +31,7 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityStartBehavior;
  * @author Daniel Meyer
  * @author Roman Smirnov
  */
-public class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior {
+public @NullMarked class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ThrowEscalationEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ThrowEscalationEventActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.behavior;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.helper.EscalationHandler;
 import org.operaton.bpm.engine.impl.bpmn.parser.Escalation;
 import org.operaton.bpm.engine.impl.bpmn.parser.EscalationEventDefinition;
@@ -29,7 +31,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Philipp Ossler
  *
  */
-public class ThrowEscalationEventActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class ThrowEscalationEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected final Escalation escalation;
 
@@ -49,7 +51,7 @@ public class ThrowEscalationEventActivityBehavior extends AbstractBpmnActivityBe
   }
 
   @SuppressWarnings("unused")
-  protected void leaveExecution(ActivityExecution execution, final PvmActivity currentActivity, EscalationEventDefinition escalationEventDefinition) {
+  protected void leaveExecution(ActivityExecution execution, final @Nullable PvmActivity currentActivity, @Nullable EscalationEventDefinition escalationEventDefinition) {
 
     // execution tree could have been expanded by triggering a non-interrupting event
     ExecutionEntity replacingExecution = ((ExecutionEntity) execution).getReplacedBy();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ThrowSignalEventActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ThrowSignalEventActivityBehavior.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.bpmn.parser.EventSubscriptionDeclaration;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -25,14 +27,17 @@ import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionManager;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
+import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.variable.VariableMap;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Defines activity behavior for signal end event and intermediate throw signal event.
  *
  * @author Daniel Meyer
  */
-public class ThrowSignalEventActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class ThrowSignalEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
   protected static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
@@ -49,6 +54,8 @@ public class ThrowSignalEventActivityBehavior extends AbstractBpmnActivityBehavi
     VariableMap variableMap = signalDefinition.getEventPayload().getInputVariables(execution);
 
     String eventName = signalDefinition.resolveExpressionOfEventName(execution);
+    EnsureUtil.ensureNotNull("Could not resolve event name", "eventName", eventName);
+    requireNonNull(eventName);
     // trigger all event subscriptions for the signal (start and intermediate)
     List<EventSubscriptionEntity> signalEventSubscriptions =
         findSignalEventSubscriptions(eventName, execution.getTenantId());
@@ -61,7 +68,7 @@ public class ThrowSignalEventActivityBehavior extends AbstractBpmnActivityBehavi
     leave(execution);
   }
 
-  protected List<EventSubscriptionEntity> findSignalEventSubscriptions(String signalName, String tenantId) {
+  protected List<EventSubscriptionEntity> findSignalEventSubscriptions(String signalName, @Nullable String tenantId) {
     EventSubscriptionManager eventSubscriptionManager = Context.getCommandContext().getEventSubscriptionManager();
 
     if (tenantId != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.bpmn.behavior;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.el.ExpressionManager;
 import org.operaton.bpm.engine.impl.migration.instance.MigratingActivityInstance;
 import org.operaton.bpm.engine.impl.migration.instance.MigratingUserTaskInstance;
@@ -37,7 +39,7 @@ import org.operaton.bpm.engine.impl.task.TaskDefinition;
  * @author Joram Barrez
  * @author Roman Smirnov
  */
-public class UserTaskActivityBehavior extends TaskActivityBehavior implements MigrationObserverBehavior {
+public @NullMarked class UserTaskActivityBehavior extends TaskActivityBehavior implements MigrationObserverBehavior {
 
   protected TaskDecorator taskDecorator;
 
@@ -67,7 +69,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Mi
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnExceptionHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnExceptionHandler.java
@@ -100,7 +100,8 @@ public final @NullMarked class BpmnExceptionHandler {
     propagateError(error.getErrorCode(), error.getMessage(), null, execution);
   }
 
-  public static void propagateError(@Nullable String errorCode, String errorMessage, @Nullable Exception origException, ActivityExecution execution) throws Exception {
+  @SuppressWarnings("java:S112") // can't declare a more specific exception type
+  public static void propagateError(@Nullable String errorCode, @Nullable String errorMessage, @Nullable Exception origException, ActivityExecution execution) throws Exception {
 
     ActivityExecutionHierarchyWalker walker = new ActivityExecutionHierarchyWalker(execution);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/ConditionalEventDefinition.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/ConditionalEventDefinition.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.bpmn.parser;
 
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.impl.Condition;
 import org.operaton.bpm.engine.impl.core.variable.event.VariableEvent;
@@ -30,16 +32,16 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
  *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
-public class ConditionalEventDefinition extends EventSubscriptionDeclaration {
+public @NullMarked class ConditionalEventDefinition extends EventSubscriptionDeclaration {
 
-  private String conditionAsString;
-  private final Condition condition;
+  private @Nullable String conditionAsString;
+  private final @Nullable Condition condition;
   private boolean interrupting;
-  private String variableName;
-  private Set<String> variableEvents;
+  private @Nullable String variableName;
+  private @Nullable Set<String> variableEvents;
   private ActivityImpl conditionalActivity;
 
-  public ConditionalEventDefinition(Condition condition, ActivityImpl conditionalActivity) {
+  public ConditionalEventDefinition(@Nullable Condition condition, ActivityImpl conditionalActivity) {
     super(null, EventType.CONDITONAL);
     this.activityId = conditionalActivity.getActivityId();
     this.conditionalActivity = conditionalActivity;
@@ -62,7 +64,7 @@ public class ConditionalEventDefinition extends EventSubscriptionDeclaration {
     this.interrupting = interrupting;
   }
 
-  public String getVariableName() {
+  public @Nullable String getVariableName() {
     return variableName;
   }
 
@@ -71,14 +73,14 @@ public class ConditionalEventDefinition extends EventSubscriptionDeclaration {
   }
 
   public Set<String> getVariableEvents() {
-    return variableEvents;
+    return variableEvents != null ? variableEvents : Set.of();
   }
 
   public void setVariableEvents(Set<String> variableEvents) {
     this.variableEvents = variableEvents;
   }
 
-  public String getConditionAsString() {
+  public @Nullable String getConditionAsString() {
     return conditionAsString;
   }
 
@@ -107,7 +109,7 @@ public class ConditionalEventDefinition extends EventSubscriptionDeclaration {
     throw new IllegalStateException("Conditional event must have a condition!");
   }
 
-  public boolean tryEvaluate(VariableEvent variableEvent, DelegateExecution execution) {
+  public boolean tryEvaluate(@Nullable VariableEvent variableEvent, DelegateExecution execution) {
     return (variableEvent == null || shouldEvaluateForVariableEvent(variableEvent)) && tryEvaluate(execution);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/model/CoreModelElement.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/model/CoreModelElement.java
@@ -20,9 +20,13 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.*;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.BaseDelegateExecution;
 import org.operaton.bpm.engine.delegate.DelegateListener;
 import org.operaton.bpm.engine.delegate.VariableListener;
+
+import static java.util.Collections.emptyList;
 
 /**
  * @author Daniel Meyer
@@ -31,12 +35,12 @@ import org.operaton.bpm.engine.delegate.VariableListener;
  *
  */
 @SuppressWarnings("java:S1948")
-public abstract class CoreModelElement implements Serializable {
+public abstract @NullMarked class CoreModelElement implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
 
   protected String id;
-  protected String name;
+  protected @Nullable String name;
   protected Properties properties = new Properties();
 
   /** contains built-in listeners */
@@ -59,7 +63,7 @@ public abstract class CoreModelElement implements Serializable {
     return id;
   }
 
-  public String getName() {
+  public @Nullable String getName() {
     return name;
   }
 
@@ -67,14 +71,14 @@ public abstract class CoreModelElement implements Serializable {
    * @see Properties#set(PropertyKey, Object)
    */
   public void setProperty(String name, Object value) {
-    properties.set(new PropertyKey<Object>(name), value);
+    properties.set(new PropertyKey<>(name), value);
   }
 
   /**
    * @see Properties#get(PropertyKey)
    */
-  public Object getProperty(String name) {
-    return properties.get(new PropertyKey<Object>(name));
+  public @Nullable Object getProperty(String name) {
+    return properties.get(new PropertyKey<>(name));
   }
 
   /**
@@ -102,34 +106,22 @@ public abstract class CoreModelElement implements Serializable {
 
   public List<DelegateListener<? extends BaseDelegateExecution>> getListeners(String eventName) {
     List<DelegateListener<? extends BaseDelegateExecution>> listenerList = getListeners().get(eventName);
-    if (listenerList != null) {
-      return listenerList;
-    }
-    return Collections.emptyList();
+    return listenerList != null ? listenerList : emptyList();
   }
 
   public List<DelegateListener<? extends BaseDelegateExecution>> getBuiltInListeners(String eventName) {
     List<DelegateListener<? extends BaseDelegateExecution>> listenerList = getBuiltInListeners().get(eventName);
-    if (listenerList != null) {
-      return listenerList;
-    }
-    return Collections.emptyList();
+    return listenerList != null ? listenerList : emptyList();
   }
 
   public List<VariableListener<?>> getVariableListenersLocal(String eventName) {
     List<VariableListener<?>> listenerList = getVariableListeners().get(eventName);
-    if (listenerList != null) {
-      return listenerList;
-    }
-    return Collections.emptyList();
+    return listenerList != null ? listenerList : emptyList();
   }
 
   public List<VariableListener<?>> getBuiltInVariableListenersLocal(String eventName) {
     List<VariableListener<?>> listenerList = getBuiltInVariableListeners().get(eventName);
-    if (listenerList != null) {
-      return listenerList;
-    }
-    return Collections.emptyList();
+    return listenerList != null ? listenerList : emptyList();
   }
 
   public void addListener(String eventName, DelegateListener<? extends BaseDelegateExecution> listener) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/DecisionDefinitionCache.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/DecisionDefinitionCache.java
@@ -24,7 +24,6 @@ import org.operaton.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionEnti
 import org.operaton.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionManager;
 import org.operaton.bpm.engine.impl.persistence.AbstractResourceDefinitionManager;
 
-import static java.util.Objects.requireNonNull;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
@@ -42,8 +41,6 @@ public @NullMarked class DecisionDefinitionCache extends ResourceDefinitionCache
   public @Nullable DecisionDefinitionEntity findDeployedDefinitionByKeyAndVersion(String definitionKey, Integer definitionVersion) {
     DecisionDefinitionEntity definition = ((DecisionDefinitionManager) getManager())
         .findDecisionDefinitionByKeyAndVersion(definitionKey, definitionVersion);
-    ensureNotNull("Decision Definition '%s' not found".formatted(definitionKey), "decisionDefinition", definition);
-    requireNonNull(definition);
 
     checkInvalidDefinitionByKeyAndVersion(definitionKey, definitionVersion, definition);
     return resolveDefinition(definition);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/PvmProcessElement.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/PvmProcessElement.java
@@ -18,27 +18,31 @@ package org.operaton.bpm.engine.impl.pvm;
 
 import java.io.Serializable;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.core.model.Properties;
 
 
 /**
  * @author Tom Baeyens
  */
-public interface PvmProcessElement extends Serializable {
+public @NullMarked interface PvmProcessElement extends Serializable {
 
   /**
-   * The id of the element
-   * @return the id
+   * @return The id of the element
    */
   String getId();
 
   /**
-   * The process definition scope, root of the scope hierarchy.
-   * @return
+   * @return The process definition scope, root of the scope hierarchy.
    */
   PvmProcessDefinition getProcessDefinition();
 
-  Object getProperty(String name);
+  /**
+   * @param name the name of the property
+   * @return the property value or null if not found
+   */
+  @Nullable Object getProperty(String name);
 
   /**
    * Returns the properties of the element.

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/cmmn/model/CmmnActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/cmmn/model/CmmnActivityTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
 import org.operaton.bpm.engine.delegate.VariableListener;
@@ -28,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CmmnActivityTest {
 
-  static class TestCmmnActivity extends CmmnActivity {
+  static @NullMarked class TestCmmnActivity extends CmmnActivity {
     private final Map<String, List<VariableListener<?>>> customLocal = new HashMap<>();
     private final Map<String, List<VariableListener<?>>> builtInLocal = new HashMap<>();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/compensate/helper/WaitStateUndoService.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/compensate/helper/WaitStateUndoService.java
@@ -16,21 +16,29 @@
  */
 package org.operaton.bpm.engine.test.bpmn.event.compensate.helper;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
 
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Daniel Meyer
  */
-public class WaitStateUndoService extends AbstractBpmnActivityBehavior implements SignallableActivityBehavior {
+public @NullMarked class WaitStateUndoService extends AbstractBpmnActivityBehavior implements SignallableActivityBehavior {
 
-  private Expression counterName;
+  private @Nullable Expression counterName;
+
+  public void setCounterName(Expression counterName) {
+    this.counterName = counterName;
+  }
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
+    requireNonNull(counterName);
     String variableName = (String) counterName.getValue(execution);
     Object variable = execution.getVariable(variableName);
     if(variable == null) {
@@ -42,7 +50,7 @@ public class WaitStateUndoService extends AbstractBpmnActivityBehavior implement
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalEvent, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalEvent, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/PassThroughDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/PassThroughDelegate.java
@@ -18,10 +18,12 @@ package org.operaton.bpm.engine.test.bpmn.event.error;
 
 import java.io.Serializable;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
-public class PassThroughDelegate extends AbstractBpmnActivityBehavior implements Serializable {
+public @NullMarked class PassThroughDelegate extends AbstractBpmnActivityBehavior implements Serializable {
 
   public static final long serialVersionUID = 1L;
 
@@ -31,9 +33,8 @@ public class PassThroughDelegate extends AbstractBpmnActivityBehavior implements
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     super.leave(execution);
   }
-
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/ThrowBpmnErrorSignallableActivityBehaviour.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/ThrowBpmnErrorSignallableActivityBehaviour.java
@@ -16,11 +16,13 @@
  */
 package org.operaton.bpm.engine.test.bpmn.event.error;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.BpmnError;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
-public class ThrowBpmnErrorSignallableActivityBehaviour extends AbstractBpmnActivityBehavior {
+public @NullMarked class ThrowBpmnErrorSignallableActivityBehaviour extends AbstractBpmnActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
@@ -28,7 +30,7 @@ public class ThrowBpmnErrorSignallableActivityBehaviour extends AbstractBpmnActi
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     throw new BpmnError("23", "Testing bpmn error in SignallableActivityBehaviour#signal");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/ThrowErrorDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/ThrowErrorDelegate.java
@@ -20,11 +20,13 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.BpmnError;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
-public class ThrowErrorDelegate extends AbstractBpmnActivityBehavior implements Serializable {
+public @NullMarked class ThrowErrorDelegate extends AbstractBpmnActivityBehavior implements Serializable {
 
   public static final long serialVersionUID = 1L;
 
@@ -34,7 +36,7 @@ public class ThrowErrorDelegate extends AbstractBpmnActivityBehavior implements 
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     handle(execution, "signaled");
   }
 
@@ -54,15 +56,15 @@ public class ThrowErrorDelegate extends AbstractBpmnActivityBehavior implements 
   }
 
   public static Map<String, Object> throwError() {
-    return Collections.singletonMap("type", (Object) "error");
+    return Collections.singletonMap("type", "error");
   }
 
   public static Map<String, Object> throwException() {
-    return Collections.singletonMap("type", (Object) "exception");
+    return Collections.singletonMap("type", "exception");
   }
 
   public static Map<String, Object> leaveExecution() {
-    return Collections.singletonMap("type", (Object) "leave");
+    return Collections.singletonMap("type", "leave");
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/SignalableBehavior.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/SignalableBehavior.java
@@ -16,10 +16,12 @@
  */
 package org.operaton.bpm.engine.test.bpmn.gateway;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
-public class SignalableBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class SignalableBehavior extends AbstractBpmnActivityBehavior {
 
   @Override
   public void execute(final ActivityExecution execution) throws Exception {
@@ -27,7 +29,7 @@ public class SignalableBehavior extends AbstractBpmnActivityBehavior {
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/sendtask/DummyActivityBehavior.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/sendtask/DummyActivityBehavior.java
@@ -16,18 +16,20 @@
  */
 package org.operaton.bpm.engine.test.bpmn.sendtask;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.TaskActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
-public class DummyActivityBehavior extends TaskActivityBehavior {
+public @NullMarked class DummyActivityBehavior extends TaskActivityBehavior {
 
   public static boolean wasExecuted;
 
-  public static String currentActivityId;
-  public static String currentActivityName;
+  public static @Nullable String currentActivityId;
+  public static @Nullable String currentActivityName;
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     currentActivityName = execution.getCurrentActivityName();
     currentActivityId = execution.getCurrentActivityId();
     leave(execution);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/ExampleSignallableActivityBehaviorBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/ExampleSignallableActivityBehaviorBean.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.integrationtest.functional.cdi.beans;
 
 import jakarta.inject.Named;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
@@ -27,7 +29,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
  *
  */
 @Named
-public class ExampleSignallableActivityBehaviorBean extends AbstractBpmnActivityBehavior implements SignallableActivityBehavior {
+public @NullMarked class ExampleSignallableActivityBehaviorBean extends AbstractBpmnActivityBehavior implements SignallableActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
@@ -35,7 +37,7 @@ public class ExampleSignallableActivityBehaviorBean extends AbstractBpmnActivity
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalEvent, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalEvent, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/beans/ExampleSignallableActivityBehavior.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/beans/ExampleSignallableActivityBehavior.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.classloading.beans;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
@@ -23,7 +25,7 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
  * @author Daniel Meyer
  *
  */
-public class ExampleSignallableActivityBehavior extends AbstractBpmnActivityBehavior {
+public @NullMarked class ExampleSignallableActivityBehavior extends AbstractBpmnActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
@@ -33,7 +35,7 @@ public class ExampleSignallableActivityBehavior extends AbstractBpmnActivityBeha
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalEvent, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalEvent, @Nullable Object signalData) throws Exception {
 
     // leave waitstate
     leave(execution);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/beans/SignalableTask.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/beans/SignalableTask.java
@@ -16,10 +16,12 @@
  */
 package org.operaton.bpm.integrationtest.functional.context.beans;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
-public class SignalableTask extends AbstractBpmnActivityBehavior {
+public @NullMarked class SignalableTask extends AbstractBpmnActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
@@ -27,7 +29,7 @@ public class SignalableTask extends AbstractBpmnActivityBehavior {
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     leave(execution);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/error/ThrowErrorDelegate.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/error/ThrowErrorDelegate.java
@@ -18,12 +18,14 @@ package org.operaton.bpm.integrationtest.functional.error;
 
 import jakarta.inject.Named;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.operaton.bpm.engine.delegate.BpmnError;
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 
 @Named
-public class ThrowErrorDelegate extends AbstractBpmnActivityBehavior {
+public @NullMarked class ThrowErrorDelegate extends AbstractBpmnActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
@@ -31,7 +33,7 @@ public class ThrowErrorDelegate extends AbstractBpmnActivityBehavior {
   }
 
   @Override
-  public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
+  public void signal(ActivityExecution execution, @Nullable String signalName, @Nullable Object signalData) throws Exception {
     handle(execution, "signaled");
   }
 


### PR DESCRIPTION
Mainly covering package `org.operaton.bpm.engine.impl.bpmn.behavior` and dependent classes. 

This PR also adds the tool `.devenv/scripts/tools/nullmarked-coverage.py` which helps to measure the progress on marking classes with `@NullMarked`.

```
.devenv/scripts/tools/nullmarked-coverage.py
Module                                                   Classes  Covered    Rate
----------------------------------------------------------------------------------
engine-plugins/connect-plugin                                  5        5  100.0%
engine                                                      2177      488   22.4%
commons/utils                                                 11        2   18.2%
jakarta-ee/ejb-service                                        10        1   10.0%
engine-spring                                                 43        3    7.0%
...
----------------------------------------------------------------------------------
TOTAL                                                       4905      514   10.5%
```