### PR TITLE
fix(engine-rest): Let a task be sent back as it was received

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskDto.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.rest.dto.task;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.OperatonFormRef;
 import org.operaton.bpm.engine.rest.dto.converter.DelegationStateConverter;
@@ -47,6 +49,8 @@ public class TaskDto {
   private String caseDefinitionId;
   private boolean suspended;
   private String formKey;
+  /** Derived from the process model; {@link #updateTask(Task)} never reads it. */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private OperatonFormRef operatonFormRef;
   private String tenantId;
   /**

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -3355,6 +3355,27 @@ public class TaskRestServiceInteractionTest extends
   }
 
   @Test
+  void testPutUpdateTaskWithFormRef() {
+    // PUT replaces the task, so a client sends back what GET returned — form reference included.
+    Map<String, Object> json = new HashMap<>();
+    json.put("name", "A Task");
+    json.put("operatonFormRef", Map.of("key", "aFormKey", "binding", "deployment"));
+
+    given()
+        .pathParam("id", EXAMPLE_TASK_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+    .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+    .when()
+        .put(SINGLE_TASK_URL);
+
+    verify(mockTask).setName("A Task");
+    verify(taskServiceMock).saveTask(mockTask);
+  }
+
+  @Test
   void testPutUpdateTaskNotFound() {
     when(mockQuery.singleResult()).thenReturn(null);
 

--- a/webapps-neo/frontend/public/locales/de-DE/translation.json
+++ b/webapps-neo/frontend/public/locales/de-DE/translation.json
@@ -138,6 +138,7 @@
     "back-to-list": "Zurück zur Aufgabenliste",
     "claim": "Beanspruchen",
     "unclaim": "Freigeben",
+    "update-failed": "Die Änderung konnte nicht gespeichert werden.",
     "you": "Sie",
     "reset-assignee": "Verantwortlichen zurücksetzen",
     "assignee-menu": "Zuständigkeits-Aktionen",

--- a/webapps-neo/frontend/public/locales/en-US/translation.json
+++ b/webapps-neo/frontend/public/locales/en-US/translation.json
@@ -138,6 +138,7 @@
     "back-to-list": "Back to task list",
     "claim": "Claim",
     "unclaim": "Unclaim",
+    "update-failed": "The change could not be saved.",
     "you": "You",
     "reset-assignee": "Reset Assignee",
     "assignee-menu": "Assignee actions",

--- a/webapps-neo/frontend/src/api/resources/task.js
+++ b/webapps-neo/frontend/src/api/resources/task.js
@@ -32,16 +32,24 @@ const get_task = (state, task_id) =>
  * @returns {Promise<{status: RESPONSE_STATE, data: *} | *>}
  */
 const update_task = (state, task, task_id) => {
-  return state.api.task.one.value?.data !== undefined
-    ? PUT(
-        `/task/${state.api.task.one.value.data.id}`,
-        { ...state.api.task.one.value.data, ...task },
-        state,
-        state.api.task.one,
-      ).then(() => engine_rest.task.get_task(state, task_id))
-    : () => {
-        throw new Error("Task in state undefined or null, can not merge");
-      };
+  const loaded = state.api.task.one.value?.data;
+  if (loaded === undefined) {
+    return Promise.resolve({
+      status: RESPONSE_STATE.ERROR,
+      error: new Error("Task in state undefined or null, can not merge"),
+    });
+  }
+  return PUT(
+    `/task/${loaded.id}`,
+    { ...loaded, ...task },
+    state,
+    state.api.task.update_result,
+  ).then((result) => {
+    if (result?.status === RESPONSE_STATE.SUCCESS) {
+      void engine_rest.task.get_task(state, task_id);
+    }
+    return result;
+  });
 };
 
 const get_task_form = (state, form_id) =>

--- a/webapps-neo/frontend/src/api/resources/task.test.js
+++ b/webapps-neo/frontend/src/api/resources/task.test.js
@@ -229,6 +229,7 @@ describe("api/resources/task", () => {
 
   describe("update_task", () => {
     it("merges the changeset onto the cached task and re-fetches afterwards", async () => {
+      PUT.mockResolvedValueOnce({ status: RESPONSE_STATE.SUCCESS });
       state.api.task.one.value = {
         data: { id: "t1", name: "Old", assignee: null },
       };
@@ -238,7 +239,7 @@ describe("api/resources/task", () => {
         url: "/task/t1",
         body: { id: "t1", name: "Old", assignee: "alice" },
         state,
-        signal: state.api.task.one,
+        signal: state.api.task.update_result,
       });
       // After the PUT resolves it re-fetches the task via engine_rest.
       expect(engine_rest.task.get_task).toHaveBeenCalled();
@@ -246,6 +247,24 @@ describe("api/resources/task", () => {
         engine_rest.task.get_task.mock.lastCall;
       expect(refetch_state).toBe(state);
       expect(refetch_id).toBe("t1");
+    });
+
+    it("does not re-fetch when the change was rejected", async () => {
+      engine_rest.task.get_task.mockClear();
+      PUT.mockResolvedValueOnce({ status: RESPONSE_STATE.ERROR });
+      state.api.task.one.value = { data: { id: "t1", name: "Old" } };
+
+      const result = await task.update_task(state, { name: "New" }, "t1");
+
+      expect(result.status).toBe(RESPONSE_STATE.ERROR);
+      expect(engine_rest.task.get_task).not.toHaveBeenCalled();
+    });
+
+    it("reports an error instead of throwing when no task is loaded", async () => {
+      state.api.task.one.value = null;
+      const result = await task.update_task(state, { name: "New" }, "t1");
+      expect(result.status).toBe(RESPONSE_STATE.ERROR);
+      expect(PUT).not.toHaveBeenCalled();
     });
   });
 

--- a/webapps-neo/frontend/src/pages/Tasks.jsx
+++ b/webapps-neo/frontend/src/pages/Tasks.jsx
@@ -563,12 +563,12 @@ const SetDueDateButton = () => {
         .update_task(
           state,
           {
-            due: `${date_state.value.date}T${date_state.value.time}:0.000+0000`,
+            due: `${date_state.value.date}T${date_state.value.time}:00.000+0000`,
           },
           params.task_id,
         )
-        .then(() => {
-          close();
+        .then((result) => {
+          if (result?.status === RESPONSE_STATE.SUCCESS) close();
         });
     };
 
@@ -619,6 +619,11 @@ const SetDueDateButton = () => {
             <button type="submit">{t("common.submit")}</button>
           </div>
         </form>
+        {state.api.task.update_result.value?.status === RESPONSE_STATE.ERROR && (
+          <p role="alert" class="error">
+            {t("tasks.update-failed")}
+          </p>
+        )}
       </dialog>
     </>
   );
@@ -655,12 +660,12 @@ const SetFollowUpDateButton = () => {
         .update_task(
           state,
           {
-            followUp: `${date_state.value.date}T${date_state.value.time}:0.000+0000`,
+            followUp: `${date_state.value.date}T${date_state.value.time}:00.000+0000`,
           },
           params.task_id,
         )
-        .then(() => {
-          close();
+        .then((result) => {
+          if (result?.status === RESPONSE_STATE.SUCCESS) close();
         });
     };
 
@@ -718,6 +723,11 @@ const SetFollowUpDateButton = () => {
             <button type="submit">{t("common.submit")}</button>
           </div>
         </form>
+        {state.api.task.update_result.value?.status === RESPONSE_STATE.ERROR && (
+          <p role="alert" class="error">
+            {t("tasks.update-failed")}
+          </p>
+        )}
       </dialog>
     </>
   );

--- a/webapps-neo/frontend/src/state.js
+++ b/webapps-neo/frontend/src/state.js
@@ -149,6 +149,7 @@ const createAppState = () => {
       rendered_form: signal(null),
       deployed_form: signal(null),
       form_variables: signal(null),
+      update_result: signal(null),
       claim_result: signal(null),
       unclaim_result: signal(null),
       assign_result: signal(null),


### PR DESCRIPTION
Fixes #3659.

## The defect

`PUT /task/{id}` rejects the body `GET /task/{id}` just produced:

```
400 Cannot construct instance of `org.operaton.bpm.engine.form.OperatonFormRef`
    (no Creators, like default constructor, exist)
```

Leaving the property out is no way around it, because the endpoint replaces the task rather
than patching it — drop `tenantId` along with it and the answer is

```
500 ENGINE-03072 Cannot change tenantId of Task '…'
```

So the whole task has to be sent, and the whole task is refused. Setting a due date or a
follow-up date is impossible for any task referencing an Operaton Form.

## Two commits

**`engine-rest`** — `TaskDto.operatonFormRef` is typed as an interface, so Jackson tried to
instantiate it on input. It never needed to: the property is output-only in fact.
`TaskDto.updateTask(Task)` copies eleven fields and not this one, and the engine's `Task`
interface has only `getOperatonFormRef()`, no setter — the value comes from the process
model. It is now marked read-only, so what a client sends for it is dropped instead of
failing the request. It is still reported on the way out.

**`webapps-neo`** — the failure was invisible, which is why it took a while to find.
`update_task` wrote the answer of the PUT into the signal holding the loaded task and
re-read the task regardless of the outcome, so the error was replaced by a fresh copy of
the unchanged task before anything could render it; both date dialogs closed
unconditionally. The PUT now has its own signal, the re-read happens only on success, the
result reaches the caller, and the dialogs close only when the change went through. The
timestamp was also built with a single-digit second — accepted by the engine, but not the
format it claims to be.

The second commit stands on its own: it makes any rejected change visible, whatever the
cause.

## Testing

`testPutUpdateTaskWithFormRef` sends a body carrying the reference and expects 204;
195 tests in `TaskRestServiceInteractionTest` green. 612 frontend tests green, three of them
new around `update_task`.

## Worth deciding separately

The OpenAPI templates use `TaskDto` as the request body for `PUT /task/{id}` and
`POST /task/create` and list this property there, so the documentation still presents it as
writable — sending it is now harmless rather than fatal, but it still does nothing. Saying
so properly means `"readOnly": true` in the schema, and the `lib.property` macro has no such
flag; no model in the repository uses one. That felt like your call rather than something to
fold into this fix.
